### PR TITLE
Translate `the-plan-for-react-18.md` to pt-br

### DIFF
--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -2,7 +2,7 @@
 title: "O Plano para o React 18"
 author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, e Seth Webster
 date: 2021/06/08
-description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos uma Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback...
+description: A equipe do React está empolgada em compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos uma versão Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback...
 ---
 
 8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
@@ -11,61 +11,61 @@ description: A equipe do React está animada para compartilhar algumas atualiza�
 
 <Intro>
 
-A equipe do React está animada para compartilhar algumas atualizações:
+A equipe do React está empolgada em compartilhar algumas atualizações:
 
 1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
 2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
-3. Publicamos uma Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback.
+3. Publicamos uma versão Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback.
 
-Essas atualizações são principalmente direcionadas aos mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar com segurança este post. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
+Essas atualizações são direcionadas principalmente aos mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post com segurança. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
 
 ---
 
 </Intro>
 
-## O que vem por aí no React 18 {/*whats-coming-in-react-18*/}
+## O que está por vir no React 18 {/*whats-coming-in-react-18*/}
 
-Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [empilhamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte integrado para `React.lazy`.
+Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agregação automática](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
 
-Esses recursos são possíveis graças a um novo mecanismo de adesão que estamos adicionando no React 18. Chamamos de “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de seu aplicativo.
+Esses recursos são possíveis graças a um novo mecanismo opcional que estamos adicionando no React 18. Ele é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido da sua aplicação.
 
-Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você o faça!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso poderia quebrar seu aplicativo. Em resposta a esse feedback da comunidade, reformulamos a estratégia de atualização para uma adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
+Se você tem acompanhando nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar sobre algo chamado “modo concorrente” ou que poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será ativada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
 
 ## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Como a concorrência no React 18 é opcional, não há mudanças significativas no comportamento dos componentes fora da caixa. **Você pode atualizar para o React 18 com alterações mínimas ou sem alterações no código de sua aplicação, com um nível de esforço comparável a uma atualização típica do React**. Com base em nossa experiência convertendo vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
+Como a concorrência no React 18 é opcional, não há mudanças significativas de comportamento dos componentes prontas para uso. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma no código da sua aplicação, com um nível de esforço comparável a uma atualização típica do React**. Com base em nossa experiência convertendo várias aplicações para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-Tivemos sucesso em enviar recursos concorrentes para dezenas de milhares de componentes no Facebook e, em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem alterações adicionais. Estamos comprometidos em garantir que isso seja uma atualização tranquila para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
+Lançamos com sucesso recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem alterações adicionais. Estamos comprometidos em garantir que esta seja uma atualização suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
 
 ## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que queríamos para este grupo inicial pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
+Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que queríamos para este grupo inicial pequeno, mas se este experimento der certo, esperamos que haja mais no futuro!
 
-**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, qualquer informação importante também será postada neste blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que o lançamento estável se aproxima, qualquer informação importante também será postada neste blog.
 
 Para mais informações sobre como atualizar para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
 ## Acessando o Grupo de Trabalho do React 18 {/*accessing-the-react-18-working-group*/}
 
-Todos podem ler as discussões no repositório do [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
+Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Como esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso à mesma informação. Acreditamos que este é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
+Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em threads. No entanto, as threads são totalmente visíveis ao público, para que todos tenham acesso às mesmas informações. Acreditamos que este é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
 
-Como sempre, você pode enviar relatórios de bugs, perguntas e comentários gerais para nosso [rastreador de issues](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para o nosso [rastreador de problemas](https://github.com/facebook/react/issues).
 
 ## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-Novas alphas são [publicadas regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Essas versões são construídas usando o commit mais recente em nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em uma alpha no dia útil seguinte.
+Novas alphas são [publicadas regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em uma alpha no dia útil seguinte.
 
-Pode haver mudanças significativas no comportamento ou na API entre as versões alpha. Por favor, lembre-se de que **as versões alpha não são recomendadas para aplicações de produção voltadas para o usuário**.
+Pode haver mudanças significativas de comportamento ou de API entre as versões alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
 
-## Cronograma de lançamento projetado do React 18 {/*projected-react-18-release-timeline*/}
+## Cronograma projetado para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
 
-Não temos uma data específica de lançamento programada, mas esperamos que leve vários meses de feedback e iteração antes que o React 18 esteja pronto para a maioria das aplicações de produção.
+Não temos uma data específica de lançamento programada, mas esperamos que leve vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
 
-* Alpha da Biblioteca: Disponível hoje
+* Biblioteca Alpha: Disponível hoje
 * Beta Pública: Pelo menos vários meses
 * Release Candidate (RC): Pelo menos várias semanas após a Beta
-* Disponibilidade Geral: Pelo menos várias semanas após a RC
+* Disponibilidade Geral: Pelo menos várias semanas após o RC
 
-Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Publicaremos atualizações neste blog quando estivermos mais próximos de um lançamento público.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Faremos atualizações neste blog quando estivermos mais próximos de um lançamento público.

--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -1,71 +1,71 @@
 ---
-title: "The Plan for React 18"
-author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, and Seth Webster
+title: "O Plano para o React 18"
+author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage e Seth Webster
 date: 2021/06/08
-description: The React team is excited to share a few updates. We’ve started work on the React 18 release, which will be our next major version. We’ve created a Working Group to prepare the community for gradual adoption of new features in React 18. We’ve published a React 18 Alpha so that library authors can try it and provide feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
 ---
 
-June 8, 2021 by [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), and [Seth Webster](https://twitter.com/sethwebster)
+8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage) e [Seth Webster](https://twitter.com/sethwebster)
 
 ---
 
 <Intro>
 
-The React team is excited to share a few updates:
+A equipe do React está animada para compartilhar algumas atualizações:
 
-1. We’ve started work on the React 18 release, which will be our next major version.
-2. We’ve created a Working Group to prepare the community for gradual adoption of new features in React 18.
-3. We’ve published a React 18 Alpha so that library authors can try it and provide feedback.
+1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
+2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
+3. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
 
-These updates are primarily aimed at maintainers of third-party libraries. If you’re learning, teaching, or using React to build user-facing applications, you can safely ignore this post. But you are welcome to follow the discussions in the React 18 Working Group if you're curious!
+Essas atualizações são destinadas principalmente a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
 
 ---
 
 </Intro>
 
-## What’s coming in React 18 {/*whats-coming-in-react-18*/}
+## O que está por vir no React 18 {/*whats-coming-in-react-18*/}
 
-When it’s released, React 18 will include out-of-the-box improvements (like [automatic batching](https://github.com/reactwg/react-18/discussions/21)), new APIs (like [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), and a [new streaming server renderer](https://github.com/reactwg/react-18/discussions/37) with built-in support for `React.lazy`.
+Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [empilhamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)) e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
 
-These features are possible thanks to a new opt-in mechanism we’re adding in React 18. It’s called “concurrent rendering” and it lets React prepare multiple versions of the UI at the same time. This change is mostly behind-the-scenes, but it unlocks new possibilities to improve both real and perceived performance of your app.
+Esses recursos são possíveis graças a um novo mecanismo de opt-in que estamos adicionando no React 18. Ele é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface ao mesmo tempo. Esta mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de seu aplicativo.
 
-If you've been following our research into the future of React (we don't expect you to!), you might have heard of something called “concurrent mode” or that it might break your app. In response to this feedback from the community, we’ve redesigned the upgrade strategy for gradual adoption. Instead of an all-or-nothing “mode”, concurrent rendering will only be enabled for updates triggered by one of the new features. In practice, this means **you will be able to adopt React 18 without rewrites and try the new features at your own pace.**
+Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você esteja!), pode ter ouvido algo chamado “modo concorrente” ou que isso poderia quebrar seu aplicativo. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para uma adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos em seu próprio ritmo.**
 
-## A gradual adoption strategy {/*a-gradual-adoption-strategy*/}
+## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Since concurrency in React 18 is opt-in, there are no significant out-of-the-box breaking changes to component behavior. **You can upgrade to React 18 with minimal or no changes to your application code, with a level of effort comparable to a typical major React release**. Based on our experience converting several apps to React 18, we expect that many users will be able to upgrade within a single afternoon.
+Como a concorrência no React 18 é opt-in, não há mudanças significativas e fora da caixa no comportamento dos componentes. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma no código da sua aplicação, com um nível de esforço comparável ao de uma liberação principal típica do React**. Com base em nossa experiência ao converter vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-We successfully shipped concurrent features to tens of thousands of components at Facebook, and in our experience, we've found that most React components “just work” without additional changes. We're committed to making sure this is a smooth upgrade for the entire community, so today we're announcing the React 18 Working Group.
+Enviamos com sucesso recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “funciona normalmente” sem mudanças adicionais. Estamos comprometidos em garantir que esta seja uma atualização suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
 
-## Working with the community {/*working-with-the-community*/}
+## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-We’re trying something new for this release: We've invited a panel of experts, developers, library authors, and educators from across the React community to participate in our [React 18 Working Group](https://github.com/reactwg/react-18) to provide feedback, ask questions, and collaborate on the release. We couldn't invite everyone we wanted to this initial, small group, but if this experiment works out, we hope there will be more in the future!
+Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não pudemos convidar todos que gostaríamos para este grupo inicial pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
 
-**The goal of the React 18 Working Group is to prepare the ecosystem for a smooth, gradual adoption of React 18 by existing applications and libraries.** The Working Group is hosted on [GitHub Discussions](https://github.com/reactwg/react-18/discussions) and is available for the public to read. Members of the working group can leave feedback, ask questions, and share ideas. The core team will also use the discussions repo to share our research findings. As the stable release gets closer, any important information will also be posted on this blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Os membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, qualquer informação importante também será postada neste blog.
 
-For more information on upgrading to React 18, or additional resources about the release, see the [React 18 announcement post](https://github.com/reactwg/react-18/discussions/4).
+Para mais informações sobre como atualizar para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
-## Accessing the React 18 Working Group {/*accessing-the-react-18-working-group*/}
+## Acessando o Grupo de Trabalho do React 18 {/*accessing-the-react-18-working-group*/}
 
-Everyone can read the discussions in the [React 18 Working Group repo](https://github.com/reactwg/react-18).
+Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Because we expect an initial surge of interest in the Working Group, only invited members will be allowed to create or comment on threads. However, the threads are fully visible to the public, so everyone has access to the same information. We believe this is a good compromise between creating a productive environment for working group members, while maintaining transparency with the wider community.
+Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados terão permissão para criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso às mesmas informações. Acreditamos que este é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
 
-As always, you can submit bug reports, questions, and general feedback to our [issue tracker](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de erros, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
 
-## How to try React 18 Alpha today {/*how-to-try-react-18-alpha-today*/}
+## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-New alphas are [regularly published to npm using the `@alpha` tag](https://github.com/reactwg/react-18/discussions/9). These releases are built using the most recent commit to our main repo. When a feature or bugfix is merged, it will appear in an alpha the following weekday.
+Novos alphas são [publicados regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia de trabalho seguinte.
 
-There may be significant behavioral or API changes between alpha releases. Please remember that **alpha releases are not recommended for user-facing, production applications**.
+Pode haver mudanças significativas de comportamento ou API entre os lançamentos alpha. Lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
 
-## Projected React 18 release timeline {/*projected-react-18-release-timeline*/}
+## Cronograma projetado para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
 
-We don't have a specific release date scheduled, but we expect it will take several months of feedback and iteration before React 18 is ready for most production applications.
+Não temos uma data de lançamento específica agendada, mas esperamos que leve vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
 
-* Library Alpha: Available today
-* Public Beta: At least several months
-* Release Candidate (RC): At least several weeks after Beta
-* General Availability: At least several weeks after RC
+* Biblioteca Alpha: Disponível hoje
+* Beta Pública: Pelo menos vários meses
+* Release Candidate (RC): Pelo menos várias semanas após a Beta
+* Disponibilidade Geral: Pelo menos várias semanas após a RC
 
-More details about our projected release timeline are [available in the Working Group](https://github.com/reactwg/react-18/discussions/9). We'll post updates on this blog when we're closer to a public release.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Postaremos atualizações neste blog quando estivermos mais perto de um lançamento público.

--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -2,7 +2,7 @@
 title: "O Plano para o React 18"
 author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, e Seth Webster
 date: 2021/06/08
-description: A equipe do React está empolgada em compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos uma versão Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novas funcionalidades no React 18. Publicamos uma versão Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback...
 ---
 
 8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
@@ -11,13 +11,13 @@ description: A equipe do React está empolgada em compartilhar algumas atualiza�
 
 <Intro>
 
-A equipe do React está empolgada em compartilhar algumas atualizações:
+A equipe do React está animada para compartilhar algumas atualizações:
 
 1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
-2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
+2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novas funcionalidades no React 18.
 3. Publicamos uma versão Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback.
 
-Essas atualizações são direcionadas principalmente aos mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post com segurança. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
+Estas atualizações são principalmente destinadas aos mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações com interface para o usuário, pode ignorar este post. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
 
 ---
 
@@ -25,47 +25,47 @@ Essas atualizações são direcionadas principalmente aos mantenedores de biblio
 
 ## O que está por vir no React 18 {/*whats-coming-in-react-18*/}
 
-Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agregação automática](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
+Quando for lançada, o React 18 incluirá melhorias prontas para uso (como [agrupamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
 
-Esses recursos são possíveis graças a um novo mecanismo opcional que estamos adicionando no React 18. Ele é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido da sua aplicação.
+Essas funcionalidades são possíveis graças a um novo mecanismo de opt-in que estamos adicionando no React 18. Ele é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface ao mesmo tempo. Essa mudança é, em grande parte, nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido da sua aplicação.
 
-Se você tem acompanhando nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar sobre algo chamado “modo concorrente” ou que poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será ativada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
+Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para uma adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações acionadas por uma das novas funcionalidades. Na prática, isso significa **que você poderá adotar o React 18 sem reescrever e experimentar as novas funcionalidades em seu próprio ritmo.**
 
 ## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Como a concorrência no React 18 é opcional, não há mudanças significativas de comportamento dos componentes prontas para uso. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma no código da sua aplicação, com um nível de esforço comparável a uma atualização típica do React**. Com base em nossa experiência convertendo várias aplicações para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
+Como a concorrência no React 18 é opt-in, não há mudanças significativas que quebrem o comportamento dos componentes prontas para uso. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma no código da sua aplicação, com um nível de esforço comparável a uma atualização típica do React principal**. Com base em nossa experiência convertendo várias aplicações para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-Lançamos com sucesso recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem alterações adicionais. Estamos comprometidos em garantir que esta seja uma atualização suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
+Nós lançamos com sucesso funcionalidades concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes do React “funciona” sem mudanças adicionais. Estamos comprometidos em garantir que essa atualização seja tranquila para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
 
 ## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que queríamos para este grupo inicial pequeno, mas se este experimento der certo, esperamos que haja mais no futuro!
+Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que gostaríamos para este grupo inicial e pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
 
-**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que o lançamento estável se aproxima, qualquer informação importante também será postada neste blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicativos e bibliotecas existentes.** O Grupo de Trabalho é hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe principal também usará o repositório de discussões para compartilhar nossos achados de pesquisa. À medida que o lançamento estável se aproxima, quaisquer informações importantes também serão postadas neste blog.
 
-Para mais informações sobre como atualizar para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
+Para mais informações sobre como atualizar para o React 18 ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
 ## Acessando o Grupo de Trabalho do React 18 {/*accessing-the-react-18-working-group*/}
 
-Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
+Todo mundo pode ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em threads. No entanto, as threads são totalmente visíveis ao público, para que todos tenham acesso às mesmas informações. Acreditamos que este é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
+Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar sobre os tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso às mesmas informações. Acreditamos que essa é uma boa solução entre criar um ambiente produtivo para os membros do grupo de trabalho, enquanto mantemos a transparência com a comunidade mais ampla.
 
-Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para o nosso [rastreador de problemas](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
 
 ## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-Novas alphas são [publicadas regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em uma alpha no dia útil seguinte.
+Novas alphas são [publicadas regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando uma funcionalidade ou correção de bug é mesclada, ela aparecerá em uma alpha no dia útil seguinte.
 
-Pode haver mudanças significativas de comportamento ou de API entre as versões alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
+Pode haver mudanças significativas de comportamento ou API entre os lançamentos alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
 
-## Cronograma projetado para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
+## Cronograma projetado de lançamento do React 18 {/*projected-react-18-release-timeline*/}
 
-Não temos uma data específica de lançamento programada, mas esperamos que leve vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
+Não temos uma data de lançamento específica programada, mas esperamos que leve vários meses de feedback e iteração antes que o React 18 esteja pronto para a maioria das aplicações em produção.
 
-* Biblioteca Alpha: Disponível hoje
+* Alpha da Biblioteca: Disponível hoje
 * Beta Pública: Pelo menos vários meses
-* Release Candidate (RC): Pelo menos várias semanas após a Beta
+* Candidato a Lançamento (RC): Pelo menos várias semanas após a Beta
 * Disponibilidade Geral: Pelo menos várias semanas após o RC
 
-Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Faremos atualizações neste blog quando estivermos mais próximos de um lançamento público.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Publicaremos atualizações neste blog quando estivermos mais perto de um lançamento público.

--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -2,7 +2,7 @@
 title: "O Plano para o React 18"
 author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, e Seth Webster
 date: 2021/06/08
-description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão React 18, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
 ---
 
 8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
@@ -13,35 +13,35 @@ description: A equipe do React está animada para compartilhar algumas atualiza�
 
 A equipe do React está animada para compartilhar algumas atualizações:
 
-1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
+1. Começamos a trabalhar na versão React 18, que será nossa próxima versão principal.
 2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
 3. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
 
-Essas atualizações são direcionadas principalmente a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post com segurança. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se tiver curiosidade!
+Essas atualizações são principalmente direcionadas a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post. Mas fique à vontade para acompanhar as discussões no Grupo de Trabalho do React 18 se você estiver curioso!
 
 ---
 
 </Intro>
 
-## O que vem por aí no React 18 {/*whats-coming-in-react-18*/}
+## O que está por vir no React 18 {/*whats-coming-in-react-18*/}
 
 Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agrupamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
 
-Esses recursos são possíveis graças a um novo mecanismo opt-in que estamos adicionando no React 18. Chama-se “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de sua aplicação.
+Esses recursos são possíveis graças a um novo mecanismo de adesão que estamos adicionando no React 18. É chamado de “renderização concorrente” e permite que o React prepare várias versões da UI ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto percebido da sua aplicação.
 
-Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para a adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será ativada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
+Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você o faça!), pode ter ouvido algo chamado “modo concorrente” ou que isso poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para a adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será ativada apenas para atualizações desencadeadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
 
 ## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Como a concorrência no React 18 é opt-in, não há mudanças significativas de quebra de comportamento dos componentes prontas para uso. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma em seu código de aplicação, com um esforço comparável ao de uma versão principal típica do React**. Com base em nossa experiência convertendo várias aplicações para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
+Como a concorrência no React 18 é opt-in, não há mudanças significativas e prontas para uso no comportamento dos componentes. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma na sua base de código da aplicação, com um nível de esforço comparável a uma versão principal típica do React**. Com base em nossa experiência convertendo vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-Conseguimos enviar recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “funciona” sem mudanças adicionais. Estamos comprometidos em garantir que esta seja uma atualização tranquila para toda a comunidade, por isso hoje estamos anunciando o Grupo de Trabalho do React 18.
+Enviamos com sucesso recursos concorrentes para dezenas de milhares de componentes no Facebook e, em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem alterações adicionais. Estamos comprometidos em garantir que essa atualização seja suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
 
 ## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que queríamos para este grupo inicial e pequeno, mas se esse experimento funcionar, esperamos que haja mais oportunidades no futuro!
+Estamos tentando algo novo para este lançamento: Convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não pudemos convidar todos que queríamos para este grupo inicial pequeno, mas se esse experimento funcionar, esperamos que haja mais no futuro!
 
-**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção gradual e tranquila do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe principal também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, quaisquer informações importantes também serão postadas neste blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado em [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Os membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe principal também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, quaisquer informações importantes também serão publicadas neste blog.
 
 Para mais informações sobre a atualização para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
@@ -49,23 +49,23 @@ Para mais informações sobre a atualização para o React 18, ou recursos adici
 
 Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Como esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, de modo que todos têm acesso às mesmas informações. Acreditamos que isso é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, ao mesmo tempo em que mantemos transparência com a comunidade em geral.
+Como esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso às mesmas informações. Acreditamos que isso é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
 
-Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para o nosso [rastreador de problemas](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
 
 ## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-Novos alphas são [publicados regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente de nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia útil seguinte.
+Novos alphas são [regularmente publicados no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia útil seguinte.
 
-Pode haver mudanças comportamentais ou de API significativas entre os lançamentos alfa. Por favor, lembre-se de que **lançamentos alfa não são recomendados para aplicações de produção voltadas para o usuário**.
+Pode haver mudanças significativas de comportamento ou API entre as versões alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
 
-## Cronograma projetado para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
+## Cronograma projetado de lançamento do React 18 {/*projected-react-18-release-timeline*/}
 
-Não temos uma data de lançamento específica agendada, mas esperamos que leve vários meses de feedback e iteração antes que o React 18 esteja pronto para a maioria das aplicações de produção.
+Não temos uma data específica de lançamento agendada, mas esperamos que levaremos vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações em produção.
 
-* Biblioteca Alpha: Disponível hoje
+* Alpha da Biblioteca: Disponível hoje
 * Beta Pública: Pelo menos vários meses
-* Release Candidate (RC): Pelo menos várias semanas após a Beta
-* Disponibilidade Geral: Pelo menos várias semanas após a RC
+* Release Candidate (RC): Pelo menos várias semanas após o Beta
+* Disponibilidade Geral: Pelo menos várias semanas após o RC
 
-Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Faremos postagens de atualizações neste blog quando estivermos mais próximos de um lançamento público.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Faremos atualizações neste blog quando estivermos mais perto de um lançamento público.

--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -1,11 +1,11 @@
 ---
 title: "O Plano para o React 18"
-author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage e Seth Webster
+author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, e Seth Webster
 date: 2021/06/08
-description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um React 18 Alpha para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
 ---
 
-8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage) e [Seth Webster](https://twitter.com/sethwebster)
+8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
 
 ---
 
@@ -15,57 +15,57 @@ A equipe do React está animada para compartilhar algumas atualizações:
 
 1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
 2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
-3. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
+3. Publicamos um React 18 Alpha para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
 
-Essas atualizações são destinadas principalmente a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
+Essas atualizações são direcionadas principalmente a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post com segurança. Mas sinta-se à vontade para seguir as discussões no Grupo de Trabalho do React 18 se estiver curioso!
 
 ---
 
 </Intro>
 
-## O que está por vir no React 18 {/*whats-coming-in-react-18*/}
+## O que vem no React 18 {/*whats-coming-in-react-18*/}
 
-Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [empilhamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)) e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
+Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agrupamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor com streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
 
-Esses recursos são possíveis graças a um novo mecanismo de opt-in que estamos adicionando no React 18. Ele é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface ao mesmo tempo. Esta mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de seu aplicativo.
+Esses recursos são possíveis graças a um novo mecanismo opcional que estamos adicionando no React 18. Isso é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é em grande parte nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de seu aplicativo.
 
-Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você esteja!), pode ter ouvido algo chamado “modo concorrente” ou que isso poderia quebrar seu aplicativo. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para uma adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos em seu próprio ritmo.**
+Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso pode quebrar seu aplicativo. Em resposta ao feedback da comunidade, redesenhamos a estratégia de atualização para adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações desencadeadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos em seu próprio ritmo.**
 
 ## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Como a concorrência no React 18 é opt-in, não há mudanças significativas e fora da caixa no comportamento dos componentes. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma no código da sua aplicação, com um nível de esforço comparável ao de uma liberação principal típica do React**. Com base em nossa experiência ao converter vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
+Como a concorrência no React 18 é opcional, não há alterações significativas de quebra de comportamento de componente prontas para uso. **Você pode atualizar para o React 18 com alterações mínimas ou nenhuma no código de sua aplicação, com um nível de esforço comparável a uma versão principal típica do React**. Com base em nossa experiência convertendo vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-Enviamos com sucesso recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “funciona normalmente” sem mudanças adicionais. Estamos comprometidos em garantir que esta seja uma atualização suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
+Conseguimos enviar recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem mudanças adicionais. Estamos comprometidos em garantir que esta seja uma atualização suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
 
 ## Trabalhando com a comunidade {/*working-with-the-community*/}
 
 Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não pudemos convidar todos que gostaríamos para este grupo inicial pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
 
-**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Os membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, qualquer informação importante também será postada neste blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho é hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que o lançamento estável se aproxima, qualquer informação importante também será postada neste blog.
 
-Para mais informações sobre como atualizar para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
+Para mais informações sobre a atualização para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
 ## Acessando o Grupo de Trabalho do React 18 {/*accessing-the-react-18-working-group*/}
 
 Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados terão permissão para criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso às mesmas informações. Acreditamos que este é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
+Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em threads. No entanto, as threads são totalmente visíveis ao público, portanto, todos têm acesso às mesmas informações. Acreditamos que este é um bom compromisso entre a criação de um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
 
-Como sempre, você pode enviar relatórios de erros, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
 
 ## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-Novos alphas são [publicados regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia de trabalho seguinte.
+Novos alphas estão [regularmente publicados no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente para nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia útil seguinte.
 
-Pode haver mudanças significativas de comportamento ou API entre os lançamentos alpha. Lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
+Pode haver mudanças comportamentais ou de API significativas entre lançamentos alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
 
-## Cronograma projetado para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
+## Linha do tempo projetada para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
 
-Não temos uma data de lançamento específica agendada, mas esperamos que leve vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
+Não temos uma data de lançamento específica programada, mas esperamos que leve vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
 
-* Biblioteca Alpha: Disponível hoje
+* Alpha da Biblioteca: Disponível hoje
 * Beta Pública: Pelo menos vários meses
 * Release Candidate (RC): Pelo menos várias semanas após a Beta
-* Disponibilidade Geral: Pelo menos várias semanas após a RC
+* Disponibilidade Geral: Pelo menos várias semanas após o RC
 
-Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Postaremos atualizações neste blog quando estivermos mais perto de um lançamento público.
+Mais detalhes sobre nossa linha do tempo de lançamento projetada estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Postaremos atualizações neste blog quando estivermos mais próximos de um lançamento público.

--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -2,7 +2,7 @@
 title: "O Plano para o React 18"
 author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, e Seth Webster
 date: 2021/06/08
-description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um React 18 Alpha para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
 ---
 
 8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
@@ -15,33 +15,33 @@ A equipe do React está animada para compartilhar algumas atualizações:
 
 1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
 2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
-3. Publicamos um React 18 Alpha para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
+3. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
 
-Essas atualizações são direcionadas principalmente a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post com segurança. Mas sinta-se à vontade para seguir as discussões no Grupo de Trabalho do React 18 se estiver curioso!
+Essas atualizações são direcionadas principalmente a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post com segurança. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se tiver curiosidade!
 
 ---
 
 </Intro>
 
-## O que vem no React 18 {/*whats-coming-in-react-18*/}
+## O que vem por aí no React 18 {/*whats-coming-in-react-18*/}
 
-Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agrupamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor com streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
+Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agrupamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
 
-Esses recursos são possíveis graças a um novo mecanismo opcional que estamos adicionando no React 18. Isso é chamado de “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é em grande parte nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de seu aplicativo.
+Esses recursos são possíveis graças a um novo mecanismo opt-in que estamos adicionando no React 18. Chama-se “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de sua aplicação.
 
-Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso pode quebrar seu aplicativo. Em resposta ao feedback da comunidade, redesenhamos a estratégia de atualização para adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações desencadeadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos em seu próprio ritmo.**
+Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você faça isso!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para a adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será ativada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
 
 ## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Como a concorrência no React 18 é opcional, não há alterações significativas de quebra de comportamento de componente prontas para uso. **Você pode atualizar para o React 18 com alterações mínimas ou nenhuma no código de sua aplicação, com um nível de esforço comparável a uma versão principal típica do React**. Com base em nossa experiência convertendo vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
+Como a concorrência no React 18 é opt-in, não há mudanças significativas de quebra de comportamento dos componentes prontas para uso. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma em seu código de aplicação, com um esforço comparável ao de uma versão principal típica do React**. Com base em nossa experiência convertendo várias aplicações para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-Conseguimos enviar recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem mudanças adicionais. Estamos comprometidos em garantir que esta seja uma atualização suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
+Conseguimos enviar recursos concorrentes para dezenas de milhares de componentes no Facebook, e em nossa experiência, descobrimos que a maioria dos componentes React “funciona” sem mudanças adicionais. Estamos comprometidos em garantir que esta seja uma atualização tranquila para toda a comunidade, por isso hoje estamos anunciando o Grupo de Trabalho do React 18.
 
 ## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não pudemos convidar todos que gostaríamos para este grupo inicial pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
+Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que queríamos para este grupo inicial e pequeno, mas se esse experimento funcionar, esperamos que haja mais oportunidades no futuro!
 
-**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho é hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que o lançamento estável se aproxima, qualquer informação importante também será postada neste blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção gradual e tranquila do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe principal também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, quaisquer informações importantes também serão postadas neste blog.
 
 Para mais informações sobre a atualização para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
@@ -49,23 +49,23 @@ Para mais informações sobre a atualização para o React 18, ou recursos adici
 
 Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Porque esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em threads. No entanto, as threads são totalmente visíveis ao público, portanto, todos têm acesso às mesmas informações. Acreditamos que este é um bom compromisso entre a criação de um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
+Como esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, de modo que todos têm acesso às mesmas informações. Acreditamos que isso é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, ao mesmo tempo em que mantemos transparência com a comunidade em geral.
 
-Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para o nosso [rastreador de problemas](https://github.com/facebook/react/issues).
 
 ## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-Novos alphas estão [regularmente publicados no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente para nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia útil seguinte.
+Novos alphas são [publicados regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente de nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia útil seguinte.
 
-Pode haver mudanças comportamentais ou de API significativas entre lançamentos alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
+Pode haver mudanças comportamentais ou de API significativas entre os lançamentos alfa. Por favor, lembre-se de que **lançamentos alfa não são recomendados para aplicações de produção voltadas para o usuário**.
 
-## Linha do tempo projetada para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
+## Cronograma projetado para o lançamento do React 18 {/*projected-react-18-release-timeline*/}
 
-Não temos uma data de lançamento específica programada, mas esperamos que leve vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
+Não temos uma data de lançamento específica agendada, mas esperamos que leve vários meses de feedback e iteração antes que o React 18 esteja pronto para a maioria das aplicações de produção.
 
-* Alpha da Biblioteca: Disponível hoje
+* Biblioteca Alpha: Disponível hoje
 * Beta Pública: Pelo menos vários meses
 * Release Candidate (RC): Pelo menos várias semanas após a Beta
-* Disponibilidade Geral: Pelo menos várias semanas após o RC
+* Disponibilidade Geral: Pelo menos várias semanas após a RC
 
-Mais detalhes sobre nossa linha do tempo de lançamento projetada estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Postaremos atualizações neste blog quando estivermos mais próximos de um lançamento público.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Faremos postagens de atualizações neste blog quando estivermos mais próximos de um lançamento público.

--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -2,7 +2,7 @@
 title: "O Plano para o React 18"
 author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, e Seth Webster
 date: 2021/06/08
-description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão React 18, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos uma Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback...
 ---
 
 8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://twitter.com/dan_abramov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
@@ -13,59 +13,59 @@ description: A equipe do React está animada para compartilhar algumas atualiza�
 
 A equipe do React está animada para compartilhar algumas atualizações:
 
-1. Começamos a trabalhar na versão React 18, que será nossa próxima versão principal.
+1. Começamos a trabalhar na versão 18 do React, que será nossa próxima versão principal.
 2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
-3. Publicamos um Alpha do React 18 para que autores de bibliotecas possam experimentá-lo e fornecer feedback.
+3. Publicamos uma Alpha do React 18 para que autores de bibliotecas possam testá-la e fornecer feedback.
 
-Essas atualizações são principalmente direcionadas a mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar este post. Mas fique à vontade para acompanhar as discussões no Grupo de Trabalho do React 18 se você estiver curioso!
+Essas atualizações são principalmente direcionadas aos mantenedores de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, pode ignorar com segurança este post. Mas você é bem-vindo para acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
 
 ---
 
 </Intro>
 
-## O que está por vir no React 18 {/*whats-coming-in-react-18*/}
+## O que vem por aí no React 18 {/*whats-coming-in-react-18*/}
 
-Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [agrupamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte embutido para `React.lazy`.
+Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [empilhamento automático](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo renderizador de servidor em streaming](https://github.com/reactwg/react-18/discussions/37) com suporte integrado para `React.lazy`.
 
-Esses recursos são possíveis graças a um novo mecanismo de adesão que estamos adicionando no React 18. É chamado de “renderização concorrente” e permite que o React prepare várias versões da UI ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto percebido da sua aplicação.
+Esses recursos são possíveis graças a um novo mecanismo de adesão que estamos adicionando no React 18. Chamamos de “renderização concorrente” e permite que o React prepare várias versões da interface do usuário ao mesmo tempo. Essa mudança é principalmente nos bastidores, mas desbloqueia novas possibilidades para melhorar tanto o desempenho real quanto o percebido de seu aplicativo.
 
-Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você o faça!), pode ter ouvido algo chamado “modo concorrente” ou que isso poderia quebrar sua aplicação. Em resposta a esse feedback da comunidade, redesenhamos a estratégia de atualização para a adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será ativada apenas para atualizações desencadeadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
+Se você tem acompanhado nossa pesquisa sobre o futuro do React (não esperamos que você o faça!), pode ter ouvido falar de algo chamado “modo concorrente” ou que isso poderia quebrar seu aplicativo. Em resposta a esse feedback da comunidade, reformulamos a estratégia de atualização para uma adoção gradual. Em vez de um “modo” tudo ou nada, a renderização concorrente será habilitada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa **que você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
 
 ## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Como a concorrência no React 18 é opt-in, não há mudanças significativas e prontas para uso no comportamento dos componentes. **Você pode atualizar para o React 18 com mudanças mínimas ou nenhuma na sua base de código da aplicação, com um nível de esforço comparável a uma versão principal típica do React**. Com base em nossa experiência convertendo vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
+Como a concorrência no React 18 é opcional, não há mudanças significativas no comportamento dos componentes fora da caixa. **Você pode atualizar para o React 18 com alterações mínimas ou sem alterações no código de sua aplicação, com um nível de esforço comparável a uma atualização típica do React**. Com base em nossa experiência convertendo vários aplicativos para o React 18, esperamos que muitos usuários consigam atualizar em uma única tarde.
 
-Enviamos com sucesso recursos concorrentes para dezenas de milhares de componentes no Facebook e, em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem alterações adicionais. Estamos comprometidos em garantir que essa atualização seja suave para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
+Tivemos sucesso em enviar recursos concorrentes para dezenas de milhares de componentes no Facebook e, em nossa experiência, descobrimos que a maioria dos componentes React “simplesmente funciona” sem alterações adicionais. Estamos comprometidos em garantir que isso seja uma atualização tranquila para toda a comunidade, então hoje estamos anunciando o Grupo de Trabalho do React 18.
 
 ## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-Estamos tentando algo novo para este lançamento: Convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não pudemos convidar todos que queríamos para este grupo inicial pequeno, mas se esse experimento funcionar, esperamos que haja mais no futuro!
+Estamos tentando algo novo para este lançamento: convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18) para fornecer feedback, fazer perguntas e colaborar no lançamento. Não conseguimos convidar todos que queríamos para este grupo inicial pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
 
-**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado em [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Os membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe principal também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, quaisquer informações importantes também serão publicadas neste blog.
+**O objetivo do Grupo de Trabalho do React 18 é preparar o ecossistema para uma adoção suave e gradual do React 18 por aplicações e bibliotecas existentes.** O Grupo de Trabalho está hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para o público ler. Membros do grupo de trabalho podem deixar feedback, fazer perguntas e compartilhar ideias. A equipe central também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que a versão estável se aproxima, qualquer informação importante também será postada neste blog.
 
-Para mais informações sobre a atualização para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
+Para mais informações sobre como atualizar para o React 18, ou recursos adicionais sobre o lançamento, veja o [post de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
 ## Acessando o Grupo de Trabalho do React 18 {/*accessing-the-react-18-working-group*/}
 
-Todos podem ler as discussões no [repositório do Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
+Todos podem ler as discussões no repositório do [Grupo de Trabalho do React 18](https://github.com/reactwg/react-18).
 
-Como esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso às mesmas informações. Acreditamos que isso é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
+Como esperamos um aumento inicial de interesse no Grupo de Trabalho, apenas membros convidados poderão criar ou comentar em tópicos. No entanto, os tópicos são totalmente visíveis ao público, então todos têm acesso à mesma informação. Acreditamos que este é um bom compromisso entre criar um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade mais ampla.
 
-Como sempre, você pode enviar relatórios de bugs, perguntas e feedback geral para nosso [rastreador de problemas](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de bugs, perguntas e comentários gerais para nosso [rastreador de issues](https://github.com/facebook/react/issues).
 
 ## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-Novos alphas são [regularmente publicados no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses lançamentos são construídos usando o commit mais recente do nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em um alpha no dia útil seguinte.
+Novas alphas são [publicadas regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Essas versões são construídas usando o commit mais recente em nosso repositório principal. Quando um recurso ou correção de bug é mesclado, ele aparecerá em uma alpha no dia útil seguinte.
 
-Pode haver mudanças significativas de comportamento ou API entre as versões alpha. Por favor, lembre-se de que **lançamentos alpha não são recomendados para aplicações de produção voltadas para o usuário**.
+Pode haver mudanças significativas no comportamento ou na API entre as versões alpha. Por favor, lembre-se de que **as versões alpha não são recomendadas para aplicações de produção voltadas para o usuário**.
 
-## Cronograma projetado de lançamento do React 18 {/*projected-react-18-release-timeline*/}
+## Cronograma de lançamento projetado do React 18 {/*projected-react-18-release-timeline*/}
 
-Não temos uma data específica de lançamento agendada, mas esperamos que levaremos vários meses de feedback e iteração até que o React 18 esteja pronto para a maioria das aplicações em produção.
+Não temos uma data específica de lançamento programada, mas esperamos que leve vários meses de feedback e iteração antes que o React 18 esteja pronto para a maioria das aplicações de produção.
 
 * Alpha da Biblioteca: Disponível hoje
 * Beta Pública: Pelo menos vários meses
-* Release Candidate (RC): Pelo menos várias semanas após o Beta
-* Disponibilidade Geral: Pelo menos várias semanas após o RC
+* Release Candidate (RC): Pelo menos várias semanas após a Beta
+* Disponibilidade Geral: Pelo menos várias semanas após a RC
 
-Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Faremos atualizações neste blog quando estivermos mais perto de um lançamento público.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Grupo de Trabalho](https://github.com/reactwg/react-18/discussions/9). Publicaremos atualizações neste blog quando estivermos mais próximos de um lançamento público.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details. 

Feel free to review and suggest any improvements to the translation.