### PR TITLE
Translate `react-conf-2021-recap.md` to pt-br

### DIFF
--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,8 +1,8 @@
 ---
-title: "Recapitulação da React Conf 2021"
+title: "Resumo da React Conf 2021"
 author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para entregar anúncios que mudaram a indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+description: Na semana passada, sediamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para fazer anúncios que mudaram a indústria, como React Native e React Hooks. Este ano, compartilhamos nossa visão multi-plataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 ---
 
 17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,13 +11,13 @@ description: Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteri
 
 <Intro>
 
-Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para entregar anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+Na semana passada, sediamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para fazer anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multi-plataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 
 </Intro>
 
 ---
 
-Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord durante os dois eventos.
+Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras, e 5.000 participantes no Discord durante os dois eventos.
 
 Todas as palestras estão [disponíveis para transmissão online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
@@ -27,21 +27,21 @@ Aqui está um resumo do que foi compartilhado no palco:
 
 Na palestra principal, compartilhamos nossa visão para o futuro do React, começando com o React 18.
 
-O React 18 adiciona o aguardado renderizador concorrente e atualizações para o Suspense sem nenhuma mudança drástica. Os aplicativos podem atualizar para o React 18 e começar a adotar gradualmente recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
+O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem nenhuma mudança significativa que quebre a compatibilidade. Aplicativos podem atualizar para o React 18 e começar a adotar gradualmente recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
 
 **Isso significa que não há modo concorrente, apenas recursos concorrentes.**
 
-Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo para o React Native em várias plataformas.
+Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo de múltiplas plataformas para o React Native.
 
 Assista à palestra completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 para Desenvolvedores de Aplicação {/*react-18-for-application-developers*/}
+## React 18 para desenvolvedores de aplicativos {/*react-18-for-application-developers*/}
 
-Na palestra principal, também anunciamos que o RC do React 18 está disponível para teste agora. Dependendo do feedback adicional, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
+Na palestra principal, também anunciamos que o React 18 RC já está disponível para testes. Dependendo de novos feedbacks, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
 
-Para tentar o RC do React 18, atualize suas dependências:
+Para experimentar o React 18 RC, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
@@ -60,17 +60,17 @@ const root = ReactDOM.createRoot(container);
 root.render(<App/>);
 ```
 
-Para uma demonstração da atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
+Para uma demonstração de atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
-## Renderização de Servidor Streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
+## Renderização de servidor em streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-O React 18 também inclui melhorias no desempenho da renderização no lado do servidor usando o Suspense.
+O React 18 também inclui melhorias no desempenho da renderização do lado do servidor usando Suspense.
 
-A renderização de servidor streaming permite que você gere HTML a partir de componentes React no servidor e transmita esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
+A renderização de servidor em streaming permite gerar HTML a partir de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
 
-Para uma análise mais aprofundada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
+Para uma análise detalhada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/pj5N-Khihgc" />
 
@@ -82,9 +82,9 @@ Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https
 
 <YouTubeIframe src="https://www.youtube.com/embed/qn7gRClrC9U" />
 
-## Ferramentas para Desenvolvedores React {/*react-developer-tooling*/}
+## Ferramentas para desenvolvedores React {/*react-developer-tooling*/}
 
-Para suportar os novos recursos nesta versão, também anunciamos a recém-formada equipe de DevTools do React e um novo Profiler de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
+Para suportar os novos recursos nesta versão, também anunciamos a recém-formada equipe do React DevTools e um novo Profiler de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
 
 Para mais informações e uma demonstração dos novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
@@ -92,69 +92,69 @@ Para mais informações e uma demonstração dos novos recursos do DevTools, vej
 
 ## React sem memo {/*react-without-memo*/}
 
-Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização da nossa pesquisa nos React Labs sobre um compilador de auto-memoização. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
+Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa dos React Labs sobre um compilador de auto-memoização. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
-## Palestra sobre a documentação do React {/*react-docs-keynote*/}
+## Palestra sobre as documentações do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) iniciou uma seção de palestras sobre aprendizado e design com React com uma palestra sobre nosso investimento na nova documentação do React ([agora lançada como react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprender e projetar com o React, com uma palestra sobre nosso investimento nas novas documentações do React ([agora disponível como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
-## E muito mais... {/*and-more*/}
+## E mais... {/*and-more*/}
 
-**Também ouvimos palestras sobre aprendizado e design com o React:**
+**Também ouvimos palestras sobre aprender e projetar com o React:**
 
-* Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
+* Debbie O'Brien: [Coisas que aprendi com as novas documentações do React](https://youtu.be/-7odLW_hG7s).
 * Sarah Rainsberger: [Aprendendo no Navegador](https://youtu.be/5X-WEQflCL0).
-* Linton Ye: [O ROI do Design com React](https://youtu.be/7cPWmID5XAk).
-* Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
+* Linton Ye: [O ROI de projetar com React](https://youtu.be/7cPWmID5XAk).
+* Delba de Oliveira: [Parques interativos com React](https://youtu.be/zL8cz2W0z34).
 
-**Palestras das equipes de Relay, React Native e PyTorch:**
+**Palestras das equipes Relay, React Native e PyTorch:**
 
 * Robert Balicki: [Reintroduzindo o Relay](https://youtu.be/lhVGdErZuN4).
 * Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [Aprendizado de Máquina em Dispositivos para React Native](https://youtu.be/NLj73vrc2I8).
+* Roman Rädle: [Aprendizagem de Máquina no Dispositivo para React Native](https://youtu.be/NLj73vrc2I8)
 
 **E palestras da comunidade sobre acessibilidade, ferramentas e Componentes do Servidor:**
 
 * Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externo](https://youtu.be/oPfSC5bQPR8).
 * Diego Haz: [Construindo Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
-* Tafu Nakazaki: [Componentes de Formulário Japonês Acessíveis com React](https://youtu.be/S4a0QlsH0pU).
+* Tafu Nakazaki: [Componentes de Formulário Acessíveis em Japonês com React](https://youtu.be/S4a0QlsH0pU).
 * Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
 * Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
 
 ## Obrigado {/*thank-you*/}
 
-Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas a agradecer.
+Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas para agradecer.
 
-Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0) e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
+Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), e [Tim Yung](https://twitter.com/yungsters).
 
-Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e atuar como nossa administradora do Discord.
+Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por organizar o Discord da conferência e servir como nossa administradora do Discord.
 
 Agradecemos a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
 
-Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação, e a [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar na moderação de ambos os eventos.
+Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores e ajudar a moderar ambos os eventos.
 
-Agradecemos aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Agradecemos aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15) e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
+Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudarem a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
 
-Agradecemos a Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), que foi a base para o site da conferência, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilharem suas experiências ao organizarem a Next.js Conf.
+Agradecemos à Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), no qual o site da conferência foi construído, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar suas experiências organizando o Next.js Conf.
 
-Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência na administração de conferências, aprendizados de como realizar a [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém sobre a realização de conferências.
+Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência organizando conferências, aprendizados de quando organizou o [RustConf](https://rustconf.com/), e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos contidos nele sobre como organizar conferências.
 
-Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilharem suas experiências na realização da Women of React Conf.
+Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilharem suas experiências organizando a Women of React Conf.
 
-Agradecemos a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
+Agradecemos a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic), e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
 
-Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda no design e na construção do site da conferência e dos ingressos.
+Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) por ajudar a projetar e construir o site da conferência e os ingressos.
 
-Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravarem os vídeos da Palestra Principal e das palestras de funcionários da Meta.
+Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções em Vídeo do Facebook por gravar os vídeos para a Palestra Principal e os talks de funcionários da Meta.
 
-Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
+Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos na transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
 
-Finalmente, agradecemos a todos os nossos participantes por tornar esta uma grande React Conf!
+Finalmente, agradecemos a todos os nossos participantes por fazer desta uma grande React Conf!

--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,8 +1,8 @@
 ---
-title: "Resumo da React Conf 2021"
+title: "Recapitulação da React Conf 2021"
 author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Na semana passada, sediamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para fazer anúncios que mudaram a indústria, como React Native e React Hooks. Este ano, compartilhamos nossa visão multi-plataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+description: Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para entregar anúncios que mudam a indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 ---
 
 17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,13 +11,13 @@ description: Na semana passada, sediamos nossa 6ª React Conf. Nos anos anterior
 
 <Intro>
 
-Na semana passada, sediamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para fazer anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multi-plataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para entregar anúncios que mudam a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 
 </Intro>
 
 ---
 
-Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras, e 5.000 participantes no Discord durante os dois eventos.
+Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord em ambos os eventos.
 
 Todas as palestras estão [disponíveis para transmissão online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
@@ -27,21 +27,21 @@ Aqui está um resumo do que foi compartilhado no palco:
 
 Na palestra principal, compartilhamos nossa visão para o futuro do React, começando com o React 18.
 
-O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem nenhuma mudança significativa que quebre a compatibilidade. Aplicativos podem atualizar para o React 18 e começar a adotar gradualmente recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
+O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem alterações significativas. Aplicativos podem atualizar para o React 18 e começar a adotar gradualmente recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
 
 **Isso significa que não há modo concorrente, apenas recursos concorrentes.**
 
-Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo de múltiplas plataformas para o React Native.
+Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes de Servidor, novos grupos de trabalho do React e nossa visão de longa data multiplataforma para o React Native.
 
 Assista à palestra completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 para desenvolvedores de aplicativos {/*react-18-for-application-developers*/}
+## React 18 para desenvolvedores de aplicações {/*react-18-for-application-developers*/}
 
-Na palestra principal, também anunciamos que o React 18 RC já está disponível para testes. Dependendo de novos feedbacks, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
+Na palestra principal, também anunciamos que o React 18 RC está disponível para testes agora. Aguardando mais feedback, esta é a versão exata do React que publicaremos para estável no início do próximo ano.
 
-Para experimentar o React 18 RC, atualize suas dependências:
+Para testar o React 18 RC, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
@@ -60,23 +60,23 @@ const root = ReactDOM.createRoot(container);
 root.render(<App/>);
 ```
 
-Para uma demonstração de atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
+Para uma demonstração da atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
 ## Renderização de servidor em streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-O React 18 também inclui melhorias no desempenho da renderização do lado do servidor usando Suspense.
+O React 18 também inclui melhorias no desempenho da renderização do lado do servidor usando o Suspense.
 
-A renderização de servidor em streaming permite gerar HTML a partir de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
+A renderização de servidor em streaming permite gerar HTML a partir de componentes React no servidor, e transmitir esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rapidamente.
 
-Para uma análise detalhada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
+Para uma análise aprofundada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/pj5N-Khihgc" />
 
 ## O primeiro grupo de trabalho do React {/*the-first-react-working-group*/}
 
-Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de biblioteca e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs, como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
+Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de bibliotecas e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
 
 Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https://twitter.com/aakansha1216):
 
@@ -84,7 +84,7 @@ Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https
 
 ## Ferramentas para desenvolvedores React {/*react-developer-tooling*/}
 
-Para suportar os novos recursos nesta versão, também anunciamos a recém-formada equipe do React DevTools e um novo Profiler de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
+Para apoiar os novos recursos neste lançamento, também anunciamos a recém-formada equipe do React DevTools e um novo Profiler de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
 
 Para mais informações e uma demonstração dos novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
@@ -92,69 +92,69 @@ Para mais informações e uma demonstração dos novos recursos do DevTools, vej
 
 ## React sem memo {/*react-without-memo*/}
 
-Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa dos React Labs sobre um compilador de auto-memoização. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
+Olhando para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa no React Labs sobre um compilador que memoiza automaticamente. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
-## Palestra sobre as documentações do React {/*react-docs-keynote*/}
+## Palestra sobre a documentação do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprender e projetar com o React, com uma palestra sobre nosso investimento nas novas documentações do React ([agora disponível como react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) começou uma seção de palestras sobre aprendizado e design com React com uma palestra sobre nosso investimento na nova documentação do React ([agora publicada como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
 ## E mais... {/*and-more*/}
 
-**Também ouvimos palestras sobre aprender e projetar com o React:**
+**Também ouvimos palestras sobre aprendizado e design com React:**
 
-* Debbie O'Brien: [Coisas que aprendi com as novas documentações do React](https://youtu.be/-7odLW_hG7s).
+* Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
 * Sarah Rainsberger: [Aprendendo no Navegador](https://youtu.be/5X-WEQflCL0).
-* Linton Ye: [O ROI de projetar com React](https://youtu.be/7cPWmID5XAk).
-* Delba de Oliveira: [Parques interativos com React](https://youtu.be/zL8cz2W0z34).
+* Linton Ye: [O ROI do Design com React](https://youtu.be/7cPWmID5XAk).
+* Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
 
-**Palestras das equipes Relay, React Native e PyTorch:**
+**Palestras das equipes do Relay, React Native e PyTorch:**
 
-* Robert Balicki: [Reintroduzindo o Relay](https://youtu.be/lhVGdErZuN4).
+* Robert Balicki: [Reapresentando o Relay](https://youtu.be/lhVGdErZuN4).
 * Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [Aprendizagem de Máquina no Dispositivo para React Native](https://youtu.be/NLj73vrc2I8)
+* Roman Rädle: [Aprendizado de Máquina em Dispositivos para React Native](https://youtu.be/NLj73vrc2I8)
 
-**E palestras da comunidade sobre acessibilidade, ferramentas e Componentes do Servidor:**
+**E palestras da comunidade sobre acessibilidade, ferramentas e Componentes de Servidor:**
 
-* Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externo](https://youtu.be/oPfSC5bQPR8).
+* Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externas](https://youtu.be/oPfSC5bQPR8).
 * Diego Haz: [Construindo Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
 * Tafu Nakazaki: [Componentes de Formulário Acessíveis em Japonês com React](https://youtu.be/S4a0QlsH0pU).
 * Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
-* Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
+* Helen Lin: [Hydrogênio + React 18](https://youtu.be/HS6vIYkSNks).
 
 ## Obrigado {/*thank-you*/}
 
-Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas para agradecer.
+Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas a agradecer.
 
-Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e  [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), e [Tim Yung](https://twitter.com/yungsters).
+Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS),  [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), e [Tim Yung](https://twitter.com/yungsters).
 
-Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por organizar o Discord da conferência e servir como nossa administradora do Discord.
+Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
 
 Agradecemos a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
 
-Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores e ajudar a moderar ambos os eventos.
+Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação, e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar a moderar ambos os eventos.
 
 Agradecemos aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudarem a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
+Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
 
-Agradecemos à Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), no qual o site da conferência foi construído, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar suas experiências organizando o Next.js Conf.
+Agradecemos à Vercel por publicar seu [Kit de Início de Evento Virtual](https://vercel.com/virtual-event-starter-kit), no qual o site da conferência foi construído, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar suas experiências na realização do Next.js Conf.
 
-Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência organizando conferências, aprendizados de quando organizou o [RustConf](https://rustconf.com/), e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos contidos nele sobre como organizar conferências.
+Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência na realização de conferências, aprendizados ao realizar o [RustConf](https://rustconf.com/), e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém sobre como realizar conferências.
 
-Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilharem suas experiências organizando a Women of React Conf.
+Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilhar suas experiências na realização da Women of React Conf.
 
 Agradecemos a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic), e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
 
-Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) por ajudar a projetar e construir o site da conferência e os ingressos.
+Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda no design e construção do site da conferência e dos ingressos.
 
-Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções em Vídeo do Facebook por gravar os vídeos para a Palestra Principal e os talks de funcionários da Meta.
+Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravar os vídeos para a palestra principal e as palestras dos funcionários do Meta.
 
-Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos na transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
+Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
 
-Finalmente, agradecemos a todos os nossos participantes por fazer desta uma grande React Conf!
+Finalmente, agradecemos a todos os nossos participantes por fazer deste um grande React Conf!

--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,8 +1,8 @@
 ---
-title: "Resumo da React Conf 2021"
+title: "Recapitulação da React Conf 2021"
 author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Na semana passada, hospedamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças significativas na indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+description: Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para entregar anúncios que mudaram a indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 ---
 
 17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,13 +11,13 @@ description: Na semana passada, hospedamos nossa 6ª React Conf. Em anos anterio
 
 <Intro>
 
-Na semana passada, hospedamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças significativas na indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+Na semana passada, realizamos nossa 6ª React Conf. Nos anos anteriores, usamos o palco da React Conf para entregar anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 
 </Intro>
 
 ---
 
-Esta foi a primeira vez que a React Conf foi hospedada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras, e 5.000 participantes no Discord durante os dois eventos.
+Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord durante os dois eventos.
 
 Todas as palestras estão [disponíveis para transmissão online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
@@ -25,23 +25,23 @@ Aqui está um resumo do que foi compartilhado no palco:
 
 ## React 18 e recursos concorrentes {/*react-18-and-concurrent-features*/}
 
-Na palestra principal, compartilhamos nossa visão para o futuro do React começando com o React 18.
+Na palestra principal, compartilhamos nossa visão para o futuro do React, começando com o React 18.
 
-O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem mudanças drásticas que quebram o código. Os aplicativos podem ser atualizados para o React 18 e começar a adotar gradualmente os recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
+O React 18 adiciona o aguardado renderizador concorrente e atualizações para o Suspense sem nenhuma mudança drástica. Os aplicativos podem atualizar para o React 18 e começar a adotar gradualmente recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
 
 **Isso significa que não há modo concorrente, apenas recursos concorrentes.**
 
-Na palestra principal, também compartilhamos nossa visão para o Suspense, Server Components, novos grupos de trabalho do React e nossa visão de múltiplas plataformas a longo prazo para o React Native.
+Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo para o React Native em várias plataformas.
 
 Assista à palestra completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 para desenvolvedores de aplicativos {/*react-18-for-application-developers*/}
+## React 18 para Desenvolvedores de Aplicação {/*react-18-for-application-developers*/}
 
-Na palestra principal, também anunciamos que o RC do React 18 está disponível para testes agora. Dependendo do feedback adicional, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
+Na palestra principal, também anunciamos que o RC do React 18 está disponível para teste agora. Dependendo do feedback adicional, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
 
-Para testar o RC do React 18, atualize suas dependências:
+Para tentar o RC do React 18, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
@@ -64,97 +64,97 @@ Para uma demonstração da atualização para o React 18, veja a palestra de [Sh
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
-## Renderização de Servidor em Streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
+## Renderização de Servidor Streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-O React 18 também inclui melhorias no desempenho da renderização do lado do servidor utilizando o Suspense.
+O React 18 também inclui melhorias no desempenho da renderização no lado do servidor usando o Suspense.
 
-A renderização de servidor em streaming permite gerar HTML a partir de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar o `Suspense` para dividir seu aplicativo em unidades menores e independentes que podem ser transmitidas independentemente umas das outras, sem bloquear o resto do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
+A renderização de servidor streaming permite que você gere HTML a partir de componentes React no servidor e transmita esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
 
-Para uma análise detalhada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
+Para uma análise mais aprofundada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/pj5N-Khihgc" />
 
 ## O primeiro grupo de trabalho do React {/*the-first-react-working-group*/}
 
-Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de bibliotecas e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs, como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
+Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de biblioteca e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs, como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
 
 Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https://twitter.com/aakansha1216):
 
 <YouTubeIframe src="https://www.youtube.com/embed/qn7gRClrC9U" />
 
-## Ferramentas de Desenvolvimento do React {/*react-developer-tooling*/}
+## Ferramentas para Desenvolvedores React {/*react-developer-tooling*/}
 
-Para apoiar os novos recursos neste lançamento, também anunciamos a nova equipe do React DevTools e um novo Perfilador de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
+Para suportar os novos recursos nesta versão, também anunciamos a recém-formada equipe de DevTools do React e um novo Profiler de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
 
-Para mais informações e uma demonstração de novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
+Para mais informações e uma demonstração dos novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
 <YouTubeIframe src="https://www.youtube.com/embed/oxDfrke8rZg" />
 
 ## React sem memo {/*react-without-memo*/}
 
-Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa no React Labs sobre um compilador de auto-memorização. Confira essa palestra para mais informações e uma demonstração do protótipo do compilador:
+Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização da nossa pesquisa nos React Labs sobre um compilador de auto-memoização. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
-## Palestra principal sobre a documentação do React {/*react-docs-keynote*/}
+## Palestra sobre a documentação do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprender e projetar com React com uma palestra sobre nosso investimento nas novas docs do React ([agora lançadas como react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) iniciou uma seção de palestras sobre aprendizado e design com React com uma palestra sobre nosso investimento na nova documentação do React ([agora lançada como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
-## E mais... {/*and-more*/}
+## E muito mais... {/*and-more*/}
 
-**Também ouvimos palestras sobre aprender e projetar com React:**
+**Também ouvimos palestras sobre aprendizado e design com o React:**
 
-* Debbie O'Brien: [Coisas que aprendi com as novas docs do React](https://youtu.be/-7odLW_hG7s).
+* Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
 * Sarah Rainsberger: [Aprendendo no Navegador](https://youtu.be/5X-WEQflCL0).
-* Linton Ye: [O ROI de Projetar com React](https://youtu.be/7cPWmID5XAk).
-* Delba de Oliveira: [Praças interativas com React](https://youtu.be/zL8cz2W0z34).
+* Linton Ye: [O ROI do Design com React](https://youtu.be/7cPWmID5XAk).
+* Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
 
 **Palestras das equipes de Relay, React Native e PyTorch:**
 
 * Robert Balicki: [Reintroduzindo o Relay](https://youtu.be/lhVGdErZuN4).
 * Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [Aprendizado de Máquina no Dispositivo para React Native](https://youtu.be/NLj73vrc2I8).
+* Roman Rädle: [Aprendizado de Máquina em Dispositivos para React Native](https://youtu.be/NLj73vrc2I8).
 
-**E palestras da comunidade sobre acessibilidade, ferramentas e Server Components:**
+**E palestras da comunidade sobre acessibilidade, ferramentas e Componentes do Servidor:**
 
 * Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externo](https://youtu.be/oPfSC5bQPR8).
 * Diego Haz: [Construindo Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
-* Tafu Nakazaki: [Componentes de Formulário Acessíveis Japoneses com React](https://youtu.be/S4a0QlsH0pU).
+* Tafu Nakazaki: [Componentes de Formulário Japonês Acessíveis com React](https://youtu.be/S4a0QlsH0pU).
 * Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
 * Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
 
 ## Obrigado {/*thank-you*/}
 
-Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas para agradecer.
+Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas a agradecer.
 
-Primeiro, obrigado a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0) e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Obrigado a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
+Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
 
-Obrigado a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
+Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e atuar como nossa administradora do Discord.
 
-Obrigado a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estávamos focados em diversidade e inclusão.
+Agradecemos a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
 
-Obrigado a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nossos esforços de moderação, e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar a moderar ambos os eventos.
+Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação, e a [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar na moderação de ambos os eventos.
 
-Obrigado aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Agradecemos aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Obrigado a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15) e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo engajante para a comunidade.
+Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15) e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
 
-Obrigado à Vercel por publicar seu [Virtual Event Starter Kit](https://vercel.com/virtual-event-starter-kit), que foi utilizado para construir o site da conferência, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar suas experiências organizando a Next.js Conf.
+Agradecemos a Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), que foi a base para o site da conferência, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilharem suas experiências ao organizarem a Next.js Conf.
 
-Obrigado a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência em organizar conferências, aprendizados de sua organização na [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém para organizar conferências.
+Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência na administração de conferências, aprendizados de como realizar a [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém sobre a realização de conferências.
 
-Obrigado a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilhar suas experiências organizando a Women of React Conf.
+Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilharem suas experiências na realização da Women of React Conf.
 
-Obrigado a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
+Agradecemos a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
 
-Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda no design e construção do site e dos ingressos da conferência.
+Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda no design e na construção do site da conferência e dos ingressos.
 
-Obrigado a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravar os vídeos da Palestra Principal e das conferências dos colaboradores da Meta.
+Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravarem os vídeos da Palestra Principal e das palestras de funcionários da Meta.
 
-Obrigado ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos do stream, traduzir todas as palestras e moderar o Discord em múltiplos idiomas.
+Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
 
-Finalmente, obrigado a todos os nossos participantes por tornar esta uma ótima React Conf!
+Finalmente, agradecemos a todos os nossos participantes por tornar esta uma grande React Conf!

--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,8 +1,8 @@
 ---
-title: "Recapitulação da React Conf 2021"
+title: "Resumo da React Conf 2021"
 author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Na semana passada, realizamos a nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças inovadoras na indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual das funcionalidades concorrentes.
+description: Na semana passada, hospedamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças significativas na indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 ---
 
 17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,43 +11,43 @@ description: Na semana passada, realizamos a nossa 6ª React Conf. Em anos anter
 
 <Intro>
 
-Na semana passada, realizamos a nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças inovadoras na indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual das funcionalidades concorrentes.
+Na semana passada, hospedamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças significativas na indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 
 </Intro>
 
 ---
 
-Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord durante os dois eventos.
+Esta foi a primeira vez que a React Conf foi hospedada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras, e 5.000 participantes no Discord durante os dois eventos.
 
 Todas as palestras estão [disponíveis para transmissão online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
 Aqui está um resumo do que foi compartilhado no palco:
 
-## React 18 e funcionalidades concorrentes {/*react-18-and-concurrent-features*/}
+## React 18 e recursos concorrentes {/*react-18-and-concurrent-features*/}
 
 Na palestra principal, compartilhamos nossa visão para o futuro do React começando com o React 18.
 
-O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem mudanças drásticas que quebrariam a compatibilidade. Aplicativos podem atualizar para o React 18 e começar a adotar gradualmente funcionalidades concorrentes com um esforço equivalente a qualquer outro lançamento importante.
+O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem mudanças drásticas que quebram o código. Os aplicativos podem ser atualizados para o React 18 e começar a adotar gradualmente os recursos concorrentes com um esforço equivalente a qualquer outro lançamento importante.
 
-**Isso significa que não há modo concorrente, apenas funcionalidades concorrentes.**
+**Isso significa que não há modo concorrente, apenas recursos concorrentes.**
 
-Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo multiplataforma para o React Native.
+Na palestra principal, também compartilhamos nossa visão para o Suspense, Server Components, novos grupos de trabalho do React e nossa visão de múltiplas plataformas a longo prazo para o React Native.
 
 Assista à palestra completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 para Desenvolvedores de Aplicação {/*react-18-for-application-developers*/}
+## React 18 para desenvolvedores de aplicativos {/*react-18-for-application-developers*/}
 
-Na palestra principal, também anunciamos que o React 18 RC está disponível para teste agora. Dependendo de mais feedback, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
+Na palestra principal, também anunciamos que o RC do React 18 está disponível para testes agora. Dependendo do feedback adicional, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
 
-Para experimentar o React 18 RC, atualize suas dependências:
+Para testar o RC do React 18, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
 ```
 
-e troque para a nova API `createRoot`:
+e mude para a nova API `createRoot`:
 
 ```js
 // antes
@@ -64,13 +64,13 @@ Para uma demonstração da atualização para o React 18, veja a palestra de [Sh
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
-## Renderização em Streaming no Servidor com Suspense {/*streaming-server-rendering-with-suspense*/}
+## Renderização de Servidor em Streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-O React 18 também inclui melhorias no desempenho da renderização do lado do servidor usando Suspense.
+O React 18 também inclui melhorias no desempenho da renderização do lado do servidor utilizando o Suspense.
 
-A renderização em streaming no servidor permite gerar HTML a partir de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
+A renderização de servidor em streaming permite gerar HTML a partir de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar o `Suspense` para dividir seu aplicativo em unidades menores e independentes que podem ser transmitidas independentemente umas das outras, sem bloquear o resto do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
 
-Para uma análise mais profunda, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
+Para uma análise detalhada, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/pj5N-Khihgc" />
 
@@ -82,23 +82,23 @@ Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https
 
 <YouTubeIframe src="https://www.youtube.com/embed/qn7gRClrC9U" />
 
-## Ferramentas para Desenvolvedor React {/*react-developer-tooling*/}
+## Ferramentas de Desenvolvimento do React {/*react-developer-tooling*/}
 
-Para apoiar as novas funcionalidades neste lançamento, também anunciamos a recém-formada equipe do React DevTools e um novo Profiler de Linha do Tempo para ajudar desenvolvedores a depurar suas aplicações React.
+Para apoiar os novos recursos neste lançamento, também anunciamos a nova equipe do React DevTools e um novo Perfilador de Linha do Tempo para ajudar os desenvolvedores a depurar seus aplicativos React.
 
-Para mais informações e uma demonstração das novas funcionalidades do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
+Para mais informações e uma demonstração de novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
 <YouTubeIframe src="https://www.youtube.com/embed/oxDfrke8rZg" />
 
 ## React sem memo {/*react-without-memo*/}
 
-Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização da nossa pesquisa do React Labs em um compilador de auto-memoização. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
+Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa no React Labs sobre um compilador de auto-memorização. Confira essa palestra para mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
 ## Palestra principal sobre a documentação do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) iniciou uma seção de palestras sobre aprender e projetar com React com uma palestra sobre nosso investimento na nova documentação do React ([agora lançada como react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprender e projetar com React com uma palestra sobre nosso investimento nas novas docs do React ([agora lançadas como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
@@ -106,55 +106,55 @@ Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) co
 
 **Também ouvimos palestras sobre aprender e projetar com React:**
 
-* Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
+* Debbie O'Brien: [Coisas que aprendi com as novas docs do React](https://youtu.be/-7odLW_hG7s).
 * Sarah Rainsberger: [Aprendendo no Navegador](https://youtu.be/5X-WEQflCL0).
 * Linton Ye: [O ROI de Projetar com React](https://youtu.be/7cPWmID5XAk).
-* Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
+* Delba de Oliveira: [Praças interativas com React](https://youtu.be/zL8cz2W0z34).
 
 **Palestras das equipes de Relay, React Native e PyTorch:**
 
-* Robert Balicki: [Reapresentando o Relay](https://youtu.be/lhVGdErZuN4).
+* Robert Balicki: [Reintroduzindo o Relay](https://youtu.be/lhVGdErZuN4).
 * Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [Aprendizado de Máquina no Dispositivo para React Native](https://youtu.be/NLj73vrc2I8)
+* Roman Rädle: [Aprendizado de Máquina no Dispositivo para React Native](https://youtu.be/NLj73vrc2I8).
 
-**E palestras da comunidade sobre acessibilidade, ferramentas e Componentes do Servidor:**
+**E palestras da comunidade sobre acessibilidade, ferramentas e Server Components:**
 
 * Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externo](https://youtu.be/oPfSC5bQPR8).
-* Diego Haz: [Construindo Componentes Acessíveis em React 18](https://youtu.be/dcm8fjBfro8).
-* Tafu Nakazaki: [Componentes de Formulário Acessíveis em Japonês com React](https://youtu.be/S4a0QlsH0pU).
+* Diego Haz: [Construindo Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
+* Tafu Nakazaki: [Componentes de Formulário Acessíveis Japoneses com React](https://youtu.be/S4a0QlsH0pU).
 * Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
 * Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
 
 ## Obrigado {/*thank-you*/}
 
-Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas a agradecer.
+Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas para agradecer.
 
-Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, obrigado a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), e [Tim Yung](https://twitter.com/yungsters).
+Obrigado a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
 
-Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
+Obrigado a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
 
-Agradecemos a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
+Obrigado a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estávamos focados em diversidade e inclusão.
 
-Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores e ajudar a moderar ambos os eventos.
+Obrigado a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nossos esforços de moderação, e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar a moderar ambos os eventos.
 
-Agradecemos aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Obrigado aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel da [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) da [React China](https://twitter.com/ReactChina) por ajudarem a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
+Obrigado a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel do [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15) e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo engajante para a comunidade.
 
-Agradecemos à Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), que foi a base do site da conferência, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilharem sua experiência organizando o Next.js Conf.
+Obrigado à Vercel por publicar seu [Virtual Event Starter Kit](https://vercel.com/virtual-event-starter-kit), que foi utilizado para construir o site da conferência, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar suas experiências organizando a Next.js Conf.
 
-Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência organizando conferências, aprendizados sobre a realização da [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que contém para conduzir conferências.
+Obrigado a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência em organizar conferências, aprendizados de sua organização na [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém para organizar conferências.
 
-Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilhar suas experiências organizando a Women of React Conf.
+Obrigado a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilhar suas experiências organizando a Women of React Conf.
 
-Agradecemos a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias ao longo do planejamento.
+Obrigado a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
 
-Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) por ajudar a projetar e construir o site e ingressos da conferência.
+Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda no design e construção do site e dos ingressos da conferência.
 
-Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravarem os vídeos para a Palestra Principal e as palestras dos funcionários da Meta.
+Obrigado a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravar os vídeos da Palestra Principal e das conferências dos colaboradores da Meta.
 
-Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
+Obrigado ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos do stream, traduzir todas as palestras e moderar o Discord em múltiplos idiomas.
 
-Finalmente, agradecemos a todos os nossos participantes por tornar esta uma grande React Conf!
+Finalmente, obrigado a todos os nossos participantes por tornar esta uma ótima React Conf!

--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,160 +1,160 @@
 ---
-title: "React Conf 2021 Recap"
-author: Jesslyn Tannady and Rick Hanlon
+title: "Resumo do React Conf 2021"
+author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Last week we hosted our 6th React Conf. In previous years, we've used the React Conf stage to deliver industry changing announcements such as React Native and React Hooks. This year, we shared our multi-platform vision for React, starting with the release of React 18 and gradual adoption of concurrent features.
+description: Na semana passada, realizamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para apresentar anúncios que mudaram a indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 ---
 
-December 17, 2021 by [Jesslyn Tannady](https://twitter.com/jtannady) and [Rick Hanlon](https://twitter.com/rickhanlonii)
+17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
 <Intro>
 
-Last week we hosted our 6th React Conf. In previous years, we've used the React Conf stage to deliver industry changing announcements such as [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) and [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). This year, we shared our multi-platform vision for React, starting with the release of React 18 and gradual adoption of concurrent features.
+Na semana passada, realizamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para apresentar anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 
 </Intro>
 
 ---
 
-This was the first time React Conf was hosted online, and it was streamed for free, translated to 8 different languages. Participants from all over the world joined our conference Discord and the replay event for accessibility in all timezones. Over 50,000 people registered, with over 60,000 views of 19 talks, and 5,000 participants in Discord across both events.
+Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se inscreveram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord durante os dois eventos.
 
-All the talks are [available to stream online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
+Todas as palestras estão [disponíveis para streaming online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
-Here’s a summary of what was shared on stage:
+Aqui está um resumo do que foi compartilhado no palco:
 
-## React 18 and concurrent features {/*react-18-and-concurrent-features*/}
+## React 18 e recursos concorrentes {/*react-18-and-concurrent-features*/}
 
-In the keynote, we shared our vision for the future of React starting with React 18.
+Na apresentação principal, compartilhamos nossa visão para o futuro do React começando com o React 18.
 
-React 18 adds the long-awaited concurrent renderer and updates to Suspense without any major breaking changes. Apps can upgrade to React 18 and begin gradually adopting concurrent features with the amount of effort on par with any other major release.
+O React 18 adiciona o tão esperado renderizador concorrente e atualizações ao Suspense sem grandes mudanças de quebra. Os aplicativos podem atualizar para o React 18 e começar a adotar gradualmente os recursos concorrentes com o mesmo esforço que qualquer outro lançamento importante.
 
-**This means there is no concurrent mode, only concurrent features.**
+**Isso significa que não há modo concorrente, apenas recursos concorrentes.**
 
-In the keynote, we also shared our vision for Suspense, Server Components, new React working groups, and our long-term many-platform vision for React Native.
+Na apresentação principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo multiplataforma para o React Native.
 
-Watch the full keynote from [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), and [Rick Hanlon](https://twitter.com/rickhanlonii) here:
+Assista à apresentação completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 for Application Developers {/*react-18-for-application-developers*/}
+## React 18 para Desenvolvedores de Aplicações {/*react-18-for-application-developers*/}
 
-In the keynote, we also announced that the React 18 RC is available to try now. Pending further feedback, this is the exact version of React that we will publish to stable early next year.
+Na apresentação principal, também anunciamos que o React 18 RC está disponível para testes agora. Dependendo do feedback adicional, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
 
-To try the React 18 RC, upgrade your dependencies:
+Para testar o React 18 RC, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
 ```
 
-and switch to the new `createRoot` API:
+e mude para a nova API `createRoot`:
 
 ```js
-// before
+// antes
 const container = document.getElementById('root');
 ReactDOM.render(<App />, container);
 
-// after
+// depois
 const container = document.getElementById('root');
 const root = ReactDOM.createRoot(container);
 root.render(<App/>);
 ```
 
-For a demo of upgrading to React 18, see [Shruti Kapoor](https://twitter.com/shrutikapoor08)’s talk here:
+Para uma demonstração de atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
-## Streaming Server Rendering with Suspense {/*streaming-server-rendering-with-suspense*/}
+## Rendering em Stream no Servidor com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-React 18 also includes improvements to server-side rendering performance using Suspense.
+O React 18 também inclui melhorias no desempenho de rendering no servidor usando Suspense.
 
-Streaming server rendering lets you generate HTML from React components on the server, and stream that HTML to your users. In React 18, you can use `Suspense` to break down your app into smaller independent units which can be streamed independently of each other without blocking the rest of the app. This means users will see your content sooner and be able to start interacting with it much faster.
+Rendering em stream no servidor permite gerar HTML a partir de componentes React no servidor e enviar esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente uma da outra sem bloquear o resto do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
 
-For a deep dive, see [Shaundai Person](https://twitter.com/shaundai)’s talk here:
+Para uma análise mais profunda, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/pj5N-Khihgc" />
 
-## The first React working group {/*the-first-react-working-group*/}
+## O primeiro grupo de trabalho do React {/*the-first-react-working-group*/}
 
-For React 18, we created our first Working Group to collaborate with a panel of experts, developers, library maintainers, and educators. Together we worked to create our gradual adoption strategy and refine new APIs such as `useId`, `useSyncExternalStore`, and `useInsertionEffect`.
+Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de bibliotecas e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
 
-For an overview of this work, see [Aakansha' Doshi](https://twitter.com/aakansha1216)'s talk:
+Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https://twitter.com/aakansha1216):
 
 <YouTubeIframe src="https://www.youtube.com/embed/qn7gRClrC9U" />
 
-## React Developer Tooling {/*react-developer-tooling*/}
+## Ferramentas de Desenvolvimento do React {/*react-developer-tooling*/}
 
-To support the new features in this release, we also announced the newly formed React DevTools team and a new Timeline Profiler to help developers debug their React apps.
+Para apoiar os novos recursos neste lançamento, também anunciamos a recém-formada equipe de React DevTools e um novo Profiler de Timeline para ajudar os desenvolvedores a depurar seus aplicativos React.
 
-For more information and a demo of new DevTools features, see [Brian Vaughn](https://twitter.com/brian_d_vaughn)’s talk:
+Para mais informações e uma demonstração dos novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
 <YouTubeIframe src="https://www.youtube.com/embed/oxDfrke8rZg" />
 
-## React without memo {/*react-without-memo*/}
+## React sem memo {/*react-without-memo*/}
 
-Looking further into the future, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) shared an update from our React Labs research into an auto-memoizing compiler. Check out this talk for more information and a demo of the compiler prototype:
+Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa nos React Labs sobre um compilador auto-memorável. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
-## React docs keynote {/*react-docs-keynote*/}
+## Palestra sobre a documentação do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) kicked off a section of talks about learning and designing with React with a keynote about our investment in React's new docs ([now shipped as react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprendizado e design com React com uma apresentação sobre nosso investimento na nova documentação do React ([agora enviado como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
-## And more... {/*and-more*/}
+## E mais... {/*and-more*/}
 
-**We also heard talks on learning and designing with React:**
+**Também ouvimos palestras sobre aprendizado e design com React:**
 
-* Debbie O'Brien: [Things I learnt from the new React docs](https://youtu.be/-7odLW_hG7s).
-* Sarah Rainsberger: [Learning in the Browser](https://youtu.be/5X-WEQflCL0).
-* Linton Ye: [The ROI of Designing with React](https://youtu.be/7cPWmID5XAk).
-* Delba de Oliveira: [Interactive playgrounds with React](https://youtu.be/zL8cz2W0z34).
+* Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
+* Sarah Rainsberger: [Aprendendo no Navegador](https://youtu.be/5X-WEQflCL0).
+* Linton Ye: [O ROI do Design com React](https://youtu.be/7cPWmID5XAk).
+* Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
 
-**Talks from the Relay, React Native, and PyTorch teams:**
+**Palestras das equipes de Relay, React Native e PyTorch:**
 
-* Robert Balicki: [Re-introducing Relay](https://youtu.be/lhVGdErZuN4).
-* Eric Rozell and Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [On-device Machine Learning for React Native](https://youtu.be/NLj73vrc2I8)
+* Robert Balicki: [Reintroduzindo o Relay](https://youtu.be/lhVGdErZuN4).
+* Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
+* Roman Rädle: [Aprendizado de Máquina em Dispositivo para React Native](https://youtu.be/NLj73vrc2I8)
 
-**And talks from the community on accessibility, tooling, and Server Components:**
+**E palestras da comunidade sobre acessibilidade, ferramentas e Componentes do Servidor:**
 
-* Daishi Kato: [React 18 for External Store Libraries](https://youtu.be/oPfSC5bQPR8).
-* Diego Haz: [Building Accessible Components in React 18](https://youtu.be/dcm8fjBfro8).
-* Tafu Nakazaki: [Accessible Japanese Form Components with React](https://youtu.be/S4a0QlsH0pU).
-* Lyle Troxell: [UI tools for artists](https://youtu.be/b3l4WxipFsE).
+* Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externas](https://youtu.be/oPfSC5bQPR8).
+* Diego Haz: [Construindo Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
+* Tafu Nakazaki: [Componentes de Formulário Acessíveis em Japonês com React](https://youtu.be/S4a0QlsH0pU).
+* Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
 * Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
 
-## Thank you {/*thank-you*/}
+## Obrigado {/*thank-you*/}
 
-This was our first year planning a conference ourselves, and we have a lot of people to thank.
+Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas a agradecer.
 
-First, thanks to all of our speakers [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), and  [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, obrigado a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Thanks to everyone who helped provide feedback on talks including [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS),  [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), and [Tim Yung](https://twitter.com/yungsters).
+Obrigado a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
 
-Thanks to [Lauren Tan](https://twitter.com/potetotes) for setting up the conference Discord and serving as our Discord admin.
+Obrigado a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
 
-Thanks to [Seth Webster](https://twitter.com/sethwebster) for feedback on overall direction and making sure we were focused on diversity and inclusion.
+Obrigado a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
 
-Thanks to [Rachel Nabors](https://twitter.com/rachelnabors) for spearheading our moderation effort, and [Aisha Blake](https://twitter.com/AishaBlake) for creating our moderation guide, leading our moderation team, training the translators and moderators, and helping to moderate both events.
+Obrigado a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação, e a [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar a moderar ambos os eventos.
 
-Thanks to our moderators [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, and [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Obrigado aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Thanks to [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), and Vihang Patel from [React India](https://www.reactindia.io/), and [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), and [YanLun Li](https://twitter.com/anneincoding) from [React China](https://twitter.com/ReactChina) for helping moderate our replay event and keep it engaging for the community.
+Obrigado a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), e Vihang Patel do [React India](https://www.reactindia.io/), e a [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
 
-Thanks to Vercel for publishing their [Virtual Event Starter Kit](https://vercel.com/virtual-event-starter-kit), which the conference website was built on, and to [Lee Robinson](https://twitter.com/leeerob) and [Delba de Oliveira](https://twitter.com/delba_oliveira) for sharing their experience running Next.js Conf.
+Obrigado à Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), com base no qual o site da conferência foi construído, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar sua experiência em conduzir o Next.js Conf.
 
-Thanks to [Leah Silber](https://twitter.com/wifelette) for sharing her experience running conferences, learnings from running [RustConf](https://rustconf.com/), and for her book [Event Driven](https://leanpub.com/eventdriven/) and the advice it contains for running conferences.
+Obrigado a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência em organizar conferências, aprendizados adquiridos ao conduzir o [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém para conduzir conferências.
 
-Thanks to [Kevin Lewis](https://twitter.com/_phzn) and [Rachel Nabors](https://twitter.com/rachelnabors) for sharing their experience running Women of React Conf.
+Obrigado a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilharem sua experiência em conduzir a Women of React Conf.
 
-Thanks to [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic), and [Shaundai Person](https://twitter.com/shaundai) for their advice and ideas throughout planning.
+Obrigado a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic), e [Shaundai Person](https://twitter.com/shaundai) por suas conselhos e ideias durante o planejamento.
 
-Thanks to [Dan Lebowitz](https://twitter.com/lebo) for help designing and building the conference website and tickets.
+Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda na concepção e construção do site da conferência e dos ingressos.
 
-Thanks to Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman and others on the Facebook Video Productions team for recording the videos for the Keynote and Meta employee talks.
+Obrigado a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros na equipe de Produções de Vídeo do Facebook por gravar os vídeos da Palestra Principal e das palestras dos empregados da Meta.
 
-Thanks to our partner HitPlay for helping to organize the conference, editing all the videos in the stream, translating all the talks, and moderating the Discord in multiple languages.
+Obrigado ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras, e moderar o Discord em múltiplos idiomas.
 
-Finally, thanks to all of our participants for making this a great React Conf!
+Finalmente, obrigado a todos os nossos participantes por fazer deste um grande React Conf!

--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,8 +1,8 @@
 ---
-title: "Resumo do React Conf 2021"
+title: "Recapitulação da React Conf 2021"
 author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Na semana passada, realizamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para apresentar anúncios que mudaram a indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+description: Na semana passada, realizamos a nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças inovadoras na indústria, como o React Native e os React Hooks. Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual das funcionalidades concorrentes.
 ---
 
 17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,43 +11,43 @@ description: Na semana passada, realizamos nossa 6ª React Conf. Em anos anterio
 
 <Intro>
 
-Na semana passada, realizamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para apresentar anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
+Na semana passada, realizamos a nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para anunciar mudanças inovadoras na indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para o React, começando com o lançamento do React 18 e a adoção gradual das funcionalidades concorrentes.
 
 </Intro>
 
 ---
 
-Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se inscreveram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord durante os dois eventos.
+Esta foi a primeira vez que a React Conf foi realizada online, e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo se juntaram ao nosso Discord da conferência e ao evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord durante os dois eventos.
 
-Todas as palestras estão [disponíveis para streaming online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
+Todas as palestras estão [disponíveis para transmissão online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
 Aqui está um resumo do que foi compartilhado no palco:
 
-## React 18 e recursos concorrentes {/*react-18-and-concurrent-features*/}
+## React 18 e funcionalidades concorrentes {/*react-18-and-concurrent-features*/}
 
-Na apresentação principal, compartilhamos nossa visão para o futuro do React começando com o React 18.
+Na palestra principal, compartilhamos nossa visão para o futuro do React começando com o React 18.
 
-O React 18 adiciona o tão esperado renderizador concorrente e atualizações ao Suspense sem grandes mudanças de quebra. Os aplicativos podem atualizar para o React 18 e começar a adotar gradualmente os recursos concorrentes com o mesmo esforço que qualquer outro lançamento importante.
+O React 18 adiciona o tão aguardado renderizador concorrente e atualizações para o Suspense sem mudanças drásticas que quebrariam a compatibilidade. Aplicativos podem atualizar para o React 18 e começar a adotar gradualmente funcionalidades concorrentes com um esforço equivalente a qualquer outro lançamento importante.
 
-**Isso significa que não há modo concorrente, apenas recursos concorrentes.**
+**Isso significa que não há modo concorrente, apenas funcionalidades concorrentes.**
 
-Na apresentação principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo multiplataforma para o React Native.
+Na palestra principal, também compartilhamos nossa visão para o Suspense, Componentes do Servidor, novos grupos de trabalho do React e nossa visão de longo prazo multiplataforma para o React Native.
 
-Assista à apresentação completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
+Assista à palestra completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 para Desenvolvedores de Aplicações {/*react-18-for-application-developers*/}
+## React 18 para Desenvolvedores de Aplicação {/*react-18-for-application-developers*/}
 
-Na apresentação principal, também anunciamos que o React 18 RC está disponível para testes agora. Dependendo do feedback adicional, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
+Na palestra principal, também anunciamos que o React 18 RC está disponível para teste agora. Dependendo de mais feedback, esta é a versão exata do React que publicaremos como estável no início do próximo ano.
 
-Para testar o React 18 RC, atualize suas dependências:
+Para experimentar o React 18 RC, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
 ```
 
-e mude para a nova API `createRoot`:
+e troque para a nova API `createRoot`:
 
 ```js
 // antes
@@ -60,15 +60,15 @@ const root = ReactDOM.createRoot(container);
 root.render(<App/>);
 ```
 
-Para uma demonstração de atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
+Para uma demonstração da atualização para o React 18, veja a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
-## Rendering em Stream no Servidor com Suspense {/*streaming-server-rendering-with-suspense*/}
+## Renderização em Streaming no Servidor com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-O React 18 também inclui melhorias no desempenho de rendering no servidor usando Suspense.
+O React 18 também inclui melhorias no desempenho da renderização do lado do servidor usando Suspense.
 
-Rendering em stream no servidor permite gerar HTML a partir de componentes React no servidor e enviar esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente uma da outra sem bloquear o resto do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
+A renderização em streaming no servidor permite gerar HTML a partir de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades independentes menores que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
 
 Para uma análise mais profunda, veja a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
@@ -76,51 +76,51 @@ Para uma análise mais profunda, veja a palestra de [Shaundai Person](https://tw
 
 ## O primeiro grupo de trabalho do React {/*the-first-react-working-group*/}
 
-Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de bibliotecas e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
+Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de bibliotecas e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs, como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
 
 Para uma visão geral desse trabalho, veja a palestra de [Aakansha' Doshi](https://twitter.com/aakansha1216):
 
 <YouTubeIframe src="https://www.youtube.com/embed/qn7gRClrC9U" />
 
-## Ferramentas de Desenvolvimento do React {/*react-developer-tooling*/}
+## Ferramentas para Desenvolvedor React {/*react-developer-tooling*/}
 
-Para apoiar os novos recursos neste lançamento, também anunciamos a recém-formada equipe de React DevTools e um novo Profiler de Timeline para ajudar os desenvolvedores a depurar seus aplicativos React.
+Para apoiar as novas funcionalidades neste lançamento, também anunciamos a recém-formada equipe do React DevTools e um novo Profiler de Linha do Tempo para ajudar desenvolvedores a depurar suas aplicações React.
 
-Para mais informações e uma demonstração dos novos recursos do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
+Para mais informações e uma demonstração das novas funcionalidades do DevTools, veja a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
 <YouTubeIframe src="https://www.youtube.com/embed/oxDfrke8rZg" />
 
 ## React sem memo {/*react-without-memo*/}
 
-Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa nos React Labs sobre um compilador auto-memorável. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
+Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização da nossa pesquisa do React Labs em um compilador de auto-memoização. Confira esta palestra para mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
-## Palestra sobre a documentação do React {/*react-docs-keynote*/}
+## Palestra principal sobre a documentação do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprendizado e design com React com uma apresentação sobre nosso investimento na nova documentação do React ([agora enviado como react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) iniciou uma seção de palestras sobre aprender e projetar com React com uma palestra sobre nosso investimento na nova documentação do React ([agora lançada como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
 ## E mais... {/*and-more*/}
 
-**Também ouvimos palestras sobre aprendizado e design com React:**
+**Também ouvimos palestras sobre aprender e projetar com React:**
 
 * Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
 * Sarah Rainsberger: [Aprendendo no Navegador](https://youtu.be/5X-WEQflCL0).
-* Linton Ye: [O ROI do Design com React](https://youtu.be/7cPWmID5XAk).
+* Linton Ye: [O ROI de Projetar com React](https://youtu.be/7cPWmID5XAk).
 * Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
 
 **Palestras das equipes de Relay, React Native e PyTorch:**
 
-* Robert Balicki: [Reintroduzindo o Relay](https://youtu.be/lhVGdErZuN4).
+* Robert Balicki: [Reapresentando o Relay](https://youtu.be/lhVGdErZuN4).
 * Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [Aprendizado de Máquina em Dispositivo para React Native](https://youtu.be/NLj73vrc2I8)
+* Roman Rädle: [Aprendizado de Máquina no Dispositivo para React Native](https://youtu.be/NLj73vrc2I8)
 
 **E palestras da comunidade sobre acessibilidade, ferramentas e Componentes do Servidor:**
 
-* Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externas](https://youtu.be/oPfSC5bQPR8).
-* Diego Haz: [Construindo Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
+* Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externo](https://youtu.be/oPfSC5bQPR8).
+* Diego Haz: [Construindo Componentes Acessíveis em React 18](https://youtu.be/dcm8fjBfro8).
 * Tafu Nakazaki: [Componentes de Formulário Acessíveis em Japonês com React](https://youtu.be/S4a0QlsH0pU).
 * Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
 * Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
@@ -129,32 +129,32 @@ Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) co
 
 Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas a agradecer.
 
-Primeiro, obrigado a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, agradecemos a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Obrigado a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
+Agradecemos a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://twitter.com/dan_abramov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), e [Tim Yung](https://twitter.com/yungsters).
 
-Obrigado a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
+Agradecemos a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e servir como nossa administradora do Discord.
 
-Obrigado a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
+Agradecemos a [Seth Webster](https://twitter.com/sethwebster) pelo feedback sobre a direção geral e por garantir que estivéssemos focados em diversidade e inclusão.
 
-Obrigado a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação, e a [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores, e ajudar a moderar ambos os eventos.
+Agradecemos a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores e ajudar a moderar ambos os eventos.
 
-Obrigado aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Agradecemos aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Obrigado a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), e Vihang Patel do [React India](https://www.reactindia.io/), e a [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
+Agradecemos a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel da [React India](https://www.reactindia.io/), e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), e [YanLun Li](https://twitter.com/anneincoding) da [React China](https://twitter.com/ReactChina) por ajudarem a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
 
-Obrigado à Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), com base no qual o site da conferência foi construído, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar sua experiência em conduzir o Next.js Conf.
+Agradecemos à Vercel por publicar seu [Kit de Início para Eventos Virtuais](https://vercel.com/virtual-event-starter-kit), que foi a base do site da conferência, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilharem sua experiência organizando o Next.js Conf.
 
-Obrigado a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência em organizar conferências, aprendizados adquiridos ao conduzir o [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém para conduzir conferências.
+Agradecemos a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência organizando conferências, aprendizados sobre a realização da [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que contém para conduzir conferências.
 
-Obrigado a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilharem sua experiência em conduzir a Women of React Conf.
+Agradecemos a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilhar suas experiências organizando a Women of React Conf.
 
-Obrigado a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic), e [Shaundai Person](https://twitter.com/shaundai) por suas conselhos e ideias durante o planejamento.
+Agradecemos a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias ao longo do planejamento.
 
-Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda na concepção e construção do site da conferência e dos ingressos.
+Agradecemos a [Dan Lebowitz](https://twitter.com/lebo) por ajudar a projetar e construir o site e ingressos da conferência.
 
-Obrigado a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros na equipe de Produções de Vídeo do Facebook por gravar os vídeos da Palestra Principal e das palestras dos empregados da Meta.
+Agradecemos a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravarem os vídeos para a Palestra Principal e as palestras dos funcionários da Meta.
 
-Obrigado ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras, e moderar o Discord em múltiplos idiomas.
+Agradecemos ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos da transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
 
-Finalmente, obrigado a todos os nossos participantes por fazer deste um grande React Conf!
+Finalmente, agradecemos a todos os nossos participantes por tornar esta uma grande React Conf!


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.