### PR TITLE
Formatação em Markdown e remoção de duplicata em `GLOSSARY.md`

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -36,6 +36,7 @@ Isto quebraria o link acima.
 Mantenha o texto em blocos de código sem tradução, exceto para os comentários. Você pode optar por traduzir o texto em strings, mas tenha cuidado para não traduzir strings que se refiram ao código!
 
 Exemplo:
+
 ```js
 // Example
 const element = <h1>Hello, world</h1>;
@@ -80,8 +81,8 @@ ReactDOM.renderizar(elemento, documento.obterElementoPorId('raiz'));
 
 Se um link externo se referir a um artigo no [MDN] or [Wikipedia] e se houver uma versão traduzida em seu idioma em uma qualidade decente, opte por usar a versão traduzida.
 
-[MDN]: https://developer.mozilla.org/pt-BR/
-[Wikipedia]: https://pt.wikipedia.org/wiki/Wikipédia:Página_principal
+[mdn]: https://developer.mozilla.org/pt-BR/
+[wikipedia]: https://pt.wikipedia.org/wiki/Wikipédia:Página_principal
 
 Exemplo:
 
@@ -101,73 +102,72 @@ Para links que não possuem tradução (Stack Overflow, vídeos do YouTube, etc.
 
 Sugestões de palavras e termos:
 
-| Palavra/Termo original | Sugestão |
-| ------------------ | ---------- |
-| assertion | asserção |
-| browser | navegador |
-| bubbling | propagar |
-| bug | erro |
-| class component | componente de classe |
-| class | classe |
-| client | cliente |
-| client-side | lado do cliente |
-| container | contêiner |
-| context | contexto |
-| controlled component | componente controlado |
-| debugging | depuração|
-| DOM node | nó do DOM |
-| event handler | manipulador de eventos (event handler) |
-| function component | componente de função |
-| handler | manipulador |
-| helper function | função auxiliar |
-| high-order components | componente de alta-ordem |
-| key | chave |
-| library | biblioteca |
-| lowercase | minúscula(s) / caixa baixa |
-| package | pacote |
-| React element | Elemento React |
-| React fragment | Fragmento React |
-| render | renderizar (verb), renderizado (noun)
-| server | servidor |
-| server-side | lado do servidor |
-| siblings | irmãos |
-| stateful component | componente com estado |
-| stateful logic | lógica com estado |
-| to assert | afirmar |
-| to wrap | encapsular |
-| uncontrolled component | componente não controlado |
-| uncontrolled component | componente não controlado |
-| uppercase | maiúscula(s) / caixa alta |
+| Palavra/Termo original | Sugestão                               |
+| ---------------------- | -------------------------------------- |
+| assertion              | asserção                               |
+| browser                | navegador                              |
+| bubbling               | propagar                               |
+| bug                    | erro                                   |
+| class component        | componente de classe                   |
+| class                  | classe                                 |
+| client                 | cliente                                |
+| client-side            | lado do cliente                        |
+| container              | contêiner                              |
+| context                | contexto                               |
+| controlled component   | componente controlado                  |
+| debugging              | depuração                              |
+| DOM node               | nó do DOM                              |
+| event handler          | manipulador de eventos (event handler) |
+| function component     | componente de função                   |
+| handler                | manipulador                            |
+| helper function        | função auxiliar                        |
+| high-order components  | componente de alta-ordem               |
+| key                    | chave                                  |
+| library                | biblioteca                             |
+| lowercase              | minúscula(s) / caixa baixa             |
+| package                | pacote                                 |
+| React element          | Elemento React                         |
+| React fragment         | Fragmento React                        |
+| render                 | renderizar (verb), renderizado (noun)  |
+| server                 | servidor                               |
+| server-side            | lado do servidor                       |
+| siblings               | irmãos                                 |
+| stateful component     | componente com estado                  |
+| stateful logic         | lógica com estado                      |
+| to assert              | afirmar                                |
+| to wrap                | encapsular                             |
+| uncontrolled component | componente não controlado              |
+| uppercase              | maiúscula(s) / caixa alta              |
 
 ## Conteúdo que não deve ser traduzido
 
-* array
-* arrow function
-* bind
-* bundle
-* bundler
-* callback
-* camelCase
-* DOM
-* event listener
-* framework
-* hook
-* log
-* mock
-* portal
-* props
-* ref
-* release
-* script
-* single-page-apps
-* state
-* string
-* string literal
-* subscribe
-* subscription
-* template literal
-* timestamps
-* UI
-* watcher
-* widgets
-* wrapper
+- array
+- arrow function
+- bind
+- bundle
+- bundler
+- callback
+- camelCase
+- DOM
+- event listener
+- framework
+- hook
+- log
+- mock
+- portal
+- props
+- ref
+- release
+- script
+- single-page-apps
+- state
+- string
+- string literal
+- subscribe
+- subscription
+- template literal
+- timestamps
+- UI
+- watcher
+- widgets
+- wrapper


### PR DESCRIPTION
### Identifiquei duas atualizações/correções que poderiam ser feitas neste arquivo:

1. A tabela [**Traduções Comuns**](https://github.com/reactjs/pt-br.react.dev/blob/main/GLOSSARY.md#tradu%C3%A7%C3%B5es-comuns) constava uma fileira duplicada: `uncontrolled component | componente não controlado`. 
2. A tabela estava sem formatação. Mesmo utilizando `prettier` no repositório, acredito que os runners CI/CD não estão formatando arquivos `.md` na raíz, então formatei "a força", deixando o arquivo bruto mais legível  (o output continua o mesmo).