### PR TITLE
docs(pt-br): translate react-components page

### DIFF
--- a/src/content/reference/react/components.md
+++ b/src/content/reference/react/components.md
@@ -1,24 +1,24 @@
 ---
-title: "Built-in React Components"
+title: "Componentes React integrados"
 ---
 
 <Intro>
 
-React exposes a few built-in components that you can use in your JSX.
+O React expõe alguns componentes internos que você pode usar em seu JSX.
 
 </Intro>
 
 ---
 
-## Built-in components {/*built-in-components*/}
+## Components integrados {/*built-in-components*/}
 
-* [`<Fragment>`](/reference/react/Fragment), alternatively written as `<>...</>`, lets you group multiple JSX nodes together.
-* [`<Profiler>`](/reference/react/Profiler) lets you measure rendering performance of a React tree programmatically.
-* [`<Suspense>`](/reference/react/Suspense) lets you display a fallback while the child components are loading.
-* [`<StrictMode>`](/reference/react/StrictMode) enables extra development-only checks that help you find bugs early.
+* [`<Fragment>`](/reference/react/Fragment), alternativamente escrito como `<>...</>`, permite que você agrupe vários nós JSX.
+* [`<Profiler>`](/reference/react/Profiler) permite medir o desempenho de renderização de uma árvore React de forma programática.
+* [`<Suspense>`](/reference/react/Suspense) permite exibir um fallback enquanto os componentes filhos estão sendo carregados.
+* [`<StrictMode>`](/reference/react/StrictMode) permite verificações adicionais somente de desenvolvimento que o ajudam a encontrar erros antecipadamente.
 
 ---
 
-## Your own components {/*your-own-components*/}
+## Seus próprios componentes {/*your-own-components*/}
 
-You can also [define your own components](/learn/your-first-component) as JavaScript functions.
+Você também pode [definir seus próprios componentes](/learn/your-first-component) como funções JavaScript.


### PR DESCRIPTION
Olá pessoal! Nesta PR foi realizado a tradução da página [`react`: Components](https://pt-br.react.dev/reference/react/components).