### PR TITLE
Translate `react-18-upgrade-guide.md` to pt-br

### DIFF
--- a/src/content/blog/2022/03/08/react-18-upgrade-guide.md
+++ b/src/content/blog/2022/03/08/react-18-upgrade-guide.md
@@ -2,7 +2,7 @@
 title: "Como Atualizar para o React 18"
 author: Rick Hanlon
 date: 2022/03/08
-description: Como compartilhamos no post de lançamento, o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicativos existentes. Neste post, vamos guiá-lo através das etapas para atualizar para o React 18.
+description: Como compartilhamos na postagem de lançamento, o React 18 introduz recursos impulsionados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicações existentes. Neste post, iremos guiá-lo pelos passos para atualizar para o React 18.
 ---
 
 8 de março de 2022 por [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,7 +11,7 @@ description: Como compartilhamos no post de lançamento, o React 18 introduz rec
 
 <Intro>
 
-Como compartilhamos no [post de lançamento](/blog/2022/03/29/react-v18), o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicativos existentes. Neste post, vamos guiá-lo através das etapas para atualizar para o React 18.
+Como compartilhamos na [postagem de lançamento](/blog/2022/03/29/react-v18), o React 18 introduz recursos impulsionados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicações existentes. Neste post, iremos guiá-lo pelos passos para atualizar para o React 18.
 
 Por favor, [relate quaisquer problemas](https://github.com/facebook/react/issues/new/choose) que você encontrar ao atualizar para o React 18.
 
@@ -19,7 +19,7 @@ Por favor, [relate quaisquer problemas](https://github.com/facebook/react/issues
 
 <Note>
 
-Para usuários do React Native, o React 18 será incluído em uma versão futura do React Native. Isso se deve ao fato de que o React 18 depende da Nova Arquitetura do React Native para se beneficiar das novas capacidades apresentadas neste post. Para mais informações, veja a [palestra da React Conf aqui](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s).
+Para usuários do React Native, o React 18 será incluído em uma versão futura do React Native. Isso ocorre porque o React 18 depende da Nova Arquitetura do React Native para se beneficiar das novas capacidades apresentadas neste blog. Para mais informações, veja a [palestra principal da React Conf aqui](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s).
 
 </Note>
 
@@ -39,17 +39,17 @@ Ou se você estiver usando yarn:
 yarn add react react-dom
 ```
 
-## Atualizações para as APIs de Renderização no Cliente {/*updates-to-client-rendering-apis*/}
+## Atualizações nas APis de Renderização do Cliente {/*updates-to-client-rendering-apis*/}
 
-Quando você instalar o React 18 pela primeira vez, verá um aviso no console:
+Quando você instala o React 18 pela primeira vez, verá um aviso no console:
 
 <ConsoleBlock level="error">
 
-ReactDOM.render não é mais suportado no React 18. Use createRoot em vez disso. Até você mudar para a nova API, seu aplicativo se comportará como se estivesse executando o React 17. Saiba mais: https://reactjs.org/link/switch-to-createroot
+ReactDOM.render não é mais suportado no React 18. Use createRoot em vez disso. Até você mudar para a nova API, seu aplicativo irá se comportar como se estivesse executando o React 17. Saiba mais: https://reactjs.org/link/switch-to-createroot
 
 </ConsoleBlock>
 
-O React 18 introduz uma nova API de raiz que fornece melhor ergonomia para gerenciar raízes. A nova API de raiz também ativa o novo renderizador concorrente, que permite que você opte por recursos concorrentes.
+O React 18 introduz uma nova API de raiz que oferece melhor ergonomia para gerenciar raízes. A nova API de raiz também habilita o novo renderizador concorrente, que permite que você opte por recursos concorrentes.
 
 ```js
 // Antes
@@ -64,7 +64,7 @@ const root = createRoot(container); // createRoot(container!) se você usar Type
 root.render(<App tab="home" />);
 ```
 
-Nós também mudamos `unmountComponentAtNode` para `root.unmount`:
+Também mudamos `unmountComponentAtNode` para `root.unmount`:
 
 ```js
 // Antes
@@ -74,7 +74,7 @@ unmountComponentAtNode(container);
 root.unmount();
 ```
 
-Nós também removemos o callback de renderização, pois ele geralmente não tem o resultado esperado ao usar Suspense:
+Também removemos o callback do render, uma vez que geralmente não tem o resultado esperado ao usar Suspense:
 
 ```js
 // Antes
@@ -99,11 +99,11 @@ root.render(<AppWithCallbackAfterRender />);
 
 <Note>
 
-Não há uma substituição um-para-um para a antiga API de callback de renderização — depende do seu caso de uso. Veja o post do grupo de trabalho sobre [Substituindo render por createRoot](https://github.com/reactwg/react-18/discussions/5) para mais informações.
+Não há uma substituição um-para-um para a antiga API de callback de renderização — isso depende do seu caso de uso. Veja a postagem do grupo de trabalho sobre [Substituindo render com createRoot](https://github.com/reactwg/react-18/discussions/5) para mais informações.
 
 </Note>
 
-Finalmente, se seu aplicativo usa renderização no lado do servidor com hidratação, atualize `hydrate` para `hydrateRoot`:
+Por fim, se seu aplicativo usa renderização no lado do servidor com hidratação, atualize `hydrate` para `hydrateRoot`:
 
 ```js
 // Antes
@@ -115,43 +115,43 @@ hydrate(<App tab="home" />, container);
 import { hydrateRoot } from 'react-dom/client';
 const container = document.getElementById('app');
 const root = hydrateRoot(container, <App tab="home" />);
-// Ao contrário do createRoot, você não precisa de uma chamada separada root.render() aqui.
+// Ao contrário do createRoot, você não precisa de uma chamada separada de root.render() aqui.
 ```
 
 Para mais informações, veja a [discussão do grupo de trabalho aqui](https://github.com/reactwg/react-18/discussions/5).
 
 <Note>
 
-**Se seu aplicativo não funcionar após a atualização, verifique se ele não está encapsulado em `<StrictMode>`.** [O Modo Estrito ficou mais rigoroso no React 18](#updates-to-strict-mode), e nem todos os seus componentes podem ser resilientes às novas verificações que ele adiciona no modo de desenvolvimento. Se remover o Modo Estrito corrigir seu aplicativo, você pode removê-lo durante a atualização e depois adicioná-lo de volta (seja no topo ou para uma parte da árvore) depois de corrigir os problemas que ele está apontando.
+**Se seu aplicativo não funcionar após a atualização, verifique se ele está encapsulado em `<StrictMode>`.** [O Modo Estrito ficou mais rigoroso no React 18](#updates-to-strict-mode), e nem todos os seus componentes podem ser resilientes às novas verificações que ele adiciona no modo de desenvolvimento. Se remover o Modo Estrito corrigir seu aplicativo, você pode removê-lo durante a atualização e, em seguida, adicioná-lo de volta (ou na parte superior ou para uma parte da árvore) após corrigir os problemas que ele aponta.
 
 </Note>
 
-## Atualizações para as APIs de Renderização no Servidor {/*updates-to-server-rendering-apis*/}
+## Atualizações nas APis de Renderização do Servidor {/*updates-to-server-rendering-apis*/}
 
-Nesta versão, estamos reformulando nossas APIs `react-dom/server` para suportar totalmente o Suspense no servidor e Streaming SSR. Como parte dessas mudanças, estamos descontinuando a antiga API de streaming do Node, que não suporta streaming de Suspense incremental no servidor.
+Nesta versão, estamos reformulando nossas APis `react-dom/server` para suportar totalmente Suspense no servidor e Streaming SSR. Como parte dessas mudanças, estamos descontinuando a antiga API de streaming Node, que não suporta streaming incrementais de Suspense no servidor.
 
-Usar essa API agora avisará:
+Usar essa API agora irá avisar:
 
 * `renderToNodeStream`: **Descontinuado ⛔️️**
 
 Em vez disso, para streaming em ambientes Node, use:
 * `renderToPipeableStream`: **Novo ✨**
 
-Estamos também introduzindo uma nova API para suportar streaming SSR com Suspense para ambientes modernos de runtime edge, como Deno e Cloudflare workers:
+Estamos também introduzindo uma nova API para suportar streaming SSR com Suspense para modernos ambientes de runtime edge, como Deno e Cloudflare workers:
 * `renderToReadableStream`: **Novo ✨**
 
-As seguintes APIs continuarão funcionando, mas com suporte limitado para Suspense:
+As seguintes APis continuarão funcionando, mas com suporte limitado para Suspense:
 * `renderToString`: **Limitado** ⚠️
 * `renderToStaticMarkup`: **Limitado** ⚠️
 
-Finalmente, esta API continuará funcionando para renderizar e-mails:
+Por fim, essa API continuará a funcionar para renderizar e-mails:
 * `renderToStaticNodeStream`
 
-Para mais informações sobre as mudanças nas APIs de renderização no servidor, veja o post do grupo de trabalho sobre [Atualizando para o React 18 no servidor](https://github.com/reactwg/react-18/discussions/22), uma [análise profunda da nova Arquitetura SSR do Suspense](https://github.com/reactwg/react-18/discussions/37), e a palestra de [Shaundai Person](https://twitter.com/shaundai) sobre [Streaming Server Rendering com Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) na React Conf 2021.
+Para mais informações sobre as mudanças nas APIs de renderização do servidor, veja a postagem do grupo de trabalho sobre [Atualizando para o React 18 no servidor](https://github.com/reactwg/react-18/discussions/22), uma [análise aprofundada da nova Arquitetura de Suspense SSR](https://github.com/reactwg/react-18/discussions/37), e a palestra de [Shaundai Person](https://twitter.com/shaundai) sobre [Streaming Server Rendering com Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) na React Conf 2021.
 
-## Atualizações para definições do TypeScript {/*updates-to-typescript-definitions*/}
+## Atualizações nas definições do TypeScript {/*updates-to-typescript-definitions*/}
 
-Se seu projeto usa TypeScript, você precisará atualizar suas dependências `@types/react` e `@types/react-dom` para as versões mais recentes. Os novos tipos são mais seguros e capturam problemas que costumavam ser ignorados pelo verificador de tipos. A mudança mais notável é que a prop `children` agora precisa ser listada explicitamente ao definir props, por exemplo:
+Se seu projeto usa TypeScript, você precisará atualizar suas dependências `@types/react` e `@types/react-dom` para as versões mais recentes. Os novos tipos são mais seguros e capturam problemas que antes eram ignorados pelo verificador de tipos. A mudança mais notável é que a prop `children` agora precisa ser listada explicitamente ao definir props, por exemplo:
 
 ```typescript{3}
 interface MyButtonProps {
@@ -160,13 +160,13 @@ interface MyButtonProps {
 }
 ```
 
-Veja o [pull request de tipagens do React 18](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) para uma lista completa de mudanças apenas de tipos. Ele vincula a correções de exemplo nas definições da biblioteca, assim você pode ver como ajustar seu código. Você pode usar o [script de migração automatizado](https://github.com/eps1lon/types-react-codemod) para ajudar a portar o código da sua aplicação para as novas e mais seguras tipagens mais rapidamente.
+Veja a [pull request de tipagem do React 18](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) para uma lista completa das mudanças apenas de tipo. Ela se conecta a correções de exemplo em tipos de biblioteca para que você possa ver como ajustar seu código. Você pode usar o [script de migração automatizado](https://github.com/eps1lon/types-react-codemod) para ajudar a portar seu código de aplicação para as novas e mais seguras tipagens mais rapidamente.
 
-Se você encontrar um erro nas tipagens, por favor, [registre um problema](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package) no repositório DefinitelyTyped.
+Se você encontrar um bug nas tipagens, por favor, [abra um problema](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package) no repositório do DefinitelyTyped.
 
 ## Agrupamento Automático {/*automatic-batching*/}
 
-O React 18 adiciona melhorias de desempenho prontamente disponíveis ao fazer mais agrupamento por padrão. O agrupamento é quando o React agrupa múltiplas atualizações de estado em um único re-render para melhor desempenho. Antes do React 18, nós apenas agrupávamos atualizações dentro de manipuladores de eventos do React. Atualizações dentro de promessas, setTimeout, manipuladores de eventos nativos, ou qualquer outro evento não eram agrupados no React por padrão:
+O React 18 adiciona melhorias de desempenho prontas para uso agrupando mais operações por padrão. O agrupamento ocorre quando o React agrupa várias atualizações de estado em uma única re-renderização para um melhor desempenho. Antes do React 18, apenas atualizações dentro de manipuladores de eventos do React eram agrupadas. Atualizações dentro de promessas, setTimeout, manipuladores de eventos nativos ou qualquer outro evento não eram agrupadas no React por padrão:
 
 ```js
 // Antes do React 18, apenas eventos do React eram agrupados
@@ -174,17 +174,18 @@ O React 18 adiciona melhorias de desempenho prontamente disponíveis ao fazer ma
 function handleClick() {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React apenas re-renderizará uma vez no final (isso é agrupamento!)
+  // O React irá re-renderizar apenas uma vez ao final (isso é agrupamento!)
 }
 
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React renderizará duas vezes, uma para cada atualização de estado (sem agrupamento)
+  // O React irá renderizar duas vezes, uma para cada atualização de estado (sem agrupamento)
 }, 1000);
 ```
 
-A partir do React 18 com `createRoot`, todas as atualizações serão automaticamente agrupadas, não importa de onde elas se originem. Isso significa que atualizações dentro de timeouts, promessas, manipuladores de eventos nativos ou qualquer outro evento serão agrupadas da mesma forma que atualizações dentro de eventos do React:
+
+A partir do React 18 com `createRoot`, todas as atualizações serão automaticamente agrupadas, não importa de onde se originem. Isso significa que atualizações dentro de timeouts, promessas, manipuladores de eventos nativos ou qualquer outro evento serão agrupadas da mesma forma que atualizações dentro de eventos do React:
 
 ```js
 // Depois do React 18, atualizações dentro de timeouts, promessas,
@@ -193,17 +194,17 @@ A partir do React 18 com `createRoot`, todas as atualizações serão automatica
 function handleClick() {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React apenas re-renderizará uma vez no final (isso é agrupamento!)
+  // O React irá re-renderizar apenas uma vez ao final (isso é agrupamento!)
 }
 
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React apenas re-renderizará uma vez no final (isso é agrupamento!)
+  // O React irá re-renderizar apenas uma vez ao final (isso é agrupamento!)
 }, 1000);
 ```
 
-Esta é uma mudança de ruptura, mas esperamos que isso resulte em menos trabalho de renderização e, portanto, melhor desempenho em suas aplicações. Para optar por não fazer agrupamento automático, você pode usar `flushSync`:
+Essa é uma mudança quebradora, mas esperamos que isso resulte em menos trabalho durante a renderização, e portanto melhor desempenho em suas aplicações. Para optar por não usar o agrupamento automático, você pode usar `flushSync`:
 
 ```js
 import { flushSync } from 'react-dom';
@@ -212,32 +213,32 @@ function handleClick() {
   flushSync(() => {
     setCounter(c => c + 1);
   });
-  // O React já atualizou o DOM até agora
+  // O React atualizou o DOM até agora
   flushSync(() => {
     setFlag(f => !f);
   });
-  // O React já atualizou o DOM até agora
+  // O React atualizou o DOM até agora
 }
 ```
 
-Para mais informações, veja a [análise profunda sobre agrupamento automático](https://github.com/reactwg/react-18/discussions/21).
+Para mais informações, veja a [análise aprofundada sobre agrupamento automático](https://github.com/reactwg/react-18/discussions/21).
 
-## Novas APIs para Bibliotecas {/*new-apis-for-libraries*/}
+## Novas APis para Bibliotecas {/*new-apis-for-libraries*/}
 
-No Grupo de Trabalho do React 18, trabalhamos com mantenedores de bibliotecas para criar novas APIs necessárias para suportar renderização concorrente para casos de uso específicos em áreas como estilos e armazéns externos. Para suportar o React 18, algumas bibliotecas podem precisar mudar para uma das seguintes APIs:
+No Grupo de Trabalho do React 18, trabalhamos com mantenedores de bibliotecas para criar novas APIs necessárias para suportar a renderização concorrente para casos específicos de uso em áreas como estilos, e lojas externas. Para suportar o React 18, algumas bibliotecas podem precisar mudar para uma das seguintes APIs:
 
-* `useSyncExternalStore` é um novo Hook que permite que armazéns externos suportem leituras concorrentes forçando atualizações do armazém a serem síncronas. Esta nova API é recomendada para qualquer biblioteca que integre com estado externo ao React. Para mais informações, veja o [post de visão geral do useSyncExternalStore](https://github.com/reactwg/react-18/discussions/70) e [detalhes da API useSyncExternalStore](https://github.com/reactwg/react-18/discussions/86).
-* `useInsertionEffect` é um novo Hook que permite que bibliotecas CSS-in-JS consigam resolver problemas de desempenho de injeção de estilos na renderização. A menos que você já tenha construído uma biblioteca CSS-in-JS, não esperamos que você use isso. Este Hook será executado depois que o DOM for modificado, mas antes que os efeitos de layout leiam o novo layout. Isso resolve um problema que já existe no React 17 e anterior, mas é ainda mais importante no React 18, pois o React cede ao navegador durante a renderização concorrente, dando a ele a chance de recalcular o layout. Para mais informações, veja o [Guia de Atualização da Biblioteca para `<style>`](https://github.com/reactwg/react-18/discussions/110).
+* `useSyncExternalStore` é um novo Hook que permite que lojas externas suportem leituras concorrentes forçando atualizações na loja para serem síncronas. Esta nova API é recomendada para qualquer biblioteca que integre com estado externo ao React. Para mais informações, veja a [postagem de visão geral do useSyncExternalStore](https://github.com/reactwg/react-18/discussions/70) e [detalhes da API do useSyncExternalStore](https://github.com/reactwg/react-18/discussions/86).
+* `useInsertionEffect` é um novo Hook que permite que bibliotecas CSS-in-JS abordem problemas de desempenho de injeção de estilos na renderização. A menos que você já tenha construido uma biblioteca CSS-in-JS, não esperamos que você use isso. Este Hook será executado após o DOM ser mutado, mas antes dos efeitos de layout lerem o novo layout. Isso resolve um problema que já existe no React 17 e anteriores, mas é ainda mais importante no React 18 porque o React cede ao navegador durante a renderização concorrente, dando-lhe a chance de recalcular o layout. Para mais informações, veja o [Guia de Atualização da Biblioteca para `<style>`](https://github.com/reactwg/react-18/discussions/110).
 
-O React 18 também introduz novas APIs para renderização concorrente, como `startTransition`, `useDeferredValue` e `useId`, as quais compartilhamos mais informações no [post de lançamento](/blog/2022/03/29/react-v18).
+O React 18 também introduz novas APIs para renderização concorrente, como `startTransition`, `useDeferredValue` e `useId`, que compartilhamos mais sobre na [postagem de lançamento](/blog/2022/03/29/react-v18).
 
-## Atualizações para o Modo Estrito {/*updates-to-strict-mode*/}
+## Atualizações no Modo Estrito {/*updates-to-strict-mode*/}
 
-No futuro, gostaríamos de adicionar um recurso que permita ao React adicionar e remover seções da UI enquanto preserva o estado. Por exemplo, quando um usuário troca de tela e volta, o React deve ser capaz de mostrar imediatamente a tela anterior. Para fazer isso, o React desmontaria e remontaria árvores usando o mesmo estado de componente que antes.
+No futuro, gostaríamos de adicionar um recurso que permita ao React adicionar e remover seções da UI enquanto preserva o estado. Por exemplo, quando um usuário navega para longe de uma tela e volta, o React deve ser capaz de mostrar imediatamente a tela anterior. Para fazer isso, o React irá desmontar e remontar árvores usando o mesmo estado de componente de antes.
 
-Esse recurso dará ao React melhor desempenho prontamente, mas requer que os componentes sejam resilientes a efeitos sendo montados e destruídos múltiplas vezes. A maioria dos efeitos funcionará sem alterações, mas alguns efeitos assumem que são montados ou destruídos apenas uma vez.
+Esse recurso dará ao React melhor desempenho pronto para uso, mas requer que os componentes sejam resilientes a efeitos sendo montados e destruídos várias vezes. A maioria dos efeitos funcionará sem alterações, mas alguns efeitos assumem que são montados ou destruídos apenas uma vez.
 
-Para ajudar a evidenciar esses problemas, o React 18 introduz uma nova verificação apenas para desenvolvimento no Modo Estrito. Esta nova verificação desmontará e remontará automaticamente cada componente, sempre que um componente for montado pela primeira vez, restaurando o estado anterior na segunda montagem.
+Para ajudar a destacar esses problemas, o React 18 introduz uma nova verificação apenas para desenvolvimento no Modo Estrito. Esta nova verificação irá automaticamente desmontar e remontar cada componente, sempre que um componente é montado pela primeira vez, restaurando o estado anterior na segunda montagem.
 
 Antes dessa mudança, o React montaria o componente e criaria os efeitos:
 
@@ -247,21 +248,21 @@ Antes dessa mudança, o React montaria o componente e criaria os efeitos:
     * Efeitos são criados.
 ```
 
-Com o Modo Estrito no React 18, o React simulará o desmonte e o remontagem do componente no modo de desenvolvimento:
+Com o Modo Estrito no React 18, o React simulará desmontar e remontar o componente em modo de desenvolvimento:
 
 ```
 * O React monta o componente.
     * Efeitos de layout são criados.
     * Efeitos são criados.
-* O React simula o desmonte do componente.
+* O React simula desmontar o componente.
     * Efeitos de layout são destruídos.
     * Efeitos são destruídos.
-* O React simula a montagem do componente com o estado anterior.
+* O React simula montar o componente com o estado anterior.
     * O código de configuração do efeito de layout é executado
     * O código de configuração do efeito é executado
 ```
 
-Para mais informações, veja os posts do Grupo de Trabalho sobre [Adicionando Estado Reutilizável ao StrictMode](https://github.com/reactwg/react-18/discussions/19) e [Como suportar Estado Reutilizável em Efeitos](https://github.com/reactwg/react-18/discussions/18).
+Para mais informações, veja as postagens do Grupo de Trabalho sobre [Adicionando Estado Reutilizável ao StrictMode](https://github.com/reactwg/react-18/discussions/19) e [Como suportar Estado Reutilizável em Efeitos](https://github.com/reactwg/react-18/discussions/18).
 
 ## Configurando Seu Ambiente de Teste {/*configuring-your-testing-environment*/}
 
@@ -280,51 +281,51 @@ Para corrigir isso, defina `globalThis.IS_REACT_ACT_ENVIRONMENT` como `true` ant
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 ```
 
-O objetivo da flag é informar ao React que está sendo executado em um ambiente semelhante a um teste unitário. O React registrará avisos úteis se você esquecer de envolver uma atualização com `act`.
+O propósito da flag é informar ao React que está sendo executado em um ambiente semelhante a um teste unitário. O React registrará avisos úteis se você esquecer de encapsular uma atualização com `act`.
 
 Você também pode definir a flag como `false` para informar ao React que `act` não é necessário. Isso pode ser útil para testes de ponta a ponta que simulam um ambiente de navegador completo.
 
-Eventualmente, esperamos que bibliotecas de teste configurem isso para você automaticamente. Por exemplo, a [próxima versão da React Testing Library tem suporte embutido para o React 18](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936) sem nenhuma configuração adicional.
+Eventualmente, esperamos que bibliotecas de teste configurem isso automaticamente para você. Por exemplo, a [próxima versão da React Testing Library tem suporte embutido para o React 18](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936) sem nenhuma configuração adicional.
 
 [Mais informações sobre a API de teste `act` e mudanças relacionadas](https://github.com/reactwg/react-18/discussions/102) estão disponíveis no grupo de trabalho.
 
-## Remoção do Suporte para o Internet Explorer {/*dropping-support-for-internet-explorer*/}
+## Remoção do Suporte ao Internet Explorer {/*dropping-support-for-internet-explorer*/}
 
-Nesta versão, o React está removendo o suporte para o Internet Explorer, que [sai de suporte em 15 de junho de 2022](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge). Estamos fazendo essa mudança agora porque os novos recursos introduzidos no React 18 são construídos usando recursos modernos de navegador, como microtarefas, que não podem ser adequadamente polidos no IE.
+Nesta versão, o React está removendo o suporte ao Internet Explorer, que está [saindo do suporte em 15 de junho de 2022](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge). Estamos fazendo essa mudança agora porque novos recursos introduzidos no React 18 são construídos usando recursos modernos de navegador, como microtarefas, que não podem ser adequadamente polidas no IE.
 
-Se você precisar dar suporte ao Internet Explorer, recomendamos que você permaneça com o React 17.
+Se você precisar suportar o Internet Explorer, recomendamos que permaneça com o React 17.
 
 ## Descontinuações {/*deprecations*/}
 
-* `react-dom`: `ReactDOM.render` foi descontinuado. Usá-lo irá avisar e executar seu aplicativo em modo React 17.
-* `react-dom`: `ReactDOM.hydrate` foi descontinuado. Usá-lo irá avisar e executar seu aplicativo em modo React 17.
+* `react-dom`: `ReactDOM.render` foi descontinuado. Usá-lo irá avisar e executar seu aplicativo no modo React 17.
+* `react-dom`: `ReactDOM.hydrate` foi descontinuado. Usá-lo irá avisar e executar seu aplicativo no modo React 17.
 * `react-dom`: `ReactDOM.unmountComponentAtNode` foi descontinuado.
 * `react-dom`: `ReactDOM.renderSubtreeIntoContainer` foi descontinuado.
 * `react-dom/server`: `ReactDOMServer.renderToNodeStream` foi descontinuado.
 
-## Outras Mudanças de Ruptura {/*other-breaking-changes*/}
+## Outras Mudanças Quebradoras {/*other-breaking-changes*/}
 
-* **Tempos consistentes do useEffect**: O React agora sempre esvazia de forma síncrona funções de efeito se a atualização foi acionada durante um evento de entrada do usuário discreto, como um clique ou um evento de keydown. Anteriormente, o comportamento nem sempre era previsível ou consistente.
-* **Erros de hidratação mais rigorosos**: Desajustes de hidratação devido a conteúdo textual ausente ou extra agora são tratados como erros, em vez de avisos. O React não tentará mais "corrigir" nós individuais inserindo ou deletando um nó no cliente em uma tentativa de combinar a marcação do servidor, e reverterá para renderização no cliente até o limite mais próximo de `<Suspense>` na árvore. Isso garante que a árvore hidratada seja consistente e evita possíveis buracos de privacidade e segurança que podem ser causados por desajustes de hidratação.
-* **Árvores de Suspense são sempre consistentes:** Se um componente suspende antes de ser totalmente adicionado à árvore, o React não o adicionará à árvore em um estado incompleto ou acionará seus efeitos. Em vez disso, o React descartará completamente a nova árvore, aguardará a operação assíncrona terminar e então tentará renderizar novamente do zero. O React renderizará a tentativa de nova renderização de forma concorrente, e sem bloquear o navegador.
-* **Efeitos de Layout com Suspense**: Quando uma árvore se re-suspende e reverte para um fallback, o React agora irá limpar efeitos de layout e, em seguida, re-criá-los quando o conteúdo dentro do limite for exibido novamente. Isso resolve um problema que impediu que bibliotecas de componentes medisse corretamente o layout ao serem usadas com Suspense.
-* **Novos Requisitos de Ambiente JS**: O React agora depende de recursos modernos dos navegadores, incluindo `Promise`, `Symbol` e `Object.assign`. Se você dá suporte a navegadores e dispositivos mais antigos, como o Internet Explorer, que não fornecem recursos modernos de navegador de forma nativa ou têm implementações não conformes, considere incluir um polyfill global na sua aplicação compilada.
+* **Consistência no timing do useEffect**: O React agora sempre esvazia sincronicamente funções de efeito se a atualização foi acionada durante um evento de entrada discreta do usuário, como um clique ou um evento de keydown. Anteriormente, o comportamento nem sempre era previsível ou consistente.
+* **Erros de hidratação mais rigorosos**: Incompatibilidades de hidratação devido a conteúdo de texto faltante ou extra agora são tratadas como erros em vez de avisos. O React não tentará mais "corrigir" nós individuais inserindo ou excluindo um nó no cliente em uma tentativa de corresponder à marcação do servidor, e reverterá para a renderização do cliente até o limite `<Suspense>` mais próximo na árvore. Isso garante que a árvore hidratada seja consistente e evita possíveis falhas de privacidade e segurança que podem ser causadas por incompatibilidades de hidratação.
+* **Árvores de Suspense são sempre consistentes:** Se um componente suspender antes de ser totalmente adicionado à árvore, o React não o adicionará à árvore em um estado incompleto ou acionará seus efeitos. Em vez disso, o React descartará completamente a nova árvore, aguardará a operação assíncrona terminar e tentará renderizar novamente do zero. O React renderizará a tentativa de repetição de forma concorrente e sem bloquear o navegador.
+* **Efeitos de Layout com Suspense**: Quando uma árvore re-suspende e reverte para um fallback, o React agora limpará efeitos de layout e, em seguida, os recriará quando o conteúdo dentro do limite for exibido novamente. Isso corrige um problema que impedia bibliotecas de componentes de medir corretamente o layout quando usadas com Suspense.
+* **Novos Requisitos de Ambiente JS**: O React agora depende de funcionalidades modernas de navegador, incluindo `Promise`, `Symbol` e `Object.assign`. Se você suportar navegadores e dispositivos mais antigos, como o Internet Explorer, que não fornecem recursos modernos de navegador nativamente ou têm implementações não conformes, considere incluir um polyfill global em sua aplicação empacotada.
 
 ## Outras Mudanças Notáveis {/*other-notable-changes*/}
 
 ### React {/*react*/}
 
-* **Componentes agora podem renderizar `undefined`:** O React não avisa mais se você retornar `undefined` de um componente. Isso torna os valores de retorno de componente permitidos consistentes com os valores que são permitidos no meio de uma árvore de componentes. Sugerimos usar um linter para evitar erros como esquecer uma declaração `return` antes do JSX.
-* **Em testes, avisos de `act` agora são opcionais:** Se você estiver executando testes de ponta a ponta, os avisos de `act` são desnecessários. Introduzimos um mecanismo [opcional](https://github.com/reactwg/react-18/discussions/102) para que você possa habilitá-los apenas para testes unitários, onde são úteis e benéficos.
-* **Sem aviso sobre `setState` em componentes desmontados:** Anteriormente, o React avisava sobre vazamentos de memória quando você chamava `setState` em um componente desmontado. Este aviso foi adicionado para assinaturas, mas as pessoas principalmente enfrentavam isso em cenários onde definir o estado é aceitável e as soluções alternativas tornam o código pior. Nós [removemos](https://github.com/facebook/react/pull/22114) este aviso.
-* **Sem supressão de logs no console:** Quando você usa o Modo Estrito, o React renderiza cada componente duas vezes para ajudá-lo a encontrar efeitos colaterais inesperados. No React 17, suprimimos logs no console para uma das duas renderizações para tornar os logs mais fáceis de ler. Em resposta ao [feedback da comunidade](https://github.com/facebook/react/issues/21783) sobre isso ser confuso, removemos a supressão. Em vez disso, se você tiver as Ferramentas de Desenvolvimento do React instaladas, a segunda renderização dos logs será mostrada em cinza, e haverá uma opção (desabilitada por padrão) para suprimi-las completamente.
-* **Uso de memória melhorado:** O React agora limpa mais campos internos ao ser desmontado, tornando o impacto de vazamentos de memória não corrigidos que podem existir no código da sua aplicação menos severo.
+* **Componentes agora podem renderizar `undefined`:** O React não avisa mais se você retornar `undefined` de um componente. Isso torna os valores de retorno de componente permitidos consistentes com valores que são permitidos no meio de uma árvore de componentes. Sugerimos usar um linter para evitar erros como esquecer uma instrução `return` antes do JSX.
+* **Nos testes, avisos de `act` agora são opt-in:** Se você estiver executando testes de ponta a ponta, os avisos de `act` são desnecessários. Introduzimos um mecanismo [opt-in](https://github.com/reactwg/react-18/discussions/102) para que você possa habilitá-los apenas para testes unitários onde eles são úteis e benéficos.
+* **Sem aviso sobre `setState` em componentes desmontados:** Anteriormente, o React avisava sobre vazamentos de memória quando você chamava `setState` em um componente desmontado. Este aviso foi adicionado para assinaturas, mas as pessoas principalmente se deparam com isso em cenários onde definir estado está tudo bem, e soluções alternativas tornam o código pior. Removemos [isso](https://github.com/facebook/react/pull/22114).
+* **Sem supressão de logs do console:** Quando você usa o Modo Estrito, o React renderiza cada componente duas vezes para ajudá-lo a encontrar efeitos colaterais inesperados. No React 17, suprimimos logs do console para uma das duas renderizações para tornar os logs mais fáceis de ler. Em resposta ao [feedback da comunidade](https://github.com/facebook/react/issues/21783) sobre isso ser confuso, removemos a supressão. Em vez disso, se você tiver o React DevTools instalado, os logs da segunda renderização serão exibidos em cinza, e haverá uma opção (desligada por padrão) para suprimir completamente esses logs.
+* **Uso de memória aprimorado:** O React agora limpa mais campos internos ao desmontar, tornando o impacto de vazamentos de memória não corrigidos que podem existir em seu código de aplicação menos severo.
 
 ### React DOM Server {/*react-dom-server*/}
 
-* **`renderToString`:** Não irá mais gerar erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para o limite mais próximo de `<Suspense>` e tentará renderizar novamente o mesmo conteúdo no cliente. Ainda é recomendável que você mude para uma API de streaming como `renderToPipeableStream` ou `renderToReadableStream`.
-* **`renderToStaticMarkup`:** Não irá mais gerar erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para o limite mais próximo de `<Suspense>`.
+* **`renderToString`:** Não apresentará mais erro ao suspender no servidor. Em vez disso, ele emitirá o HTML fallback para o limite `<Suspense>` mais próximo e, em seguida, tentará renderizar o mesmo conteúdo no cliente novamente. Ainda é recomendável que você mude para uma API de streaming como `renderToPipeableStream` ou `renderToReadableStream` em vez disso.
+* **`renderToStaticMarkup`:** Não apresentará mais erro ao suspender no servidor. Em vez disso, ele emitirá o HTML fallback para o limite `<Suspense>` mais próximo.
 
-## Log de Mudanças {/*changelog*/}
+## Registro de Mudanças {/*changelog*/}
 
-Você pode ver o [log de mudanças completo aqui](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Você pode visualizar o [registro de mudanças completo aqui](https://github.com/facebook/react/blob/main/CHANGELOG.md).

--- a/src/content/blog/2022/03/08/react-18-upgrade-guide.md
+++ b/src/content/blog/2022/03/08/react-18-upgrade-guide.md
@@ -2,7 +2,7 @@
 title: "Como Atualizar para o React 18"
 author: Rick Hanlon
 date: 2022/03/08
-description: Como compartilhamos no post de lançamento, o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicações existentes. Neste post, iremos orientá-lo através das etapas para atualizar para o React 18.
+description: Como compartilhamos no post de lançamento, o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicativos existentes. Neste post, vamos guiá-lo através das etapas para atualizar para o React 18.
 ---
 
 8 de março de 2022 por [Rick Hanlon](https://twitter.com/rickhanlonii)
@@ -11,15 +11,15 @@ description: Como compartilhamos no post de lançamento, o React 18 introduz rec
 
 <Intro>
 
-Como compartilhamos no [post de lançamento](/blog/2022/03/29/react-v18), o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicações existentes. Neste post, iremos orientá-lo através das etapas para atualizar para o React 18.
+Como compartilhamos no [post de lançamento](/blog/2022/03/29/react-v18), o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicativos existentes. Neste post, vamos guiá-lo através das etapas para atualizar para o React 18.
 
-Por favor, [relate qualquer problema](https://github.com/facebook/react/issues/new/choose) que encontrar durante a atualização para o React 18.
+Por favor, [relate quaisquer problemas](https://github.com/facebook/react/issues/new/choose) que você encontrar ao atualizar para o React 18.
 
 </Intro>
 
 <Note>
 
-Para usuários do React Native, o React 18 será disponibilizado em uma versão futura do React Native. Isso ocorre porque o React 18 depende da Nova Arquitetura do React Native para se beneficiar das novas capacidades apresentadas neste post. Para mais informações, veja a [keynote da React Conf aqui](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s).
+Para usuários do React Native, o React 18 será incluído em uma versão futura do React Native. Isso se deve ao fato de que o React 18 depende da Nova Arquitetura do React Native para se beneficiar das novas capacidades apresentadas neste post. Para mais informações, veja a [palestra da React Conf aqui](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s).
 
 </Note>
 
@@ -39,17 +39,17 @@ Ou se você estiver usando yarn:
 yarn add react react-dom
 ```
 
-## Atualizações nas APIs de Renderização do Cliente {/*updates-to-client-rendering-apis*/}
+## Atualizações para as APIs de Renderização no Cliente {/*updates-to-client-rendering-apis*/}
 
-Quando você instala o React 18 pela primeira vez, verá um aviso no console:
+Quando você instalar o React 18 pela primeira vez, verá um aviso no console:
 
 <ConsoleBlock level="error">
 
-ReactDOM.render não é mais suportado no React 18. Use createRoot em vez disso. Até você mudar para a nova API, seu aplicativo se comportará como se estivesse rodando o React 17. Saiba mais: https://reactjs.org/link/switch-to-createroot
+ReactDOM.render não é mais suportado no React 18. Use createRoot em vez disso. Até você mudar para a nova API, seu aplicativo se comportará como se estivesse executando o React 17. Saiba mais: https://reactjs.org/link/switch-to-createroot
 
 </ConsoleBlock>
 
-O React 18 introduz uma nova API de root que oferece melhor ergonomia para gerenciar roots. A nova API de root também possibilita o novo renderizador concorrente, que permite optar por recursos concorrentes.
+O React 18 introduz uma nova API de raiz que fornece melhor ergonomia para gerenciar raízes. A nova API de raiz também ativa o novo renderizador concorrente, que permite que você opte por recursos concorrentes.
 
 ```js
 // Antes
@@ -64,7 +64,7 @@ const root = createRoot(container); // createRoot(container!) se você usar Type
 root.render(<App tab="home" />);
 ```
 
-Também mudamos `unmountComponentAtNode` para `root.unmount`:
+Nós também mudamos `unmountComponentAtNode` para `root.unmount`:
 
 ```js
 // Antes
@@ -74,7 +74,7 @@ unmountComponentAtNode(container);
 root.unmount();
 ```
 
-Também removemos o callback de render, uma vez que geralmente não produz o resultado esperado ao usar Suspense:
+Nós também removemos o callback de renderização, pois ele geralmente não tem o resultado esperado ao usar Suspense:
 
 ```js
 // Antes
@@ -99,11 +99,11 @@ root.render(<AppWithCallbackAfterRender />);
 
 <Note>
 
-Não há uma substituição um-a-um para a antiga API de callback de render — depende do seu caso de uso. Veja o post do grupo de trabalho sobre [Substituindo render por createRoot](https://github.com/reactwg/react-18/discussions/5) para mais informações.
+Não há uma substituição um-para-um para a antiga API de callback de renderização — depende do seu caso de uso. Veja o post do grupo de trabalho sobre [Substituindo render por createRoot](https://github.com/reactwg/react-18/discussions/5) para mais informações.
 
 </Note>
 
-Finalmente, se seu aplicativo utiliza renderização do lado do servidor com hidratação, atualize `hydrate` para `hydrateRoot`:
+Finalmente, se seu aplicativo usa renderização no lado do servidor com hidratação, atualize `hydrate` para `hydrateRoot`:
 
 ```js
 // Antes
@@ -115,41 +115,41 @@ hydrate(<App tab="home" />, container);
 import { hydrateRoot } from 'react-dom/client';
 const container = document.getElementById('app');
 const root = hydrateRoot(container, <App tab="home" />);
-// Ao contrário de createRoot, você não precisa de uma chamada separada root.render() aqui.
+// Ao contrário do createRoot, você não precisa de uma chamada separada root.render() aqui.
 ```
 
 Para mais informações, veja a [discussão do grupo de trabalho aqui](https://github.com/reactwg/react-18/discussions/5).
 
 <Note>
 
-**Se seu aplicativo não funcionar após a atualização, verifique se ele está envolto em `<StrictMode>`.** [O Modo Estrito ficou mais rigoroso no React 18](#updates-to-strict-mode), e nem todos os seus componentes podem ser resilientes às novas verificações que ele adiciona em modo de desenvolvimento. Se remover o Modo Estrito corrigir seu aplicativo, você pode removê-lo durante a atualização e, em seguida, adicioná-lo de volta (seja no topo ou para uma parte da árvore) depois de corrigir os problemas que ele apontar.
+**Se seu aplicativo não funcionar após a atualização, verifique se ele não está encapsulado em `<StrictMode>`.** [O Modo Estrito ficou mais rigoroso no React 18](#updates-to-strict-mode), e nem todos os seus componentes podem ser resilientes às novas verificações que ele adiciona no modo de desenvolvimento. Se remover o Modo Estrito corrigir seu aplicativo, você pode removê-lo durante a atualização e depois adicioná-lo de volta (seja no topo ou para uma parte da árvore) depois de corrigir os problemas que ele está apontando.
 
 </Note>
 
-## Atualizações nas APIs de Renderização do Servidor {/*updates-to-server-rendering-apis*/}
+## Atualizações para as APIs de Renderização no Servidor {/*updates-to-server-rendering-apis*/}
 
-Nesta versão, estamos reformulando nossas APIs `react-dom/server` para dar suporte completo ao Suspense no servidor e ao SSR em streaming. Como parte dessas mudanças, estamos descontinuando a antiga API de streaming Node, que não dá suporte ao streaming incremental de Suspense no servidor.
+Nesta versão, estamos reformulando nossas APIs `react-dom/server` para suportar totalmente o Suspense no servidor e Streaming SSR. Como parte dessas mudanças, estamos descontinuando a antiga API de streaming do Node, que não suporta streaming de Suspense incremental no servidor.
 
-Usar esta API agora emitirá avisos:
+Usar essa API agora avisará:
 
 * `renderToNodeStream`: **Descontinuado ⛔️️**
 
 Em vez disso, para streaming em ambientes Node, use:
 * `renderToPipeableStream`: **Novo ✨**
 
-Estamos também introduzindo uma nova API para dar suporte ao SSR em streaming com Suspense para ambientes de runtime modernos, como Deno e trabalhadores Cloudflare:
+Estamos também introduzindo uma nova API para suportar streaming SSR com Suspense para ambientes modernos de runtime edge, como Deno e Cloudflare workers:
 * `renderToReadableStream`: **Novo ✨**
 
 As seguintes APIs continuarão funcionando, mas com suporte limitado para Suspense:
 * `renderToString`: **Limitado** ⚠️
 * `renderToStaticMarkup`: **Limitado** ⚠️
 
-Por fim, esta API continuará funcionando para renderizar e-mails:
+Finalmente, esta API continuará funcionando para renderizar e-mails:
 * `renderToStaticNodeStream`
 
-Para mais informações sobre as mudanças nas APIs de renderização do servidor, veja o post do grupo de trabalho sobre [Atualizando para o React 18 no servidor](https://github.com/reactwg/react-18/discussions/22), uma [análise detalhada da nova Arquitetura SSR do Suspense](https://github.com/reactwg/react-18/discussions/37), e a palestra de [Shaundai Person](https://twitter.com/shaundai) sobre [Renderização de Servidor em Streaming com Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) na React Conf 2021.
+Para mais informações sobre as mudanças nas APIs de renderização no servidor, veja o post do grupo de trabalho sobre [Atualizando para o React 18 no servidor](https://github.com/reactwg/react-18/discussions/22), uma [análise profunda da nova Arquitetura SSR do Suspense](https://github.com/reactwg/react-18/discussions/37), e a palestra de [Shaundai Person](https://twitter.com/shaundai) sobre [Streaming Server Rendering com Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) na React Conf 2021.
 
-## Atualizações nas definições do TypeScript {/*updates-to-typescript-definitions*/}
+## Atualizações para definições do TypeScript {/*updates-to-typescript-definitions*/}
 
 Se seu projeto usa TypeScript, você precisará atualizar suas dependências `@types/react` e `@types/react-dom` para as versões mais recentes. Os novos tipos são mais seguros e capturam problemas que costumavam ser ignorados pelo verificador de tipos. A mudança mais notável é que a prop `children` agora precisa ser listada explicitamente ao definir props, por exemplo:
 
@@ -160,13 +160,13 @@ interface MyButtonProps {
 }
 ```
 
-Veja o [pull request de tipagem do React 18](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) para uma lista completa de mudanças apenas nas tipos. Ele contém exemplos de correções em tipos de bibliotecas para que você possa ver como ajustar seu código. Você pode usar o [script de migração automatizado](https://github.com/eps1lon/types-react-codemod) para ajudar a portar o código do seu aplicativo para as novas e mais seguras tipagens mais rapidamente.
+Veja o [pull request de tipagens do React 18](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) para uma lista completa de mudanças apenas de tipos. Ele vincula a correções de exemplo nas definições da biblioteca, assim você pode ver como ajustar seu código. Você pode usar o [script de migração automatizado](https://github.com/eps1lon/types-react-codemod) para ajudar a portar o código da sua aplicação para as novas e mais seguras tipagens mais rapidamente.
 
-Se encontrar um bug nas tipagens, por favor, [registre um problema](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package) no repositório DefinitelyTyped.
+Se você encontrar um erro nas tipagens, por favor, [registre um problema](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package) no repositório DefinitelyTyped.
 
 ## Agrupamento Automático {/*automatic-batching*/}
 
-O React 18 adiciona melhorias de performance prontas para uso agrupando mais atualizações por padrão. Agrupamento é quando o React agrupa várias atualizações de estado em uma única re-renderização para melhor desempenho. Antes do React 18, só agrupávamos atualizações dentro de manipuladores de eventos do React. Atualizações dentro de promessas, setTimeout, manipuladores de eventos nativos ou qualquer outro evento não eram agrupadas no React por padrão:
+O React 18 adiciona melhorias de desempenho prontamente disponíveis ao fazer mais agrupamento por padrão. O agrupamento é quando o React agrupa múltiplas atualizações de estado em um único re-render para melhor desempenho. Antes do React 18, nós apenas agrupávamos atualizações dentro de manipuladores de eventos do React. Atualizações dentro de promessas, setTimeout, manipuladores de eventos nativos, ou qualquer outro evento não eram agrupados no React por padrão:
 
 ```js
 // Antes do React 18, apenas eventos do React eram agrupados
@@ -174,17 +174,17 @@ O React 18 adiciona melhorias de performance prontas para uso agrupando mais atu
 function handleClick() {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React re-renderizará apenas uma vez no final (isso é agrupamento!)
+  // O React apenas re-renderizará uma vez no final (isso é agrupamento!)
 }
 
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React re-renderizará duas vezes, uma para cada atualização de estado (sem agrupamento)
+  // O React renderizará duas vezes, uma para cada atualização de estado (sem agrupamento)
 }, 1000);
 ```
 
-A partir do React 18 com `createRoot`, todas as atualizações serão agrupadas automaticamente, não importa de onde elas se originem. Isso significa que atualizações dentro de timeouts, promessas, manipuladores de eventos nativos ou qualquer outro evento serão agrupadas da mesma forma que as atualizações dentro de eventos do React:
+A partir do React 18 com `createRoot`, todas as atualizações serão automaticamente agrupadas, não importa de onde elas se originem. Isso significa que atualizações dentro de timeouts, promessas, manipuladores de eventos nativos ou qualquer outro evento serão agrupadas da mesma forma que atualizações dentro de eventos do React:
 
 ```js
 // Depois do React 18, atualizações dentro de timeouts, promessas,
@@ -193,17 +193,17 @@ A partir do React 18 com `createRoot`, todas as atualizações serão agrupadas 
 function handleClick() {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React re-renderizará apenas uma vez no final (isso é agrupamento!)
+  // O React apenas re-renderizará uma vez no final (isso é agrupamento!)
 }
 
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // O React re-renderizará apenas uma vez no final (isso é agrupamento!)
+  // O React apenas re-renderizará uma vez no final (isso é agrupamento!)
 }, 1000);
 ```
 
-Esta é uma mudança significativa, mas esperamos que resulte em menos trabalho renderizando, e portanto melhor desempenho em suas aplicações. Para desativar o agrupamento automático, você pode usar `flushSync`:
+Esta é uma mudança de ruptura, mas esperamos que isso resulte em menos trabalho de renderização e, portanto, melhor desempenho em suas aplicações. Para optar por não fazer agrupamento automático, você pode usar `flushSync`:
 
 ```js
 import { flushSync } from 'react-dom';
@@ -212,32 +212,32 @@ function handleClick() {
   flushSync(() => {
     setCounter(c => c + 1);
   });
-  // O React atualizou o DOM até agora
+  // O React já atualizou o DOM até agora
   flushSync(() => {
     setFlag(f => !f);
   });
-  // O React atualizou o DOM até agora
+  // O React já atualizou o DOM até agora
 }
 ```
 
-Para mais informações, veja a [análise detalhada de agrupamento automático](https://github.com/reactwg/react-18/discussions/21).
+Para mais informações, veja a [análise profunda sobre agrupamento automático](https://github.com/reactwg/react-18/discussions/21).
 
 ## Novas APIs para Bibliotecas {/*new-apis-for-libraries*/}
 
-No Grupo de Trabalho do React 18, trabalhamos com mantenedores de bibliotecas para criar novas APIs necessárias para dar suporte à renderização concorrente para casos de uso específicos nas áreas de estilos e lojas externas. Para dar suporte ao React 18, algumas bibliotecas podem precisar mudar para uma das seguintes APIs:
+No Grupo de Trabalho do React 18, trabalhamos com mantenedores de bibliotecas para criar novas APIs necessárias para suportar renderização concorrente para casos de uso específicos em áreas como estilos e armazéns externos. Para suportar o React 18, algumas bibliotecas podem precisar mudar para uma das seguintes APIs:
 
-* `useSyncExternalStore` é um novo Hook que permite que lojas externas suportem leituras concorrentes, forçando atualizações na loja a serem síncronas. Esta nova API é recomendada para qualquer biblioteca que se integre com estado externo ao React. Para mais informações, veja o [post de visão geral do useSyncExternalStore](https://github.com/reactwg/react-18/discussions/70) e [detalhes da API useSyncExternalStore](https://github.com/reactwg/react-18/discussions/86).
-* `useInsertionEffect` é um novo Hook que permite que bibliotecas CSS-in-JS resolvam problemas de desempenho ao injetar estilos na renderização. A menos que você já tenha construído uma biblioteca CSS-in-JS, não esperamos que você a utilize. Este Hook será executado após a mutação do DOM, mas antes que os efeitos de layout leiam o novo layout. Isso resolve um problema que já existe no React 17 e abaixo, mas é ainda mais importante no React 18, uma vez que o React cede espaço ao navegador durante a renderização concorrente, dando a ele a chance de recalcular o layout. Para mais informações, veja o [Guia de Atualização da Biblioteca para `<style>`](https://github.com/reactwg/react-18/discussions/110).
+* `useSyncExternalStore` é um novo Hook que permite que armazéns externos suportem leituras concorrentes forçando atualizações do armazém a serem síncronas. Esta nova API é recomendada para qualquer biblioteca que integre com estado externo ao React. Para mais informações, veja o [post de visão geral do useSyncExternalStore](https://github.com/reactwg/react-18/discussions/70) e [detalhes da API useSyncExternalStore](https://github.com/reactwg/react-18/discussions/86).
+* `useInsertionEffect` é um novo Hook que permite que bibliotecas CSS-in-JS consigam resolver problemas de desempenho de injeção de estilos na renderização. A menos que você já tenha construído uma biblioteca CSS-in-JS, não esperamos que você use isso. Este Hook será executado depois que o DOM for modificado, mas antes que os efeitos de layout leiam o novo layout. Isso resolve um problema que já existe no React 17 e anterior, mas é ainda mais importante no React 18, pois o React cede ao navegador durante a renderização concorrente, dando a ele a chance de recalcular o layout. Para mais informações, veja o [Guia de Atualização da Biblioteca para `<style>`](https://github.com/reactwg/react-18/discussions/110).
 
-O React 18 também introduz novas APIs para renderização concorrente, como `startTransition`, `useDeferredValue` e `useId`, sobre as quais compartilhamos mais detalhes no [post de lançamento](/blog/2022/03/29/react-v18).
+O React 18 também introduz novas APIs para renderização concorrente, como `startTransition`, `useDeferredValue` e `useId`, as quais compartilhamos mais informações no [post de lançamento](/blog/2022/03/29/react-v18).
 
-## Atualizações no Modo Estrito {/*updates-to-strict-mode*/}
+## Atualizações para o Modo Estrito {/*updates-to-strict-mode*/}
 
-No futuro, gostaríamos de adicionar um recurso que permite ao React adicionar e remover seções da interface do usuário enquanto preserva o estado. Por exemplo, quando um usuário muda de tela e volta, o React deve ser capaz de mostrar imediatamente a tela anterior. Para fazer isso, o React desmontaria e remontaria árvores usando o mesmo estado do componente que antes.
+No futuro, gostaríamos de adicionar um recurso que permita ao React adicionar e remover seções da UI enquanto preserva o estado. Por exemplo, quando um usuário troca de tela e volta, o React deve ser capaz de mostrar imediatamente a tela anterior. Para fazer isso, o React desmontaria e remontaria árvores usando o mesmo estado de componente que antes.
 
-Esse recurso proporcionará melhor desempenho ao React prontamente, mas requer que os componentes sejam resilientes a efeitos sendo montados e destruídos várias vezes. A maioria dos efeitos funcionará sem alterações, mas alguns efeitos assumem que são montados ou desmontados apenas uma vez.
+Esse recurso dará ao React melhor desempenho prontamente, mas requer que os componentes sejam resilientes a efeitos sendo montados e destruídos múltiplas vezes. A maioria dos efeitos funcionará sem alterações, mas alguns efeitos assumem que são montados ou destruídos apenas uma vez.
 
-Para ajudar a evidenciar esses problemas, o React 18 introduz uma nova verificação apenas para desenvolvimento no Modo Estrito. Esta nova verificação desmontará e remontará automaticamente cada componente sempre que um componente for montado pela primeira vez, restaurando o estado anterior na segunda montagem.
+Para ajudar a evidenciar esses problemas, o React 18 introduz uma nova verificação apenas para desenvolvimento no Modo Estrito. Esta nova verificação desmontará e remontará automaticamente cada componente, sempre que um componente for montado pela primeira vez, restaurando o estado anterior na segunda montagem.
 
 Antes dessa mudança, o React montaria o componente e criaria os efeitos:
 
@@ -247,25 +247,25 @@ Antes dessa mudança, o React montaria o componente e criaria os efeitos:
     * Efeitos são criados.
 ```
 
-Com o Modo Estrito no React 18, o React simulará o desmontar e remontar do componente em modo de desenvolvimento:
+Com o Modo Estrito no React 18, o React simulará o desmonte e o remontagem do componente no modo de desenvolvimento:
 
 ```
 * O React monta o componente.
     * Efeitos de layout são criados.
     * Efeitos são criados.
-* O React simula o desmontar do componente.
+* O React simula o desmonte do componente.
     * Efeitos de layout são destruídos.
     * Efeitos são destruídos.
 * O React simula a montagem do componente com o estado anterior.
-    * O código de configuração do efeito de layout é executado.
-    * O código de configuração do efeito é executado.
+    * O código de configuração do efeito de layout é executado
+    * O código de configuração do efeito é executado
 ```
 
 Para mais informações, veja os posts do Grupo de Trabalho sobre [Adicionando Estado Reutilizável ao StrictMode](https://github.com/reactwg/react-18/discussions/19) e [Como suportar Estado Reutilizável em Efeitos](https://github.com/reactwg/react-18/discussions/18).
 
 ## Configurando Seu Ambiente de Teste {/*configuring-your-testing-environment*/}
 
-Quando você atualizar seus testes para usar `createRoot`, você pode ver este aviso no console de testes:
+Quando você atualizar seus testes para usar `createRoot`, pode ver este aviso no console de teste:
 
 <ConsoleBlock level="error">
 
@@ -273,58 +273,58 @@ O ambiente de teste atual não está configurado para suportar act(...)
 
 </ConsoleBlock>
 
-Para corrigir isso, defina `globalThis.IS_REACT_ACT_ENVIRONMENT` como `true` antes de rodar seu teste:
+Para corrigir isso, defina `globalThis.IS_REACT_ACT_ENVIRONMENT` como `true` antes de executar seu teste:
 
 ```js
 // No seu arquivo de configuração de teste
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 ```
 
-O propósito da flag é informar ao React que está rodando em um ambiente parecido com um teste unitário. O React registrará avisos úteis se você esquecer de envolver uma atualização com `act`.
+O objetivo da flag é informar ao React que está sendo executado em um ambiente semelhante a um teste unitário. O React registrará avisos úteis se você esquecer de envolver uma atualização com `act`.
 
-Você também pode definir a flag como `false` para informar ao React que o `act` não é necessário. Isso pode ser útil para testes de ponta a ponta que simulam um ambiente completo de navegador.
+Você também pode definir a flag como `false` para informar ao React que `act` não é necessário. Isso pode ser útil para testes de ponta a ponta que simulam um ambiente de navegador completo.
 
-Eventualmente, esperamos que bibliotecas de teste configurem isso automaticamente para você. Por exemplo, a [próxima versão da React Testing Library tem suporte embutido para o React 18](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936) sem configuração adicional.
+Eventualmente, esperamos que bibliotecas de teste configurem isso para você automaticamente. Por exemplo, a [próxima versão da React Testing Library tem suporte embutido para o React 18](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936) sem nenhuma configuração adicional.
 
 [Mais informações sobre a API de teste `act` e mudanças relacionadas](https://github.com/reactwg/react-18/discussions/102) estão disponíveis no grupo de trabalho.
 
-## Remoção do Suporte para Internet Explorer {/*dropping-support-for-internet-explorer*/}
+## Remoção do Suporte para o Internet Explorer {/*dropping-support-for-internet-explorer*/}
 
-Nesta versão, o React está removendo o suporte para Internet Explorer, que [sairá de suporte em 15 de junho de 2022](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge). Estamos fazendo esta mudança agora porque os novos recursos introduzidos no React 18 são construídos usando recursos modernos de navegadores, como microtarefas, que não podem ser adequadamente compatibilizados no IE.
+Nesta versão, o React está removendo o suporte para o Internet Explorer, que [sai de suporte em 15 de junho de 2022](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge). Estamos fazendo essa mudança agora porque os novos recursos introduzidos no React 18 são construídos usando recursos modernos de navegador, como microtarefas, que não podem ser adequadamente polidos no IE.
 
-Se você precisa oferecer suporte ao Internet Explorer, recomendamos que fique com o React 17.
+Se você precisar dar suporte ao Internet Explorer, recomendamos que você permaneça com o React 17.
 
-## Descontinuidades {/*deprecations*/}
+## Descontinuações {/*deprecations*/}
 
-* `react-dom`: `ReactDOM.render` foi descontinuado. Usá-lo emitirá avisos e executará seu aplicativo no modo React 17.
-* `react-dom`: `ReactDOM.hydrate` foi descontinuado. Usá-lo emitirá avisos e executará seu aplicativo no modo React 17.
+* `react-dom`: `ReactDOM.render` foi descontinuado. Usá-lo irá avisar e executar seu aplicativo em modo React 17.
+* `react-dom`: `ReactDOM.hydrate` foi descontinuado. Usá-lo irá avisar e executar seu aplicativo em modo React 17.
 * `react-dom`: `ReactDOM.unmountComponentAtNode` foi descontinuado.
 * `react-dom`: `ReactDOM.renderSubtreeIntoContainer` foi descontinuado.
 * `react-dom/server`: `ReactDOMServer.renderToNodeStream` foi descontinuado.
 
-## Outras Mudanças Quebradoras {/*other-breaking-changes*/}
+## Outras Mudanças de Ruptura {/*other-breaking-changes*/}
 
-* **Consistência no timing do useEffect**: O React agora sempre esvazia sincronamente funções de efeito se a atualização foi acionada durante um evento de entrada discreta do usuário, como um clique ou um evento keydown. Anteriormente, o comportamento não era sempre previsível ou consistente.
-* **Erros de hidratação mais rigorosos**: Desvios de hidratação devido a conteúdo de texto ausente ou extra agora são tratados como erros em vez de avisos. O React não tentará mais "corrigir" nós individuais inserindo ou excluindo um nó no cliente em uma tentativa de corresponder à marcação do servidor, e reverterá para a renderização do cliente até o limite mais próximo de `<Suspense>` na árvore. Isso garante que a árvore hidratada seja consistente e evita potenciais buracos de privacidade e segurança que podem ser causados por desvios de hidratação.
-* **As árvores do Suspense são sempre consistentes:** Se um componente suspender antes de ser totalmente adicionado à árvore, o React não o adicionará à árvore em um estado incompleto ou ativará seus efeitos. Em vez disso, o React descartará completamente a nova árvore, aguardará a operação assíncrona terminar e então tentará renderizar novamente do zero. O React renderizará a tentativa de nova renderização de forma concorrente e sem bloquear o navegador.
-* **Efeitos de Layout com Suspense**: Quando uma árvore volta a suspender e reverte para um fallback, o React agora limpará os efeitos de layout e, em seguida, os recriará quando o conteúdo dentro da fronteira for mostrado novamente. Isso corrige um problema que impedia bibliotecas de componentes de medir corretamente o layout quando usadas com Suspense.
-* **Novos Requisitos de Ambiente JS**: O React agora depende de recursos modernos de navegadores, incluindo `Promise`, `Symbol` e `Object.assign`. Se você oferece suporte a navegadores e dispositivos mais antigos, como o Internet Explorer, que não fornecem recursos modernos de navegador nativamente ou têm implementações não compatíveis, considere incluir um polyfill global em seu aplicativo empacotado.
+* **Tempos consistentes do useEffect**: O React agora sempre esvazia de forma síncrona funções de efeito se a atualização foi acionada durante um evento de entrada do usuário discreto, como um clique ou um evento de keydown. Anteriormente, o comportamento nem sempre era previsível ou consistente.
+* **Erros de hidratação mais rigorosos**: Desajustes de hidratação devido a conteúdo textual ausente ou extra agora são tratados como erros, em vez de avisos. O React não tentará mais "corrigir" nós individuais inserindo ou deletando um nó no cliente em uma tentativa de combinar a marcação do servidor, e reverterá para renderização no cliente até o limite mais próximo de `<Suspense>` na árvore. Isso garante que a árvore hidratada seja consistente e evita possíveis buracos de privacidade e segurança que podem ser causados por desajustes de hidratação.
+* **Árvores de Suspense são sempre consistentes:** Se um componente suspende antes de ser totalmente adicionado à árvore, o React não o adicionará à árvore em um estado incompleto ou acionará seus efeitos. Em vez disso, o React descartará completamente a nova árvore, aguardará a operação assíncrona terminar e então tentará renderizar novamente do zero. O React renderizará a tentativa de nova renderização de forma concorrente, e sem bloquear o navegador.
+* **Efeitos de Layout com Suspense**: Quando uma árvore se re-suspende e reverte para um fallback, o React agora irá limpar efeitos de layout e, em seguida, re-criá-los quando o conteúdo dentro do limite for exibido novamente. Isso resolve um problema que impediu que bibliotecas de componentes medisse corretamente o layout ao serem usadas com Suspense.
+* **Novos Requisitos de Ambiente JS**: O React agora depende de recursos modernos dos navegadores, incluindo `Promise`, `Symbol` e `Object.assign`. Se você dá suporte a navegadores e dispositivos mais antigos, como o Internet Explorer, que não fornecem recursos modernos de navegador de forma nativa ou têm implementações não conformes, considere incluir um polyfill global na sua aplicação compilada.
 
 ## Outras Mudanças Notáveis {/*other-notable-changes*/}
 
 ### React {/*react*/}
 
-* **Componentes agora podem renderizar `undefined`:** O React não avisa mais se você retornar `undefined` de um componente. Isso torna os valores de retorno permitidos para componentes consistentes com os valores que são permitidos no meio de uma árvore de componentes. Sugerimos usar um linter para evitar erros como esquecer uma declaração de `return` antes do JSX.
-* **Nos testes, avisos de `act` agora são opt-in:** Se você está executando testes de ponta a ponta, os avisos de `act` são desnecessários. Introduzimos um mecanismo de [opção opt-in](https://github.com/reactwg/react-18/discussions/102) para que você possa habilitá-los apenas para testes unitários onde eles são úteis e benéficos.
-* **Sem aviso sobre `setState` em componentes desmontados:** Anteriormente, o React avisava sobre vazamentos de memória quando você chamava `setState` em um componente desmontado. Este aviso foi adicionado para assinaturas, mas as pessoas encontram isso principalmente em cenários onde definir o estado é aceitável, e soluções alternativas pioram o código. Nós [removemos](https://github.com/facebook/react/pull/22114) este aviso.
-* **Sem supressão de logs no console:** Quando você usa o Modo Estrito, o React renderiza cada componente duas vezes para ajudá-lo a encontrar efeitos colaterais inesperados. No React 17, suprimimos logs do console para uma das duas renderizações para tornar os logs mais fáceis de ler. Em resposta ao [feedback da comunidade](https://github.com/facebook/react/issues/21783) sobre isso ser confuso, removemos a supressão. Em vez disso, se você tiver o React DevTools instalado, as renderizações do segundo log serão exibidas em cinza, e haverá uma opção (desativada por padrão) para suprimir completamente.
-* **Uso de memória melhorado:** O React agora limpa mais campos internos ao desmontar, tornando o impacto de vazamentos de memória não corrigidos que podem existir no código do seu aplicativo menos severo.
+* **Componentes agora podem renderizar `undefined`:** O React não avisa mais se você retornar `undefined` de um componente. Isso torna os valores de retorno de componente permitidos consistentes com os valores que são permitidos no meio de uma árvore de componentes. Sugerimos usar um linter para evitar erros como esquecer uma declaração `return` antes do JSX.
+* **Em testes, avisos de `act` agora são opcionais:** Se você estiver executando testes de ponta a ponta, os avisos de `act` são desnecessários. Introduzimos um mecanismo [opcional](https://github.com/reactwg/react-18/discussions/102) para que você possa habilitá-los apenas para testes unitários, onde são úteis e benéficos.
+* **Sem aviso sobre `setState` em componentes desmontados:** Anteriormente, o React avisava sobre vazamentos de memória quando você chamava `setState` em um componente desmontado. Este aviso foi adicionado para assinaturas, mas as pessoas principalmente enfrentavam isso em cenários onde definir o estado é aceitável e as soluções alternativas tornam o código pior. Nós [removemos](https://github.com/facebook/react/pull/22114) este aviso.
+* **Sem supressão de logs no console:** Quando você usa o Modo Estrito, o React renderiza cada componente duas vezes para ajudá-lo a encontrar efeitos colaterais inesperados. No React 17, suprimimos logs no console para uma das duas renderizações para tornar os logs mais fáceis de ler. Em resposta ao [feedback da comunidade](https://github.com/facebook/react/issues/21783) sobre isso ser confuso, removemos a supressão. Em vez disso, se você tiver as Ferramentas de Desenvolvimento do React instaladas, a segunda renderização dos logs será mostrada em cinza, e haverá uma opção (desabilitada por padrão) para suprimi-las completamente.
+* **Uso de memória melhorado:** O React agora limpa mais campos internos ao ser desmontado, tornando o impacto de vazamentos de memória não corrigidos que podem existir no código da sua aplicação menos severo.
 
 ### React DOM Server {/*react-dom-server*/}
 
-* **`renderToString`:** Não gerará mais erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para a fronteira `<Suspense>` mais próxima e, em seguida, tentará renderizar o mesmo conteúdo no cliente. Ainda é recomendado que você mude para uma API de streaming como `renderToPipeableStream` ou `renderToReadableStream`.
-* **`renderToStaticMarkup`:** Não gerará mais erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para a fronteira `<Suspense>` mais próxima.
+* **`renderToString`:** Não irá mais gerar erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para o limite mais próximo de `<Suspense>` e tentará renderizar novamente o mesmo conteúdo no cliente. Ainda é recomendável que você mude para uma API de streaming como `renderToPipeableStream` ou `renderToReadableStream`.
+* **`renderToStaticMarkup`:** Não irá mais gerar erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para o limite mais próximo de `<Suspense>`.
 
-## Registro de Mudanças {/*changelog*/}
+## Log de Mudanças {/*changelog*/}
 
-Você pode visualizar o [registro de mudanças completo aqui](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Você pode ver o [log de mudanças completo aqui](https://github.com/facebook/react/blob/main/CHANGELOG.md).

--- a/src/content/blog/2022/03/08/react-18-upgrade-guide.md
+++ b/src/content/blog/2022/03/08/react-18-upgrade-guide.md
@@ -1,92 +1,92 @@
 ---
-title: "How to Upgrade to React 18"
+title: "Como Atualizar para o React 18"
 author: Rick Hanlon
 date: 2022/03/08
-description: As we shared in the release post, React 18 introduces features powered by our new concurrent renderer, with a gradual adoption strategy for existing applications. In this post, we will guide you through the steps for upgrading to React 18.
+description: Como compartilhamos no post de lançamento, o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicações existentes. Neste post, iremos orientá-lo através das etapas para atualizar para o React 18.
 ---
 
-March 08, 2022 by [Rick Hanlon](https://twitter.com/rickhanlonii)
+8 de março de 2022 por [Rick Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
 <Intro>
 
-As we shared in the [release post](/blog/2022/03/29/react-v18), React 18 introduces features powered by our new concurrent renderer, with a gradual adoption strategy for existing applications. In this post, we will guide you through the steps for upgrading to React 18.
+Como compartilhamos no [post de lançamento](/blog/2022/03/29/react-v18), o React 18 introduz recursos suportados pelo nosso novo renderizador concorrente, com uma estratégia de adoção gradual para aplicações existentes. Neste post, iremos orientá-lo através das etapas para atualizar para o React 18.
 
-Please [report any issues](https://github.com/facebook/react/issues/new/choose) you encounter while upgrading to React 18.
+Por favor, [relate qualquer problema](https://github.com/facebook/react/issues/new/choose) que encontrar durante a atualização para o React 18.
 
 </Intro>
 
 <Note>
 
-For React Native users, React 18 will ship in a future version of React Native. This is because React 18 relies on the New React Native Architecture to benefit from the new capabilities presented in this blogpost. For more information, see the [React Conf keynote here](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s).
+Para usuários do React Native, o React 18 será disponibilizado em uma versão futura do React Native. Isso ocorre porque o React 18 depende da Nova Arquitetura do React Native para se beneficiar das novas capacidades apresentadas neste post. Para mais informações, veja a [keynote da React Conf aqui](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s).
 
 </Note>
 
 ---
 
-## Installing {/*installing*/}
+## Instalando {/*installing*/}
 
-To install the latest version of React:
+Para instalar a versão mais recente do React:
 
 ```bash
 npm install react react-dom
 ```
 
-Or if you’re using yarn:
+Ou se você estiver usando yarn:
 
 ```bash
 yarn add react react-dom
 ```
 
-## Updates to Client Rendering APIs {/*updates-to-client-rendering-apis*/}
+## Atualizações nas APIs de Renderização do Cliente {/*updates-to-client-rendering-apis*/}
 
-When you first install React 18, you will see a warning in the console:
+Quando você instala o React 18 pela primeira vez, verá um aviso no console:
 
 <ConsoleBlock level="error">
 
-ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
+ReactDOM.render não é mais suportado no React 18. Use createRoot em vez disso. Até você mudar para a nova API, seu aplicativo se comportará como se estivesse rodando o React 17. Saiba mais: https://reactjs.org/link/switch-to-createroot
 
 </ConsoleBlock>
 
-React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.
+O React 18 introduz uma nova API de root que oferece melhor ergonomia para gerenciar roots. A nova API de root também possibilita o novo renderizador concorrente, que permite optar por recursos concorrentes.
 
 ```js
-// Before
+// Antes
 import { render } from 'react-dom';
 const container = document.getElementById('app');
 render(<App tab="home" />, container);
 
-// After
+// Depois
 import { createRoot } from 'react-dom/client';
 const container = document.getElementById('app');
-const root = createRoot(container); // createRoot(container!) if you use TypeScript
+const root = createRoot(container); // createRoot(container!) se você usar TypeScript
 root.render(<App tab="home" />);
 ```
 
-We’ve also changed `unmountComponentAtNode` to `root.unmount`:
+Também mudamos `unmountComponentAtNode` para `root.unmount`:
 
 ```js
-// Before
+// Antes
 unmountComponentAtNode(container);
 
-// After
+// Depois
 root.unmount();
 ```
 
-We've also removed the callback from render, since it usually does not have the expected result when using Suspense:
+Também removemos o callback de render, uma vez que geralmente não produz o resultado esperado ao usar Suspense:
 
 ```js
-// Before
+// Antes
 const container = document.getElementById('app');
 render(<App tab="home" />, container, () => {
-  console.log('rendered');
+  console.log('renderizado');
 });
 
-// After
+// Depois
 function AppWithCallbackAfterRender() {
   useEffect(() => {
-    console.log('rendered');
+    console.log('renderizado');
   });
 
   return <App tab="home" />
@@ -99,59 +99,59 @@ root.render(<AppWithCallbackAfterRender />);
 
 <Note>
 
-There is no one-to-one replacement for the old render callback API — it depends on your use case. See the working group post for [Replacing render with createRoot](https://github.com/reactwg/react-18/discussions/5) for more information.
+Não há uma substituição um-a-um para a antiga API de callback de render — depende do seu caso de uso. Veja o post do grupo de trabalho sobre [Substituindo render por createRoot](https://github.com/reactwg/react-18/discussions/5) para mais informações.
 
 </Note>
 
-Finally, if your app uses server-side rendering with hydration, upgrade `hydrate` to `hydrateRoot`:
+Finalmente, se seu aplicativo utiliza renderização do lado do servidor com hidratação, atualize `hydrate` para `hydrateRoot`:
 
 ```js
-// Before
+// Antes
 import { hydrate } from 'react-dom';
 const container = document.getElementById('app');
 hydrate(<App tab="home" />, container);
 
-// After
+// Depois
 import { hydrateRoot } from 'react-dom/client';
 const container = document.getElementById('app');
 const root = hydrateRoot(container, <App tab="home" />);
-// Unlike with createRoot, you don't need a separate root.render() call here.
+// Ao contrário de createRoot, você não precisa de uma chamada separada root.render() aqui.
 ```
 
-For more information, see the [working group discussion here](https://github.com/reactwg/react-18/discussions/5).
+Para mais informações, veja a [discussão do grupo de trabalho aqui](https://github.com/reactwg/react-18/discussions/5).
 
 <Note>
 
-**If your app doesn't work after upgrading, check whether it's wrapped in `<StrictMode>`.** [Strict Mode has gotten stricter in React 18](#updates-to-strict-mode), and not all your components may be resilient to the new checks it adds in development mode. If removing Strict Mode fixes your app, you can remove it during the upgrade, and then add it back (either at the top or for a part of the tree) after you fix the issues that it's pointing out.
+**Se seu aplicativo não funcionar após a atualização, verifique se ele está envolto em `<StrictMode>`.** [O Modo Estrito ficou mais rigoroso no React 18](#updates-to-strict-mode), e nem todos os seus componentes podem ser resilientes às novas verificações que ele adiciona em modo de desenvolvimento. Se remover o Modo Estrito corrigir seu aplicativo, você pode removê-lo durante a atualização e, em seguida, adicioná-lo de volta (seja no topo ou para uma parte da árvore) depois de corrigir os problemas que ele apontar.
 
 </Note>
 
-## Updates to Server Rendering APIs {/*updates-to-server-rendering-apis*/}
+## Atualizações nas APIs de Renderização do Servidor {/*updates-to-server-rendering-apis*/}
 
-In this release, we’re revamping our `react-dom/server` APIs to fully support Suspense on the server and Streaming SSR. As part of these changes, we're deprecating the old Node streaming API, which does not support incremental Suspense streaming on the server.
+Nesta versão, estamos reformulando nossas APIs `react-dom/server` para dar suporte completo ao Suspense no servidor e ao SSR em streaming. Como parte dessas mudanças, estamos descontinuando a antiga API de streaming Node, que não dá suporte ao streaming incremental de Suspense no servidor.
 
-Using this API will now warn:
+Usar esta API agora emitirá avisos:
 
-* `renderToNodeStream`: **Deprecated ⛔️️**
+* `renderToNodeStream`: **Descontinuado ⛔️️**
 
-Instead, for streaming in Node environments, use:
-* `renderToPipeableStream`: **New ✨**
+Em vez disso, para streaming em ambientes Node, use:
+* `renderToPipeableStream`: **Novo ✨**
 
-We're also introducing a new API to support streaming SSR with Suspense for modern edge runtime environments, such as Deno and Cloudflare workers:
-* `renderToReadableStream`: **New ✨**
+Estamos também introduzindo uma nova API para dar suporte ao SSR em streaming com Suspense para ambientes de runtime modernos, como Deno e trabalhadores Cloudflare:
+* `renderToReadableStream`: **Novo ✨**
 
-The following APIs will continue working, but with limited support for Suspense:
-* `renderToString`: **Limited** ⚠️
-* `renderToStaticMarkup`: **Limited** ⚠️
+As seguintes APIs continuarão funcionando, mas com suporte limitado para Suspense:
+* `renderToString`: **Limitado** ⚠️
+* `renderToStaticMarkup`: **Limitado** ⚠️
 
-Finally, this API will continue to work for rendering e-mails:
+Por fim, esta API continuará funcionando para renderizar e-mails:
 * `renderToStaticNodeStream`
 
-For more information on the changes to server rendering APIs, see the working group post on [Upgrading to React 18 on the server](https://github.com/reactwg/react-18/discussions/22), a [deep dive on the new Suspense SSR Architecture](https://github.com/reactwg/react-18/discussions/37), and [Shaundai Person’s](https://twitter.com/shaundai) talk on [Streaming Server Rendering with Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) at React Conf 2021.
+Para mais informações sobre as mudanças nas APIs de renderização do servidor, veja o post do grupo de trabalho sobre [Atualizando para o React 18 no servidor](https://github.com/reactwg/react-18/discussions/22), uma [análise detalhada da nova Arquitetura SSR do Suspense](https://github.com/reactwg/react-18/discussions/37), e a palestra de [Shaundai Person](https://twitter.com/shaundai) sobre [Renderização de Servidor em Streaming com Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) na React Conf 2021.
 
-## Updates to TypeScript definitions {/*updates-to-typescript-definitions*/}
+## Atualizações nas definições do TypeScript {/*updates-to-typescript-definitions*/}
 
-If your project uses TypeScript, you will need to update your `@types/react` and `@types/react-dom` dependencies to the latest versions. The new types are safer and catch issues that used to be ignored by the type checker. The most notable change is that the `children` prop now needs to be listed explicitly when defining props, for example:
+Se seu projeto usa TypeScript, você precisará atualizar suas dependências `@types/react` e `@types/react-dom` para as versões mais recentes. Os novos tipos são mais seguros e capturam problemas que costumavam ser ignorados pelo verificador de tipos. A mudança mais notável é que a prop `children` agora precisa ser listada explicitamente ao definir props, por exemplo:
 
 ```typescript{3}
 interface MyButtonProps {
@@ -160,51 +160,50 @@ interface MyButtonProps {
 }
 ```
 
-See the [React 18 typings pull request](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) for a full list of type-only changes. It links to example fixes in library types so you can see how to adjust your code. You can use the [automated migration script](https://github.com/eps1lon/types-react-codemod) to help port your application code to the new and safer typings faster.
+Veja o [pull request de tipagem do React 18](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) para uma lista completa de mudanças apenas nas tipos. Ele contém exemplos de correções em tipos de bibliotecas para que você possa ver como ajustar seu código. Você pode usar o [script de migração automatizado](https://github.com/eps1lon/types-react-codemod) para ajudar a portar o código do seu aplicativo para as novas e mais seguras tipagens mais rapidamente.
 
-If you find a bug in the typings, please [file an issue](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package) in the DefinitelyTyped repo.
+Se encontrar um bug nas tipagens, por favor, [registre um problema](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package) no repositório DefinitelyTyped.
 
-## Automatic Batching {/*automatic-batching*/}
+## Agrupamento Automático {/*automatic-batching*/}
 
-React 18 adds out-of-the-box performance improvements by doing more batching by default. Batching is when React groups multiple state updates into a single re-render for better performance. Before React 18, we only batched updates inside React event handlers. Updates inside of promises, setTimeout, native event handlers, or any other event were not batched in React by default:
+O React 18 adiciona melhorias de performance prontas para uso agrupando mais atualizações por padrão. Agrupamento é quando o React agrupa várias atualizações de estado em uma única re-renderização para melhor desempenho. Antes do React 18, só agrupávamos atualizações dentro de manipuladores de eventos do React. Atualizações dentro de promessas, setTimeout, manipuladores de eventos nativos ou qualquer outro evento não eram agrupadas no React por padrão:
 
 ```js
-// Before React 18 only React events were batched
+// Antes do React 18, apenas eventos do React eram agrupados
 
 function handleClick() {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // React will only re-render once at the end (that's batching!)
+  // O React re-renderizará apenas uma vez no final (isso é agrupamento!)
 }
 
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // React will render twice, once for each state update (no batching)
+  // O React re-renderizará duas vezes, uma para cada atualização de estado (sem agrupamento)
 }, 1000);
 ```
 
-
-Starting in React 18 with `createRoot`, all updates will be automatically batched, no matter where they originate from. This means that updates inside of timeouts, promises, native event handlers or any other event will batch the same way as updates inside of React events:
+A partir do React 18 com `createRoot`, todas as atualizações serão agrupadas automaticamente, não importa de onde elas se originem. Isso significa que atualizações dentro de timeouts, promessas, manipuladores de eventos nativos ou qualquer outro evento serão agrupadas da mesma forma que as atualizações dentro de eventos do React:
 
 ```js
-// After React 18 updates inside of timeouts, promises,
-// native event handlers or any other event are batched.
+// Depois do React 18, atualizações dentro de timeouts, promessas,
+// manipuladores de eventos nativos ou qualquer outro evento são agrupadas.
 
 function handleClick() {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // React will only re-render once at the end (that's batching!)
+  // O React re-renderizará apenas uma vez no final (isso é agrupamento!)
 }
 
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);
-  // React will only re-render once at the end (that's batching!)
+  // O React re-renderizará apenas uma vez no final (isso é agrupamento!)
 }, 1000);
 ```
 
-This is a breaking change, but we expect this to result in less work rendering, and therefore better performance in your applications. To opt-out of automatic batching, you can use `flushSync`:
+Esta é uma mudança significativa, mas esperamos que resulte em menos trabalho renderizando, e portanto melhor desempenho em suas aplicações. Para desativar o agrupamento automático, você pode usar `flushSync`:
 
 ```js
 import { flushSync } from 'react-dom';
@@ -213,119 +212,119 @@ function handleClick() {
   flushSync(() => {
     setCounter(c => c + 1);
   });
-  // React has updated the DOM by now
+  // O React atualizou o DOM até agora
   flushSync(() => {
     setFlag(f => !f);
   });
-  // React has updated the DOM by now
+  // O React atualizou o DOM até agora
 }
 ```
 
-For more information, see the [Automatic batching deep dive](https://github.com/reactwg/react-18/discussions/21).
+Para mais informações, veja a [análise detalhada de agrupamento automático](https://github.com/reactwg/react-18/discussions/21).
 
-## New APIs for Libraries {/*new-apis-for-libraries*/}
+## Novas APIs para Bibliotecas {/*new-apis-for-libraries*/}
 
-In the React 18 Working Group we worked with library maintainers to create new APIs needed to support concurrent rendering for use cases specific to their use case in areas like styles, and external stores. To support React 18, some libraries may need to switch to one of the following APIs:
+No Grupo de Trabalho do React 18, trabalhamos com mantenedores de bibliotecas para criar novas APIs necessárias para dar suporte à renderização concorrente para casos de uso específicos nas áreas de estilos e lojas externas. Para dar suporte ao React 18, algumas bibliotecas podem precisar mudar para uma das seguintes APIs:
 
-* `useSyncExternalStore` is a new Hook that allows external stores to support concurrent reads by forcing updates to the store to be synchronous. This new API is recommended for any library that integrates with state external to React. For more information, see the [useSyncExternalStore overview post](https://github.com/reactwg/react-18/discussions/70) and [useSyncExternalStore API details](https://github.com/reactwg/react-18/discussions/86).
-* `useInsertionEffect` is a new Hook that allows CSS-in-JS libraries to address performance issues of injecting styles in render. Unless you've already built a CSS-in-JS library we don't expect you to ever use this. This Hook will run after the DOM is mutated, but before layout effects read the new layout. This solves an issue that already exists in React 17 and below, but is even more important in React 18 because React yields to the browser during concurrent rendering, giving it a chance to recalculate layout. For more information, see the [Library Upgrade Guide for `<style>`](https://github.com/reactwg/react-18/discussions/110).
+* `useSyncExternalStore` é um novo Hook que permite que lojas externas suportem leituras concorrentes, forçando atualizações na loja a serem síncronas. Esta nova API é recomendada para qualquer biblioteca que se integre com estado externo ao React. Para mais informações, veja o [post de visão geral do useSyncExternalStore](https://github.com/reactwg/react-18/discussions/70) e [detalhes da API useSyncExternalStore](https://github.com/reactwg/react-18/discussions/86).
+* `useInsertionEffect` é um novo Hook que permite que bibliotecas CSS-in-JS resolvam problemas de desempenho ao injetar estilos na renderização. A menos que você já tenha construído uma biblioteca CSS-in-JS, não esperamos que você a utilize. Este Hook será executado após a mutação do DOM, mas antes que os efeitos de layout leiam o novo layout. Isso resolve um problema que já existe no React 17 e abaixo, mas é ainda mais importante no React 18, uma vez que o React cede espaço ao navegador durante a renderização concorrente, dando a ele a chance de recalcular o layout. Para mais informações, veja o [Guia de Atualização da Biblioteca para `<style>`](https://github.com/reactwg/react-18/discussions/110).
 
-React 18 also introduces new APIs for concurrent rendering such as `startTransition`, `useDeferredValue` and `useId`, which we share more about in the [release post](/blog/2022/03/29/react-v18).
+O React 18 também introduz novas APIs para renderização concorrente, como `startTransition`, `useDeferredValue` e `useId`, sobre as quais compartilhamos mais detalhes no [post de lançamento](/blog/2022/03/29/react-v18).
 
-## Updates to Strict Mode {/*updates-to-strict-mode*/}
+## Atualizações no Modo Estrito {/*updates-to-strict-mode*/}
 
-In the future, we'd like to add a feature that allows React to add and remove sections of the UI while preserving state. For example, when a user tabs away from a screen and back, React should be able to immediately show the previous screen. To do this, React would unmount and remount trees using the same component state as before.
+No futuro, gostaríamos de adicionar um recurso que permite ao React adicionar e remover seções da interface do usuário enquanto preserva o estado. Por exemplo, quando um usuário muda de tela e volta, o React deve ser capaz de mostrar imediatamente a tela anterior. Para fazer isso, o React desmontaria e remontaria árvores usando o mesmo estado do componente que antes.
 
-This feature will give React better performance out-of-the-box, but requires components to be resilient to effects being mounted and destroyed multiple times. Most effects will work without any changes, but some effects assume they are only mounted or destroyed once.
+Esse recurso proporcionará melhor desempenho ao React prontamente, mas requer que os componentes sejam resilientes a efeitos sendo montados e destruídos várias vezes. A maioria dos efeitos funcionará sem alterações, mas alguns efeitos assumem que são montados ou desmontados apenas uma vez.
 
-To help surface these issues, React 18 introduces a new development-only check to Strict Mode. This new check will automatically unmount and remount every component, whenever a component mounts for the first time, restoring the previous state on the second mount.
+Para ajudar a evidenciar esses problemas, o React 18 introduz uma nova verificação apenas para desenvolvimento no Modo Estrito. Esta nova verificação desmontará e remontará automaticamente cada componente sempre que um componente for montado pela primeira vez, restaurando o estado anterior na segunda montagem.
 
-Before this change, React would mount the component and create the effects:
-
-```
-* React mounts the component.
-    * Layout effects are created.
-    * Effect effects are created.
-```
-
-With Strict Mode in React 18, React will simulate unmounting and remounting the component in development mode:
+Antes dessa mudança, o React montaria o componente e criaria os efeitos:
 
 ```
-* React mounts the component.
-    * Layout effects are created.
-    * Effect effects are created.
-* React simulates unmounting the component.
-    * Layout effects are destroyed.
-    * Effects are destroyed.
-* React simulates mounting the component with the previous state.
-    * Layout effect setup code runs
-    * Effect setup code runs
+* O React monta o componente.
+    * Efeitos de layout são criados.
+    * Efeitos são criados.
 ```
 
-For more information, see the Working Group posts for [Adding Reusable State to StrictMode](https://github.com/reactwg/react-18/discussions/19) and [How to support Reusable State in Effects](https://github.com/reactwg/react-18/discussions/18).
+Com o Modo Estrito no React 18, o React simulará o desmontar e remontar do componente em modo de desenvolvimento:
 
-## Configuring Your Testing Environment {/*configuring-your-testing-environment*/}
+```
+* O React monta o componente.
+    * Efeitos de layout são criados.
+    * Efeitos são criados.
+* O React simula o desmontar do componente.
+    * Efeitos de layout são destruídos.
+    * Efeitos são destruídos.
+* O React simula a montagem do componente com o estado anterior.
+    * O código de configuração do efeito de layout é executado.
+    * O código de configuração do efeito é executado.
+```
 
-When you first update your tests to use `createRoot`, you may see this warning in your test console:
+Para mais informações, veja os posts do Grupo de Trabalho sobre [Adicionando Estado Reutilizável ao StrictMode](https://github.com/reactwg/react-18/discussions/19) e [Como suportar Estado Reutilizável em Efeitos](https://github.com/reactwg/react-18/discussions/18).
+
+## Configurando Seu Ambiente de Teste {/*configuring-your-testing-environment*/}
+
+Quando você atualizar seus testes para usar `createRoot`, você pode ver este aviso no console de testes:
 
 <ConsoleBlock level="error">
 
-The current testing environment is not configured to support act(...)
+O ambiente de teste atual não está configurado para suportar act(...)
 
 </ConsoleBlock>
 
-To fix this, set `globalThis.IS_REACT_ACT_ENVIRONMENT` to `true` before running your test:
+Para corrigir isso, defina `globalThis.IS_REACT_ACT_ENVIRONMENT` como `true` antes de rodar seu teste:
 
 ```js
-// In your test setup file
+// No seu arquivo de configuração de teste
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 ```
 
-The purpose of the flag is to tell React that it's running in a unit test-like environment. React will log helpful warnings if you forget to wrap an update with `act`.
+O propósito da flag é informar ao React que está rodando em um ambiente parecido com um teste unitário. O React registrará avisos úteis se você esquecer de envolver uma atualização com `act`.
 
-You can also set the flag to `false` to tell React that `act` isn't needed. This can be useful for end-to-end tests that simulate a full browser environment.
+Você também pode definir a flag como `false` para informar ao React que o `act` não é necessário. Isso pode ser útil para testes de ponta a ponta que simulam um ambiente completo de navegador.
 
-Eventually, we expect testing libraries will configure this for you automatically. For example, the [next version of React Testing Library has built-in support for React 18](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936) without any additional configuration.
+Eventualmente, esperamos que bibliotecas de teste configurem isso automaticamente para você. Por exemplo, a [próxima versão da React Testing Library tem suporte embutido para o React 18](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936) sem configuração adicional.
 
-[More background on the `act` testing API and related changes](https://github.com/reactwg/react-18/discussions/102) is available in the working group.
+[Mais informações sobre a API de teste `act` e mudanças relacionadas](https://github.com/reactwg/react-18/discussions/102) estão disponíveis no grupo de trabalho.
 
-## Dropping Support for Internet Explorer {/*dropping-support-for-internet-explorer*/}
+## Remoção do Suporte para Internet Explorer {/*dropping-support-for-internet-explorer*/}
 
-In this release, React is dropping support for Internet Explorer, which is [going out of support on June 15, 2022](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge). We’re making this change now because new features introduced in React 18 are built using modern browser features such as microtasks which cannot be adequately polyfilled in IE.
+Nesta versão, o React está removendo o suporte para Internet Explorer, que [sairá de suporte em 15 de junho de 2022](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge). Estamos fazendo esta mudança agora porque os novos recursos introduzidos no React 18 são construídos usando recursos modernos de navegadores, como microtarefas, que não podem ser adequadamente compatibilizados no IE.
 
-If you need to support Internet Explorer we recommend you stay with React 17.
+Se você precisa oferecer suporte ao Internet Explorer, recomendamos que fique com o React 17.
 
-## Deprecations {/*deprecations*/}
+## Descontinuidades {/*deprecations*/}
 
-* `react-dom`: `ReactDOM.render` has been deprecated. Using it will warn and run your app in React 17 mode.
-* `react-dom`: `ReactDOM.hydrate` has been deprecated. Using it will warn and run your app in React 17 mode.
-* `react-dom`: `ReactDOM.unmountComponentAtNode` has been deprecated.
-* `react-dom`: `ReactDOM.renderSubtreeIntoContainer` has been deprecated.
-* `react-dom/server`: `ReactDOMServer.renderToNodeStream` has been deprecated.
+* `react-dom`: `ReactDOM.render` foi descontinuado. Usá-lo emitirá avisos e executará seu aplicativo no modo React 17.
+* `react-dom`: `ReactDOM.hydrate` foi descontinuado. Usá-lo emitirá avisos e executará seu aplicativo no modo React 17.
+* `react-dom`: `ReactDOM.unmountComponentAtNode` foi descontinuado.
+* `react-dom`: `ReactDOM.renderSubtreeIntoContainer` foi descontinuado.
+* `react-dom/server`: `ReactDOMServer.renderToNodeStream` foi descontinuado.
 
-## Other Breaking Changes {/*other-breaking-changes*/}
+## Outras Mudanças Quebradoras {/*other-breaking-changes*/}
 
-* **Consistent useEffect timing**: React now always synchronously flushes effect functions if the update was triggered during a discrete user input event such as a click or a keydown event. Previously, the behavior wasn't always predictable or consistent.
-* **Stricter hydration errors**: Hydration mismatches due to missing or extra text content are now treated like errors instead of warnings. React will no longer attempt to "patch up" individual nodes by inserting or deleting a node on the client in an attempt to match the server markup, and will revert to client rendering up to the closest `<Suspense>` boundary in the tree. This ensures the hydrated tree is consistent and avoids potential privacy and security holes that can be caused by hydration mismatches.
-* **Suspense trees are always consistent:** If a component suspends before it's fully added to the tree, React will not add it to the tree in an incomplete state or fire its effects. Instead, React will throw away the new tree completely, wait for the asynchronous operation to finish, and then retry rendering again from scratch. React will render the retry attempt concurrently, and without blocking the browser.
-* **Layout Effects with Suspense**: When a tree re-suspends and reverts to a fallback, React will now clean up layout effects, and then re-create them when the content inside the boundary is shown again. This fixes an issue which prevented component libraries from correctly measuring layout when used with Suspense.
-* **New JS Environment Requirements**: React now depends on modern browsers features including `Promise`, `Symbol`, and `Object.assign`. If you support older browsers and devices such as Internet Explorer which do not provide modern browser features natively or have non-compliant implementations, consider including a global polyfill in your bundled application.
+* **Consistência no timing do useEffect**: O React agora sempre esvazia sincronamente funções de efeito se a atualização foi acionada durante um evento de entrada discreta do usuário, como um clique ou um evento keydown. Anteriormente, o comportamento não era sempre previsível ou consistente.
+* **Erros de hidratação mais rigorosos**: Desvios de hidratação devido a conteúdo de texto ausente ou extra agora são tratados como erros em vez de avisos. O React não tentará mais "corrigir" nós individuais inserindo ou excluindo um nó no cliente em uma tentativa de corresponder à marcação do servidor, e reverterá para a renderização do cliente até o limite mais próximo de `<Suspense>` na árvore. Isso garante que a árvore hidratada seja consistente e evita potenciais buracos de privacidade e segurança que podem ser causados por desvios de hidratação.
+* **As árvores do Suspense são sempre consistentes:** Se um componente suspender antes de ser totalmente adicionado à árvore, o React não o adicionará à árvore em um estado incompleto ou ativará seus efeitos. Em vez disso, o React descartará completamente a nova árvore, aguardará a operação assíncrona terminar e então tentará renderizar novamente do zero. O React renderizará a tentativa de nova renderização de forma concorrente e sem bloquear o navegador.
+* **Efeitos de Layout com Suspense**: Quando uma árvore volta a suspender e reverte para um fallback, o React agora limpará os efeitos de layout e, em seguida, os recriará quando o conteúdo dentro da fronteira for mostrado novamente. Isso corrige um problema que impedia bibliotecas de componentes de medir corretamente o layout quando usadas com Suspense.
+* **Novos Requisitos de Ambiente JS**: O React agora depende de recursos modernos de navegadores, incluindo `Promise`, `Symbol` e `Object.assign`. Se você oferece suporte a navegadores e dispositivos mais antigos, como o Internet Explorer, que não fornecem recursos modernos de navegador nativamente ou têm implementações não compatíveis, considere incluir um polyfill global em seu aplicativo empacotado.
 
-## Other Notable Changes {/*other-notable-changes*/}
+## Outras Mudanças Notáveis {/*other-notable-changes*/}
 
 ### React {/*react*/}
 
-* **Components can now render `undefined`:** React no longer warns if you return `undefined` from a component. This makes the allowed component return values consistent with values that are allowed in the middle of a component tree. We suggest to use a linter to prevent mistakes like forgetting a `return` statement before JSX.
-* **In tests, `act` warnings are now opt-in:** If you're running end-to-end tests, the `act` warnings are unnecessary. We've introduced an [opt-in](https://github.com/reactwg/react-18/discussions/102) mechanism so you can enable them only for unit tests where they are useful and beneficial.
-* **No warning about `setState` on unmounted components:** Previously, React warned about memory leaks when you call `setState` on an unmounted component. This warning was added for subscriptions, but people primarily run into it in scenarios where setting state is fine, and workarounds make the code worse. We've [removed](https://github.com/facebook/react/pull/22114) this warning.
-* **No suppression of console logs:** When you use Strict Mode, React renders each component twice to help you find unexpected side effects. In React 17, we've suppressed console logs for one of the two renders to make the logs easier to read. In response to [community feedback](https://github.com/facebook/react/issues/21783) about this being confusing, we've removed the suppression. Instead, if you have React DevTools installed, the second log's renders will be displayed in grey, and there will be an option (off by default) to suppress them completely.
-* **Improved memory usage:** React now cleans up more internal fields on unmount, making the impact from unfixed memory leaks that may exist in your application code less severe.
+* **Componentes agora podem renderizar `undefined`:** O React não avisa mais se você retornar `undefined` de um componente. Isso torna os valores de retorno permitidos para componentes consistentes com os valores que são permitidos no meio de uma árvore de componentes. Sugerimos usar um linter para evitar erros como esquecer uma declaração de `return` antes do JSX.
+* **Nos testes, avisos de `act` agora são opt-in:** Se você está executando testes de ponta a ponta, os avisos de `act` são desnecessários. Introduzimos um mecanismo de [opção opt-in](https://github.com/reactwg/react-18/discussions/102) para que você possa habilitá-los apenas para testes unitários onde eles são úteis e benéficos.
+* **Sem aviso sobre `setState` em componentes desmontados:** Anteriormente, o React avisava sobre vazamentos de memória quando você chamava `setState` em um componente desmontado. Este aviso foi adicionado para assinaturas, mas as pessoas encontram isso principalmente em cenários onde definir o estado é aceitável, e soluções alternativas pioram o código. Nós [removemos](https://github.com/facebook/react/pull/22114) este aviso.
+* **Sem supressão de logs no console:** Quando você usa o Modo Estrito, o React renderiza cada componente duas vezes para ajudá-lo a encontrar efeitos colaterais inesperados. No React 17, suprimimos logs do console para uma das duas renderizações para tornar os logs mais fáceis de ler. Em resposta ao [feedback da comunidade](https://github.com/facebook/react/issues/21783) sobre isso ser confuso, removemos a supressão. Em vez disso, se você tiver o React DevTools instalado, as renderizações do segundo log serão exibidas em cinza, e haverá uma opção (desativada por padrão) para suprimir completamente.
+* **Uso de memória melhorado:** O React agora limpa mais campos internos ao desmontar, tornando o impacto de vazamentos de memória não corrigidos que podem existir no código do seu aplicativo menos severo.
 
 ### React DOM Server {/*react-dom-server*/}
 
-* **`renderToString`:** Will no longer error when suspending on the server. Instead, it will emit the fallback HTML for the closest `<Suspense>` boundary and then retry rendering the same content on the client. It is still recommended that you switch to a streaming API like `renderToPipeableStream` or `renderToReadableStream` instead.
-* **`renderToStaticMarkup`:** Will no longer error when suspending on the server. Instead, it will emit the fallback HTML for the closest `<Suspense>` boundary.
+* **`renderToString`:** Não gerará mais erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para a fronteira `<Suspense>` mais próxima e, em seguida, tentará renderizar o mesmo conteúdo no cliente. Ainda é recomendado que você mude para uma API de streaming como `renderToPipeableStream` ou `renderToReadableStream`.
+* **`renderToStaticMarkup`:** Não gerará mais erro ao suspender no servidor. Em vez disso, emitirá o HTML de fallback para a fronteira `<Suspense>` mais próxima.
 
-## Changelog {/*changelog*/}
+## Registro de Mudanças {/*changelog*/}
 
-You can view the [full changelog here](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Você pode visualizar o [registro de mudanças completo aqui](https://github.com/facebook/react/blob/main/CHANGELOG.md).


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

	Refer to the source repository workflow that generated this translation for more details: https://github.com/NivaldoFarias/pt-br.react.dev

	Feel free to review and suggest any improvements to the translation.