### PR TITLE
Adds new common translation terms to `GLOSSARY.md`

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -105,6 +105,7 @@ Sugestões de palavras e termos:
 | Palavra/Termo original | Sugestão                               |
 | ---------------------- | -------------------------------------- |
 | assertion              | asserção                               |
+| at the top level       | na raiz                                |
 | browser                | navegador                              |
 | bubbling               | propagar                               |
 | bug                    | erro                                   |
@@ -136,6 +137,7 @@ Sugestões de palavras e termos:
 | stateful logic         | lógica com estado                      |
 | to assert              | afirmar                                |
 | to wrap                | encapsular                             |
+| troubleshooting        | solução de problemas                   |
 | uncontrolled component | componente não controlado              |
 | uppercase              | maiúscula(s) / caixa alta              |
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -109,6 +109,7 @@ Sugestões de palavras e termos:
 | browser                | navegador                              |
 | bubbling               | propagar                               |
 | bug                    | erro                                   |
+| caveats                | ressalvas                              |
 | class component        | componente de classe                   |
 | class                  | classe                                 |
 | client                 | cliente                                |


### PR DESCRIPTION
During the translation of the `useEffect` page, I noticed two terms that are being used in many places on the docs but are missing on the `GLOSSARY.md` file. I'm opening this PR to add those terms to that file.