### PR TITLE
Translate `react-19-upgrade-guide.md` to pt-br

### DIFF
--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -1,77 +1,78 @@
 ---
-title: "Guia de Atualização para o Beta do React 19"
+
+title: "Guia de Atualização do React 19 Beta"
 author: Ricky Hanlon
 date: 2024/04/25
-description: As melhorias adicionadas ao React 19 requerem algumas mudanças que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo através das etapas para atualizar bibliotecas para a versão beta do React 19.
+description: As melhorias adicionadas ao React 19 requerem algumas mudanças incompatíveis, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, iremos guiá-lo através das etapas para atualizar bibliotecas para o React 19 beta.
 ---
 
 25 de abril de 2024 por [Ricky Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
-<Note>
+<Nota>
 
-Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos alterações com base no feedback.
+Este lançamento beta é para que as bibliotecas se preparem para o React 19. Desenvolvedores de aplicativos devem atualizar para a versão 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos alterações com base no feedback.
 
-</Note>
+</Nota>
 
 
-<Intro>
+<Introdução>
 
-As melhorias adicionadas ao React 19 requerem algumas mudanças que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
+As melhorias adicionadas ao React 19 requerem algumas mudanças incompatíveis, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
 
-Para ajudar a tornar a atualização mais fácil, hoje também estamos publicando o React 18.3.
+Para ajudar a tornar a atualização mais fácil, estamos também publicando o React 18.3 hoje.
 
-</Intro>
+</Introdução>
 
-<Note>
+<Nota>
 
 #### O React 18.3 também foi publicado {/*react-18-3*/}
 
-Para ajudar a facilitar a atualização para o React 19, publicamos um lançamento `react@18.3` que é idêntico ao 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças necessárias para o React 19. 
+Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças que são necessárias para o React 19. 
 
 Recomendamos atualizar para o React 18.3 primeiro para ajudar a identificar quaisquer problemas antes de atualizar para o React 19.
 
-Para uma lista de mudanças no 18.3, consulte as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Para uma lista de mudanças na 18.3, consulte as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
 
-</Note>
+</Nota>
 
-Neste post, vamos guiá-lo através das etapas para atualizar bibliotecas para a versão beta do React 19:
+Neste post, iremos guiá-lo através das etapas para atualizar bibliotecas para o React 19 beta:
 
 - [Instalando](#installing)
-- [Mudanças quebrando a compatibilidade](#breaking-changes)
-- [Novas desativações](#new-deprecations)
+- [Mudanças incompatíveis](#breaking-changes)
+- [Novas obsolescências](#new-deprecations)
 - [Mudanças notáveis](#notable-changes)
 - [Mudanças no TypeScript](#typescript-changes)
-- [Notas de versão](#changelog)
+- [Changelog](#changelog)
 
-Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, consulte o [post de lançamento do React 19](/blog/2024/04/25/react-19).
+Se você gostaria de nos ajudar a testar o React 19, siga as etapas neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, consulte o [post de lançamento do React 19](/blog/2024/04/25/react-19).
 
 ---
 ## Instalando {/*installing*/}
 
-<Note>
+<Nota>
 
-#### Novo JSX Transform agora é obrigatório {/*new-jsx-transform-is-now-required*/}
+#### Novo Transform do JSX agora é obrigatório {/*new-jsx-transform-is-now-required*/}
 
-Introduzimos um [novo transformador JSX](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias de velocidade do JSX, que requerem o novo transformador.
+Introduzimos um [novo transform do JSX](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do bundle e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias na velocidade do JSX que requerem o novo transform.
 
-Se o novo transformador não estiver habilitado, você verá o seguinte aviso:
+Se o novo transform não estiver habilitado, você verá o seguinte aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Seu aplicativo (ou uma de suas dependências) está usando um transformador JSX obsoleto. Atualize para o transformador JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
+Seu aplicativo (ou uma de suas dependências) está usando um transform do JSX desatualizado. Atualize para o transform moderno do JSX para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
 
-Esperamos que a maioria dos aplicativos não seja afetada, pois o transformador já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, consulte o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Esperamos que a maioria dos aplicativos não seja afetada, uma vez que o transform já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, veja o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
-</Note>
+</Nota>
 
 
 Para instalar a versão mais recente do React e do React DOM:
@@ -80,7 +81,7 @@ Para instalar a versão mais recente do React e do React DOM:
 npm install react@beta react-dom@beta
 ```
 
-Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim que o React 19 for lançado como estável, você pode instalar os tipos normalmente de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser forçados no seu `package.json`:
+Se você estiver usando TypeScript, também precisa atualizar os tipos. Assim que o React 19 for liberado como estável, você poderá instalar os tipos normalmente a partir de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser impostos no seu `package.json`:
 
 ```json
 {
@@ -95,29 +96,29 @@ Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim
 }
 ```
 
-Estamos também incluindo um codemod para as substituições mais comuns. Consulte as [mudanças no TypeScript](#typescript-changes) abaixo.
+Estamos também incluindo um codemod para as substituições mais comuns. Veja [Mudanças no TypeScript](#typescript-changes) abaixo.
 
 
-## Mudanças quebrando a compatibilidade {/*breaking-changes*/}
+## Mudanças incompatíveis {/*breaking-changes*/}
 
-### Erros na renderização não são re-lançados {/*errors-in-render-are-not-re-thrown*/}
+### Erros no render não são mais relançados {/*errors-in-render-are-not-re-thrown*/}
 
-Nas versões anteriores do React, erros lançados durante a renderização eram capturados e relançados. Em DEV, também registrávamos em `console.error`, resultando em registros de erro duplicados. 
+Nas versões anteriores do React, erros lançados durante o render eram capturados e relançados. No modo DEV, também faríamos logs para `console.error`, resultando em logs de erro duplicados. 
 
-No React 19, [melhoramos como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação, não relançando:
+No React 19, melhoramos como os erros são tratados [/blog/2024/04/25/react-19#error-handling] para reduzir a duplicação ao não relançar:
 
-- **Erros Não Capturados**: Erros que não são capturados por um Boundary de Erro são relatados para `window.reportError`.
-- **Erros Capturados**: Erros que são capturados por um Boundary de Erro são relatados para `console.error`.
+- **Erros Não Capturados**: Erros que não são capturados por um Error Boundary são reportados para `window.reportError`.
+- **Erros Capturados**: Erros que são capturados por um Error Boundary são reportados para `console.error`.
 
-Essa mudança não deve impactar a maioria dos aplicativos, mas se sua relatória de erros em produção depende de erros sendo relançados, você pode precisar atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erros personalizado:
+Essa mudança não deve impactar a maioria dos aplicativos, mas se sua contabilidade de erro em produção depende de erros serem relançados, talvez você precise atualizar seu tratamento de erro. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erro personalizado:
 
 ```js [[1, 2, "onUncaughtError"], [2, 5, "onCaughtError"]]
 const root = createRoot(container, {
   onUncaughtError: (error, errorInfo) => {
-    // ... registrar relatório de erro
+    // ... log erro
   },
   onCaughtError: (error, errorInfo) => {
-    // ... registrar relatório de erro
+    // ... log erro
   }
 });
 ```
@@ -125,14 +126,14 @@ const root = createRoot(container, {
 Para mais informações, consulte a documentação para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
 
 
-### APIs obsoletas do React removidas {/*removed-deprecated-react-apis*/}
+### APIs do React obsoletas removidas {/*removed-deprecated-react-apis*/}
 
 #### Removido: `propTypes` e `defaultProps` para funções {/*removed-proptypes-and-defaultprops*/}
-`PropTypes` foram descontinuados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
+`PropTypes` foram obsoletados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
 
-No React 19, estamos removendo as verificações de `propType` do pacote React, e seu uso será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
+No React 19, estamos removendo as verificações de `propType` do pacote React, e usá-las será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipo.
 
-Estamos também removendo `defaultProps` de componentes de função em lugar de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, já que não há alternativa no ES6.
+Estamos também removendo `defaultProps` de componentes de função em vez de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, uma vez que não há alternativa do ES6.
 
 ```js
 // Antes
@@ -145,7 +146,7 @@ Heading.propTypes = {
   text: PropTypes.string,
 };
 Heading.defaultProps = {
-  text: 'Hello, world!',
+  text: 'Olá, mundo!',
 };
 ```
 ```ts
@@ -153,16 +154,16 @@ Heading.defaultProps = {
 interface Props {
   text?: string;
 }
-function Heading({text = 'Hello, world!'}: Props) {
+function Heading({text = 'Olá, mundo!'}: Props) {
   return <h1>{text}</h1>;
 }
 ```
 
 #### Removido: Contexto Legado usando `contextTypes` e `getChildContext` {/*removed-removing-legacy-context*/}
 
-O Contexto Legado foi descontinuado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
+O Contexto Legado foi obsoleto em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
 
-O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React um pouco menor e mais rápido.
+O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a erros sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React um pouco menor e mais rápido.
 
 Se você ainda estiver usando o Contexto Legado em componentes de classe, precisará migrar para a nova API `contextType`:
 
@@ -219,9 +220,9 @@ class Child extends React.Component {
 ```
 
 #### Removido: refs de string {/*removed-string-refs*/}
-Refs de string foram descontinuados em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+Refs de string foram obsoletos em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
-Componentes de classe suportavam refs de string antes de serem substituídos por callbacks de ref devido a [vários contratempos](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo refs de string para simplificar o React e torná-lo mais fácil de entender.
+Componentes de classe suportavam refs de string antes de serem substituídos por callbacks de ref devido a [múltiplas desvantagens](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo o uso de refs de string para tornar o React mais simples e fácil de entender.
 
 Se você ainda estiver usando refs de string em componentes de classe, precisará migrar para callbacks de ref:
 
@@ -251,16 +252,16 @@ class MyComponent extends React.Component {
 }
 ```
 
-<Note>
+<Nota>
 
-Para ajudar com a migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de `ref`. Siga [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para testá-lo.
+Para ajudar com a migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de `ref`. Acompanhe [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-lo.
 
-</Note>
+</Nota>
 
 #### Removido: Fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
-Fábricas de padrão de módulo foram descontinuadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
+Fábricas de padrão de módulo foram obsoletas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
 
-Esse padrão era raramente usado e seu suporte fazia com que o React fosse ligeiramente maior e mais lento do que o necessário. No React 19, estamos removendo o suporte a fábricas de padrão de módulo, e você precisará migrar para funções regulares:
+Esse padrão era raramente utilizado e seu suporte faz com que o React seja um pouco maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrão de módulo, e você precisará migrar para funções regulares:
 
 ```js
 // Antes
@@ -277,9 +278,9 @@ function FactoryComponent() {
 ```
 
 #### Removido: `React.createFactory` {/*removed-createfactory*/}
-`createFactory` foi descontinuado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
+`createFactory` foi obsoleto em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
 
-Usar `createFactory` era comum antes do amplo suporte ao JSX, mas hoje é raramente utilizado e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
+Usar `createFactory` era comum antes do amplo suporte a JSX, mas agora é raramente utilizado e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
 
 ```js
 // Antes
@@ -295,7 +296,7 @@ const button = <button />;
 
 #### Removido: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
 
-No React 18, atualizamos `react-test-renderer/shallow` para re-exportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir instalar o pacote diretamente:
+No React 18, atualizamos `react-test-renderer/shallow` para reexportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir instalar o pacote diretamente:
 
 ```bash
 npm install react-shallow-renderer --save-dev
@@ -305,15 +306,15 @@ npm install react-shallow-renderer --save-dev
 + import ShallowRenderer from 'react-shallow-renderer';
 ```
 
-<Note>
+<Nota>
 
-##### Por favor, reconsidere a renderização superficial {/*please-reconsider-shallow-rendering*/}
+##### Por favor, repense a renderização superficial {/*please-reconsider-shallow-rendering*/}
 
-A renderização superficial depende dos internos do React e pode bloqueá-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
+A renderização superficial depende de internos do React e pode bloqueá-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
 
-</Note>
+</Nota>
 
-### APIs obsoletas do React DOM removidas {/*removed-deprecated-react-dom-apis*/}
+### APIs do React DOM obsoletas removidas {/*removed-deprecated-react-dom-apis*/}
 
 #### Removido: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
 
@@ -323,7 +324,7 @@ Movemos `act` de `react-dom/test-utils` para o pacote `react`:
 
 <ConsoleLogLine level="error">
 
-`ReactDOMTestUtils.act` está obsoleto em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Consulte https://react.dev/warnings/react-dom-test-utils para mais informações.
+`ReactDOMTestUtils.act` está obsoleto em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
 
 </ConsoleLogLine>
 
@@ -336,13 +337,13 @@ Para corrigir esse aviso, você pode importar `act` de `react`:
 + import {act} from 'react';
 ```
 
-Todas as outras funções de `test-utils` foram removidas. Essas utilidades eram incomuns e facilitavam demais a dependência de detalhes de implementação de baixo nível dos seus componentes e do React. No React 19, essas funções gerarão erro quando chamadas e suas exportações serão removidas em uma versão futura.
+Todas as outras funções `test-utils` foram removidas. Essas utilidades eram incomuns e facilitavam demais depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão erro quando chamadas e suas exportações serão removidas em uma versão futura.
 
-Consulte a [página de aviso](https://react.dev/warnings/react-dom-test-utils) para alternativas.
+Veja a [página de avisos](https://react.dev/warnings/react-dom-test-utils) para alternativas.
 
 #### Removido: `ReactDOM.render` {/*removed-reactdom-render*/}
 
-`ReactDOM.render` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para usar [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
+`ReactDOM.render` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
 
 ```js
 // Antes
@@ -357,7 +358,7 @@ root.render(<App />);
 
 #### Removido: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
 
-`ReactDOM.hydrate` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para usar [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
+`ReactDOM.hydrate` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
 
 ```js
 // Antes
@@ -372,8 +373,7 @@ hydrateRoot(document.getElementById('root'), <App />);
 
 #### Removido: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
 
-`ReactDOM.unmountComponentAtNode` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para usar `root.unmount()`.
-
+`ReactDOM.unmountComponentAtNode` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para `root.unmount()`.
 
 ```js
 // Antes
@@ -387,9 +387,9 @@ Para mais informações, consulte `root.unmount()` para [`createRoot`](https://r
 
 
 #### Removido: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
-`ReactDOM.findDOMNode` foi [descontinuado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
+`ReactDOM.findDOMNode` foi [obsoleto em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
 
-Estamos removendo `findDOMNode` porque era uma saída de legado que era lenta para executar, frágil a refatorações, retornava apenas o primeiro filho e quebrava os níveis de abstração (consulte mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
+Estamos removendo `findDOMNode` porque era um escape hatch legado que era lento para executar, frágil à refatoração, retornava apenas o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
 
 ```js
 // Antes
@@ -417,19 +417,19 @@ function AutoselectingInput() {
 }
 ```
 
-## Novas desativações {/*new-deprecations*/}
+## Novas obsolescências {/*new-deprecations*/}
 
 ### Obsoleto: `element.ref` {/*deprecated-element-ref*/}
 
-O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos descontinuando o `element.ref` em lugar de `element.props.ref`.
+O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos tornando obsoleto `element.ref` em vez de `element.props.ref`.
 
-Acessar `element.ref` gerará aviso:
+Acessar `element.ref` irá gerar um aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Acessar element.ref não é mais suportado. ref agora é uma prop regular. Ele será removido do tipo Elemento JSX em uma versão futura.
+Acesso a element.ref não é mais suportado. ref é agora uma prop comum. Ele será removido do tipo JSX Element em um futuro lançamento.
 
 </ConsoleLogLine>
 
@@ -437,27 +437,27 @@ Acessar element.ref não é mais suportado. ref agora é uma prop regular. Ele s
 
 ### Obsoleto: `react-test-renderer` {/*deprecated-react-test-renderer*/}
 
-Estamos descontinuando `react-test-renderer` porque implementa seu próprio ambiente de renderização que não corresponde ao ambiente que os usuários usam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
+Estamos tornando `react-test-renderer` obsoleto porque implementa seu próprio ambiente de renderizador que não coincidem com o ambiente que os usuários utilizam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
 
-O test renderer foi criado antes que estratégias de teste mais viáveis estivessem disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de teste moderna.
+O renderizador de teste foi criado antes que houvesse estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de testes moderna.
 
-No React 19, `react-test-renderer` registra um aviso de desativação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
+No React 19, `react-test-renderer` gera um aviso de obsolescência e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
 
 ## Mudanças notáveis {/*notable-changes*/}
 
 ### Mudanças no StrictMode {/*strict-mode-improvements*/}
 
-O React 19 inclui várias correções e melhorias ao Strict Mode.
+O React 19 inclui várias correções e melhorias no Strict Mode.
 
-Ao fazer a renderização dupla no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem perceber nenhuma diferença no comportamento.
+Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem notar uma diferença no comportamento.
 
-Como em todos os comportamentos do Strict Mode, esses recursos são projetados para proativamente expor bugs em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode invocará em dobro funções de callback de refs na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
+Como com todos os comportamentos do Strict Mode, esses recursos são projetados para destacar proativamente erros em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode chamará duas vezes as funções de callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
 
-### Builds UMD removidas {/*umd-builds-removed*/}
+### Construtores UMD removidos {/*umd-builds-removed*/}
 
-UMD foi amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais builds UMD para reduzir a complexidade de seu processo de teste e lançamento. 
+UMD era amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais construtores UMD para reduzir a complexidade de seu processo de teste e lançamento. 
 
-Para carregar o React 19 com uma tag de script, recomendamos usar uma CDN baseada em ESM como [esm.sh](https://esm.sh/).
+Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado em ESM, como [esm.sh](https://esm.sh/).
 
 ```html
 <script type="module">
@@ -467,11 +467,11 @@ Para carregar o React 19 com uma tag de script, recomendamos usar uma CDN basead
 </script>
 ```
 
-### Bibliotecas que dependem dos internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
+### Bibliotecas dependendo de internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
 
-Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para realizar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
+Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para a melhoria de recursos no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
 
-Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não são listadas como mudanças quebrando a compatibilidade, e não estamos incluindo documentos para como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
+Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças incompatíveis, e não estamos incluindo documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
 
 Para refletir o impacto de usar internos, renomeamos o sufixo `SECRET_INTERNALS` para: 
 
@@ -481,64 +481,64 @@ No futuro, bloquearemos mais agressivamente o acesso a internos do React para de
 
 ## Mudanças no TypeScript {/*typescript-changes*/}
 
-### Removed deprecated TypeScript types {/*removed-deprecated-typescript-types*/}
+### Tipos TypeScript obsoletos removidos {/*removed-deprecated-typescript-types*/}
 
-Limpeza dos tipos TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
+Limparamos os tipos TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
 
-<Note>
-Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças quebrando a compatibilidade relacionadas a tipos:
+<Nota>
+Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças de quebra relacionadas a tipos:
 
 ```bash
 npx types-react-codemod@latest preset-19 ./path-to-app
 ```
 
-Se você tem muito acesso não seguro a `element.props`, pode executar este codemod adicional:
+Se você tiver um acesso muito inseguro a `element.props`, pode executar esse codemod adicional:
 
 ```bash
 npx types-react-codemod@latest react-element-default-any-props ./path-to-your-react-ts-files
 ```
 
-</Note>
+</Nota>
 
-Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você achar que falta um codemod, isso pode ser rastreado na [lista de codemods do React 19 que estão faltando](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
+Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você sentir que um codemod está faltando, isso pode ser rastreado na [lista de codemods faltantes do React 19](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
 
 
-### Limpeza de `ref` necessária {/*ref-cleanup-required*/}
+### Limpezas de `ref` necessárias {/*ref-cleanup-required*/}
 
 _Essa mudança está incluída no preset codemod `react-19` como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
 
-Devido à introdução de funções de limpeza de refs, retornar qualquer outra coisa de um callback de ref será agora rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
+Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de uma callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
+O código original retornou a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
 
 ### `useRef` requer um argumento {/*useref-requires-argument*/}
 
 _Essa mudança está incluída no preset codemod `react-19` como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
 
-Uma reclamação de longa data sobre como TypeScript e React funcionam foi `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
+Uma reclamação de longa data sobre como TypeScript e React funcionam era sobre `useRef`. Mudamos os tipos para que `useRef` agora requeira um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
 
 ```ts
-// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
+// @ts-expect-error: Expected 1 argument but saw none
 useRef();
 // Passa
 useRef(undefined);
-// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
+// @ts-expect-error: Expected 1 argument but saw none
 createContext();
 // Passa
 createContext(undefined);
 ```
 
-Isso agora também significa que todas as refs são mutáveis. Você não encontrará mais o problema em que não pode mutar uma ref porque você a inicializou com `null`:
+Isso também significa que todas as refs são mutáveis. Você não encontrará mais o problema em que não pode mutar uma ref porque a inicializou com `null`:
 
 ```ts
 const ref = useRef<number>(null);
 
-// Não é possível atribuir a 'current' porque é uma propriedade de somente leitura
+// Cannot assign to 'current' because it is a read-only property
 ref.current = 1;
 ```
 
@@ -552,36 +552,36 @@ interface RefObject<T> {
 declare function useRef<T>: RefObject<T>
 ```
 
-`useRef` ainda tem uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento necessário para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que automáticamente retorna `RefObject<T | undefined>`.
+`useRef` ainda possui uma sobrecarga de conveniência para `useRef<T>(null)` que retorna automaticamente `RefObject<T | null>`. Para facilitar a migração devido ao argumento necessário para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que retorna automaticamente `RefObject<T | undefined>`.
 
-Consulte [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
+Confira [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
 
 ### Mudanças no tipo TypeScript `ReactElement` {/*changes-to-the-reactelement-typescript-type*/}
 
 _Essa mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
 
-As `props` dos elementos React agora têm como padrão `unknown` em vez de `any` se o elemento for tipado como `ReactElement`. Isso não o afeta se você passar um argumento de tipo para `ReactElement`:
+As `props` dos elementos React agora padrão para `unknown` em vez de `any` se o elemento estiver tipado como `ReactElement`. Isso não o afeta se você passar um argumento de tipo para `ReactElement`:
 
 ```ts
 type Example2 = ReactElement<{ id: string }>["props"];
 //   ^? { id: string }
 ```
 
-Mas se você confiava no padrão, agora precisa lidar com `unknown`:
+Mas se você confiou no padrão, agora precisa lidar com `unknown`:
 
 ```ts
 type Example = ReactElement["props"];
 //   ^? Antes, era 'any', agora 'unknown'
 ```
 
-Você só deve precisar disso se tiver muito código legado dependendo do acesso não seguro das props do elemento. A introspecção de elementos existe apenas como uma saída e você deve deixar explícito que seu acesso a props é inseguro através de um `any` explícito.
+Você só precisará disso se tiver muito código legado dependendo do acesso inseguro das props do elemento. A introspecção de elementos existe apenas como um escape hatch, e você deve deixar explícito que seu acesso às props é inseguro por meio de um `any` explícito.
 
 ### O namespace JSX no TypeScript {/*the-jsx-namespace-in-typescript*/}
 Essa mudança está incluída no preset codemod `react-19` como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
 
-Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a evitar poluição de tipos globais que impede conflitos entre diferentes bibliotecas de UI que usam JSX.
+Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais, o que impede conflitos entre diferentes bibliotecas de UI que utilizam JSX.
 
-Agora você precisará envolver a augmentação de módulo do namespace JSX em `declare module "....":
+Você agora precisará envolver a alteração de módulo do namespace JSX em `declare module "....":
 
 ```diff
 // global.d.ts
@@ -596,44 +596,44 @@ Agora você precisará envolver a augmentação de módulo do namespace JSX em `
 + }
 ```
 
-O especificador de módulo exato depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
+O especificador exato do módulo depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
 
 - Para `"jsx": "react-jsx"` seria `react/jsx-runtime`.
 - Para `"jsx": "react-jsxdev"` seria `react/jsx-dev-runtime`.
 - Para `"jsx": "react"` e `"jsx": "preserve"` seria `react`.
 
-### Melhores tipagens para `useReducer` {/*better-usereducer-typings*/}
+### Melhores tipos para `useReducer` {/*better-usereducer-typings*/}
 
-`useReducer` agora tem melhor inferência de tipo graças a [@mfp22](https://github.com/mfp22).
+`useReducer` agora tem uma inferência de tipo melhorada graças a [@mfp22](https://github.com/mfp22).
 
-No entanto, isso exigiu uma mudança quebrando a compatibilidade onde `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos os tipos de estado e ação.
+No entanto, isso exigiu uma mudança incompatível em que `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e depender da tipagem contextual) ou precisa de ambos, o tipo de estado e o tipo de ação.
 
 A nova melhor prática é _não_ passar argumentos de tipo para `useReducer`.
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer(reducer)
 ```
-Isso pode não funcionar em casos extremos onde você pode tipar explicitamente o estado e a ação, passando a `Action` em uma tupla:
+Isso pode não funcionar em casos extremos onde você pode digitar explicitamente o estado e a ação, passando o `Action` em uma tupla:
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer<State, [Action]>(reducer)
 ```
-Se você definir o redutor inline, incentivamos a anotar os parâmetros da função em vez disso:
+Se você definir o redutor em linha, aconselhamos a anotar os parâmetros da função:
 ```diff
 - useReducer<React.Reducer<State, Action>>((state, action) => state)
 + useReducer((state: State, action: Action) => state)
 ```
-Isso também é o que você teria que fazer se mover o redutor para fora da chamada de `useReducer`:
+Isso também é o que você teria que fazer se movesse o redutor para fora da chamada `useReducer`:
 
 ```ts
 const reducer = (state: State, action: Action) => state;
 ```
 
-## Notas de versão {/*changelog*/}
+## Changelog {/*changelog*/}
 
-### Outras mudanças quebrando a compatibilidade {/*other-breaking-changes*/}
+### Outras mudanças incompatíveis {/*other-breaking-changes*/}
 
-- **react-dom**: Erro para URLs JavaScript em src/href [#26507](https://github.com/facebook/react/pull/26507)
+- **react-dom**: Erro para URLs javascript em src/href [#26507](https://github.com/facebook/react/pull/26507)
 - **react-dom**: Remover `errorInfo.digest` de `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
 - **react-dom**: Remover `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
 - **react-dom**: Remover `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
@@ -643,15 +643,15 @@ const reducer = (state: State, action: Action) => state;
 
 ### Outras mudanças notáveis {/*other-notable-changes*/}
 
-- **react**: Lotes sincronos, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
-- **react**: Não pré-renderizar irmãos de componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
-- **react**: Detectar loops de atualização infinitos causados por atualizações da fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
+- **react**: Lanes de sync, default e contínuas [#25700](https://github.com/facebook/react/pull/25700)
+- **react**: Não pré-renderizar irmãos do componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
+- **react**: Detectar loops de atualização infinitos causados por atualizações na fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
 - **react-dom**: Transições em popstate agora são síncronas [#26025](https://github.com/facebook/react/pull/26025)
 - **react-dom**: Remover aviso de efeito de layout durante SSR [#26395](https://github.com/facebook/react/pull/26395)
-- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags de anexo) [#28124](https://github.com/facebook/react/pull/28124)
+- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags ancla) [#28124](https://github.com/facebook/react/pull/28124)
 
 Publicaremos o changelog completo com o lançamento estável do React 19.
 
 ---
 
-Obrigado a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) pela revisão e edição deste post.
+Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) por revisar e editar este post.

--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -1,8 +1,8 @@
 ---
-title: "Guia de Atualização para o React 19 Beta"
+title: "Guia de Atualização do React 19 Beta"
 author: Ricky Hanlon
 date: 2024/04/25
-description: As melhorias adicionadas ao React 19 exigem algumas mudanças quebradoras, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta.
+description: As melhorias adicionadas ao React 19 requerem algumas mudanças que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo através das etapas para atualizar bibliotecas para o React 19 beta.
 ---
 
 25 de abril de 2024 por [Ricky Hanlon](https://twitter.com/rickhanlonii)
@@ -11,14 +11,14 @@ description: As melhorias adicionadas ao React 19 exigem algumas mudanças quebr
 
 <Note>
 
-Esta versão beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
+Esta versão beta é para bibliotecas se prepararem para o React 19. Os desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
 
 <Intro>
 
-As melhorias adicionadas ao React 19 exigem algumas mudanças quebradoras, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
+As melhorias adicionadas ao React 19 requerem algumas mudanças que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
 
 Para ajudar a facilitar a atualização, hoje também estamos publicando o React 18.3.
 
@@ -28,7 +28,7 @@ Para ajudar a facilitar a atualização, hoje também estamos publicando o React
 
 #### O React 18.3 também foi publicado {/*react-18-3*/}
 
-Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs depreciadas e outras mudanças necessárias para o React 19. 
+Para ajudar a facilitar a atualização para o React 19, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças necessárias para o React 19. 
 
 Recomendamos atualizar para o React 18.3 primeiro para ajudar a identificar quaisquer problemas antes de atualizar para o React 19.
 
@@ -36,40 +36,40 @@ Para uma lista de mudanças na 18.3, veja as [Notas de Lançamento](https://gith
 
 </Note>
 
-Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta:
+Neste post, vamos guiá-lo através das etapas para atualizar bibliotecas para o React 19 beta:
 
 - [Instalação](#installing)
-- [Mudanças quebradoras](#breaking-changes)
-- [Novas deprecações](#new-deprecations)
+- [Mudanças que quebram a compatibilidade](#breaking-changes)
+- [Novas desativações](#new-deprecations)
 - [Mudanças notáveis](#notable-changes)
 - [Mudanças no TypeScript](#typescript-changes)
 - [Changelog](#changelog)
 
-Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [reporte quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, veja o [post de lançamento do React 19](/blog/2024/04/25/react-19).
+Se você gostaria de nos ajudar a testar o React 19, siga as etapas neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, veja o [post de lançamento do React 19](/blog/2024/04/25/react-19).
 
 ---
 ## Instalação {/*installing*/}
 
 <Note>
 
-#### Novo transformador JSX agora é necessário {/*new-jsx-transform-is-now-required*/}
+#### O Novo JSX Transform agora é obrigatório {/*new-jsx-transform-is-now-required*/}
 
-Introduzimos um [novo transformador JSX](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias de velocidade do JSX que requerem o novo transformador.
+Introduzimos um [novo JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do bundle e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias de velocidade do JSX que requerem o novo transform.
 
-Se o novo transformador não estiver habilitado, você verá este aviso:
+Se o novo transform não estiver habilitado, você verá este aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Seu aplicativo (ou uma de suas dependências) está usando um transformador JSX desatualizado. Atualize para o transformador JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
+Seu aplicativo (ou uma de suas dependências) está usando um transform JSX desatualizado. Atualize para o transform JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
 
-Esperamos que a maioria dos aplicativos não seja afetada, pois o transformador já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, veja o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Esperamos que a maioria dos aplicativos não seja afetada, uma vez que o transform já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, veja o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
 </Note>
 
@@ -80,7 +80,7 @@ Para instalar a versão mais recente do React e do React DOM:
 npm install react@beta react-dom@beta
 ```
 
-Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim que o React 19 for lançado como estável, você pode instalar os tipos como de costume de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser impostos em seu `package.json`:
+Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim que o React 19 for lançado como estável, você poderá instalar os tipos como de costume do `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser aplicados no seu `package.json`:
 
 ```json
 {
@@ -98,18 +98,18 @@ Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim
 Também estamos incluindo um codemod para as substituições mais comuns. Veja [Mudanças no TypeScript](#typescript-changes) abaixo.
 
 
-## Mudanças quebradoras {/*breaking-changes*/}
+## Mudanças que quebram a compatibilidade {/*breaking-changes*/}
 
-### Erros na renderização não são mais relançados {/*errors-in-render-are-not-re-thrown*/}
+### Erros na renderização não são re-lançados {/*errors-in-render-are-not-re-thrown*/}
 
-Nas versões anteriores do React, erros lançados durante a renderização eram capturados e relançados. No ambiente de desenvolvimento (DEV), também registrávamos no `console.error`, resultando em logs de erro duplicados. 
+Nas versões anteriores do React, os erros lançados durante a renderização eram capturados e relançados. No DEV, também registraríamos no `console.error`, resultando em logs de erro duplicados. 
 
 No React 19, melhoramos [como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação ao não relançar:
 
-- **Erros Não Capturados**: Erros que não são capturados por um Error Boundary são reportados para `window.reportError`.
-- **Erros Capturados**: Erros que são capturados por um Error Boundary são reportados para `console.error`.
+- **Erros Não Capturados**: Erros que não são capturados por um Boundary de Erro são relatados para `window.reportError`.
+- **Erros Capturados**: Erros que são capturados por um Boundary de Erro são relatados para `console.error`.
 
-Essa mudança não deve impactar a maioria dos aplicativos, mas se o seu relatório de erro em produção depender do relançamento de erros, pode ser necessário atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erro personalizado:
+Essa mudança não deve impactar a maioria dos aplicativos, mas se sua reportagem de erro em produção depender de erros serem relançados, você pode precisar atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos ao `createRoot` e `hydrateRoot` para tratamento de erros personalizado:
 
 ```js [[1, 2, "onUncaughtError"], [2, 5, "onCaughtError"]]
 const root = createRoot(container, {
@@ -122,17 +122,17 @@ const root = createRoot(container, {
 });
 ```
 
-Para mais informações, veja a documentação de [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
+Para mais informações, veja a documentação para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
 
 
-### APIs React depreciadas removidas {/*removed-deprecated-react-apis*/}
+### APIs do React obsoletas removidas {/*removed-deprecated-react-apis*/}
 
 #### Removido: `propTypes` e `defaultProps` para funções {/*removed-proptypes-and-defaultprops*/}
-`PropTypes` foram depreciados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
+`PropTypes` foram descontinuados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
 
-No React 19, estamos removendo as verificações `propType` do pacote React, e usá-las será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
+No React 19, estamos removendo as verificações de `propType` do pacote React, e usá-las será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
 
-Estamos também removendo `defaultProps` de componentes de função em favor de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, pois não há uma alternativa em ES6.
+Estamos também removendo `defaultProps` de componentes de função em favor de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, uma vez que não há alternativa do ES6.
 
 ```js
 // Antes
@@ -160,7 +160,7 @@ function Heading({text = 'Hello, world!'}: Props) {
 
 #### Removido: Contexto Legado usando `contextTypes` e `getChildContext` {/*removed-removing-legacy-context*/}
 
-O Contexto Legado foi depreciado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
+O Contexto Legado foi descontinuado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
 
 O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React ligeiramente menor e mais rápido.
 
@@ -218,12 +218,12 @@ class Child extends React.Component {
 }
 ```
 
-#### Removido: refs de string {/*removed-string-refs*/}
-Refs de string foram depreciadas em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+#### Removido: referências de string {/*removed-string-refs*/}
+Referências de string foram descontinuadas em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
-Componentes de classe suportavam refs de string antes de serem substituídas por callbacks de ref devido a [vários problemas](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo refs de string para simplificar o React e torná-lo mais fácil de entender.
+Componentes de classe suportavam referências de string antes de serem substituídas por callbacks de ref devido a [vários inconvenientes](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo referências de string para simplificar o React e torná-lo mais fácil de entender.
 
-Se você ainda estiver usando refs de string em componentes de classe, precisará migrar para callbacks de ref:
+Se você ainda estiver usando referências de string em componentes de classe, precisará migrar para callbacks de ref:
 
 ```js {4,8}
 // Antes
@@ -253,14 +253,14 @@ class MyComponent extends React.Component {
 
 <Note>
 
-Para ajudar na migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de `ref`. Siga [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-lo.
+Para ajudar na migração, estaremos publicando um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente referências de string por callbacks de `ref`. Siga [esta PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-la.
 
 </Note>
 
-#### Removido: Fábricas de padrões de módulo {/*removed-module-pattern-factories*/}
-Fábricas de padrões de módulo foram depreciadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
+#### Removido: Fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
+Fábricas de padrão de módulo foram descontinuadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
 
-Esse padrão foi raramente usado e seu suporte faz o React ser um pouco maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrões de módulo, e você precisará migrar para funções regulares:
+Esse padrão era raramente usado e suportá-lo causa o React a ser ligeiramente maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrão de módulo, e você precisará migrar para funções regulares:
 
 ```js
 // Antes
@@ -277,9 +277,9 @@ function FactoryComponent() {
 ```
 
 #### Removido: `React.createFactory` {/*removed-createfactory*/}
-`createFactory` foi depreciado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
+`createFactory` foi descontinuado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
 
-Usar `createFactory` era comum antes do amplo suporte ao JSX, mas é raramente usado hoje e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
+Usar `createFactory` era comum antes do suporte amplo para JSX, mas é raramente usado hoje e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
 
 ```js
 // Antes
@@ -307,23 +307,23 @@ npm install react-shallow-renderer --save-dev
 
 <Note>
 
-##### Por favor, reconsidere a renderização superficial {/*please-reconsider-shallow-rendering*/}
+##### Por favor, reconsidere a renderização superficial{/*please-reconsider-shallow-rendering*/}
 
-A renderização superficial depende de internos do React e pode bloquear futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
+A renderização superficial depende de internals do React e pode bloquear você de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started).
 
 </Note>
 
-### APIs React DOM depreciadas removidas {/*removed-deprecated-react-dom-apis*/}
+### APIs do React DOM obsoletas removidas {/*removed-deprecated-react-dom-apis*/}
 
 #### Removido: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
 
-Mudamos `act` de `react-dom/test-utils` para o pacote `react`:
+Movemos `act` de `react-dom/test-utils` para o pacote `react`:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-`ReactDOMTestUtils.act` é depreciado em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
+`ReactDOMTestUtils.act` está obsoleto em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
 
 </ConsoleLogLine>
 
@@ -336,13 +336,13 @@ Para corrigir este aviso, você pode importar `act` de `react`:
 + import {act} from 'react';
 ```
 
-Todas as outras funções de `test-utils` foram removidas. Esses utilitários eram incomuns e tornavam muito fácil depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão um erro quando chamadas e suas exportações serão removidas em uma versão futura.
+Todas as outras funções `test-utils` foram removidas. Esses utilitários eram incomuns, e tornavam muito fácil depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão erro quando chamadas e suas exportações serão removidas em uma versão futura.
 
 Veja a [página de aviso](https://react.dev/warnings/react-dom-test-utils) para alternativas.
 
 #### Removido: `ReactDOM.render` {/*removed-reactdom-render*/}
 
-`ReactDOM.render` foi depreciado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para usar [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
+`ReactDOM.render` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para usar [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
 
 ```js
 // Antes
@@ -357,7 +357,7 @@ root.render(<App />);
 
 #### Removido: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
 
-`ReactDOM.hydrate` foi depreciado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate`, você precisará migrar para usar [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
+`ReactDOM.hydrate` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para usar [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
 
 ```js
 // Antes
@@ -372,7 +372,7 @@ hydrateRoot(document.getElementById('root'), <App />);
 
 #### Removido: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
 
-`ReactDOM.unmountComponentAtNode` foi depreciado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para usar `root.unmount()`.
+`ReactDOM.unmountComponentAtNode` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para usar `root.unmount()`.
 
 
 ```js
@@ -383,13 +383,13 @@ unmountComponentAtNode(document.getElementById('root'));
 root.unmount();
 ```
 
-Para mais informações, veja `root.unmount()` para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
+Para mais informações veja `root.unmount()` para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
 
 
 #### Removido: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
-`ReactDOM.findDOMNode` foi [depreciado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
+`ReactDOM.findDOMNode` foi [descontinuado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
 
-Estamos removendo `findDOMNode` porque era uma alternativa legada que era lenta para executar, frágil à refatoração, apenas retornava o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
+Estamos removendo `findDOMNode` porque era uma saída legada que tinha desempenho lento, era frágil em refatorações, retornava apenas o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
 
 ```js
 // Antes
@@ -417,31 +417,31 @@ function AutoselectingInput() {
 }
 ```
 
-## Novas deprecações {/*new-deprecations*/}
+## Novas desativações {/*new-deprecations*/}
 
-### Depecado: `element.ref` {/*deprecated-element-ref*/}
+### Obsoleto: `element.ref` {/*deprecated-element-ref*/}
 
-O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos depreciando `element.ref` em vez de `element.props.ref`.
+O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), portanto estamos descontinuando o `element.ref` em favor de `element.props.ref`.
 
-Acessar `element.ref` gerará um aviso:
+Acessar `element.ref` irá gerar um aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Acessar element.ref não é mais suportado. ref agora é uma prop regular. Ele será removido do tipo JSX Element em uma versão futura.
+Acessar element.ref não é mais suportado. ref agora é uma prop regular. Ele será removido do tipo Elemento JSX em uma versão futura.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### Depecado: `react-test-renderer` {/*deprecated-react-test-renderer*/}
+### Obsoleto: `react-test-renderer` {/*deprecated-react-test-renderer*/}
 
-Estamos depreciando `react-test-renderer` porque implementa seu próprio ambiente de renderização que não corresponde ao ambiente que os usuários usam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
+Estamos descontinuando `react-test-renderer` porque ele implementa seu próprio ambiente de renderização que não corresponde ao ambiente que os usuários utilizam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
 
 O renderizador de teste foi criado antes que houvesse estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de teste moderna em vez disso.
 
-No React 19, `react-test-renderer` registra um aviso de deprecação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
+No React 19, `react-test-renderer` gera um aviso de desativação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
 
 ## Mudanças notáveis {/*notable-changes*/}
 
@@ -449,13 +449,13 @@ No React 19, `react-test-renderer` registra um aviso de deprecação e mudou par
 
 O React 19 inclui várias correções e melhorias no Strict Mode.
 
-Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem notar diferença no comportamento.
+Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem perceber uma diferença no comportamento.
 
-Como acontece com todos os comportamentos do Strict Mode, esses recursos são projetados para detectar proativamente erros em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode invocará duas vezes as funções de callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
+Como com todas as funcionalidades do Strict Mode, esses recursos foram projetados para fazer surgir proativamente bugs em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes que sejam enviados para a produção. Por exemplo, durante o desenvolvimento, o Strict Mode invocará duas vezes as funções callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
 
 ### Builds UMD removidas {/*umd-builds-removed*/}
 
-UMD era amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais builds UMD para reduzir a complexidade de seu processo de teste e lançamento. 
+UMD foi amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de build. Agora, há alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais builds UMD para reduzir a complexidade de seu processo de teste e lançamento. 
 
 Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado em ESM como [esm.sh](https://esm.sh/).
 
@@ -467,32 +467,32 @@ Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado
 </script>
 ```
 
-### Bibliotecas dependendo de internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
+### Bibliotecas que dependem dos internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
 
-Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para implementar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
+Esta versão inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para implementar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
 
-Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças quebradoras e não incluiremos documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
+Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças que quebram a compatibilidade, e não estamos incluindo documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
 
-Para refletir o impacto do uso de internos, renomeamos o sufixo `SECRET_INTERNALS` para: 
+Para refletir o impacto de usar internos, renomeamos o sufixo `SECRET_INTERNALS` para: 
 
 `_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`
 
-No futuro, bloquearemos de forma mais agressiva o acesso a internos do React para desencorajar o uso e garantir que os usuários não sejam bloqueados de atualizar.
+No futuro, bloquearemos mais agressivamente o acesso a internos do React para desencorajar o uso e garantir que os usuários não sejam bloqueados de atualizar.
 
 ## Mudanças no TypeScript {/*typescript-changes*/}
 
-### Tipos TypeScript depreciados removidos {/*removed-deprecated-typescript-types*/}
+### Tipos do TypeScript obsoletos removidos {/*removed-deprecated-typescript-types*/}
 
-Limparamos os tipos TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
+Limparamos os tipos do TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
 
 <Note>
-Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças quebradoras relacionadas a tipos:
+Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças de quebra relacionadas a tipos:
 
 ```bash
 npx types-react-codemod@latest preset-19 ./path-to-app
 ```
 
-Se você tem um acesso inconsistente a `element.props`, pode executar este codemod adicional:
+Se você tem um acesso muito inseguro a `element.props`, pode executar este codemod adicional:
 
 ```bash
 npx types-react-codemod@latest react-element-default-any-props ./path-to-your-react-ts-files
@@ -500,14 +500,14 @@ npx types-react-codemod@latest react-element-default-any-props ./path-to-your-re
 
 </Note>
 
-Veja [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você achar que um codemod está faltando, ele pode ser rastreado na [lista de codemods ausentes do React 19](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
+Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você sentir que um codemod está faltando, ele pode ser rastreado na [lista de codemods faltantes do React 19](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
 
 
-### Limpeza de `ref` necessária {/*ref-cleanup-required*/}
+### Limpezas de `ref` exigidas {/*ref-cleanup-required*/}
 
-_Esta mudança está incluída no preset `react-19` codemod como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
+_Essa mudança está incluída no preset `react-19` codemod como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
 
-Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de um callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
+Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de uma callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
@@ -518,22 +518,22 @@ O código original retornou a instância do `HTMLDivElement` e o TypeScript não
 
 ### `useRef` requer um argumento {/*useref-requires-argument*/}
 
-_Esta mudança está incluída no preset `react-19` codemod como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
+_Essa mudança está incluída no preset `react-19` codemod como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
 
-Uma reclamação de longa data sobre como TypeScript e React funcionam tem sido o `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
+Uma reclamação de longa data sobre como TypeScript e React funcionam foi `useRef`. Alteramos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
 
 ```ts
-// @ts-expect-error: Esperava 1 argumento mas não viu nenhum
+// @ts-expect-error: Esperado 1 argumento, mas não foi visto nenhum
 useRef();
-// Aceita
+// Passa
 useRef(undefined);
-// @ts-expect-error: Esperava 1 argumento mas não viu nenhum
+// @ts-expect-error: Esperado 1 argumento, mas não foi visto nenhum
 createContext();
-// Aceita
+// Passa
 createContext(undefined);
 ```
 
-Isso agora também significa que todas as refs são mutáveis. Você não encontrará mais o problema em que não pode mutar uma ref porque você a inicializou com `null`:
+Isso também significa que todas as refs são mutáveis. Você não enfrentará mais o problema em que não pode mutar uma ref porque a inicializou com `null`:
 
 ```ts
 const ref = useRef<number>(null);
@@ -542,7 +542,7 @@ const ref = useRef<number>(null);
 ref.current = 1;
 ```
 
-`MutableRef` agora é depreciado em favor de um único tipo `RefObject` que `useRef` sempre retornará:
+`MutableRef` agora está obsoleto em favor de um único tipo `RefObject` que `useRef` sempre retornará:
 
 ```ts
 interface RefObject<T> {
@@ -552,36 +552,36 @@ interface RefObject<T> {
 declare function useRef<T>: RefObject<T>
 ```
 
-`useRef` ainda possui uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento requerido para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que automaticamente retorna `RefObject<T | undefined>`.
+`useRef` ainda possui uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento necessário para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que retorna automaticamente `RefObject<T | undefined>`.
 
-Veja [[RFC] Faça todas as refs mutáveis](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
+Confira [[RFC] Torne todas as refs mutáveis](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
 
 ### Mudanças no tipo TypeScript `ReactElement` {/*changes-to-the-reactelement-typescript-type*/}
 
-_Esta mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
+_Essa mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
 
-As `props` de elementos React agora padrão para `unknown` em vez de `any` se o elemento estiver tipado como `ReactElement`. Isso não afetará você se passar um argumento de tipo para `ReactElement`:
+As `props` de elementos React agora padrão como `unknown` em vez de `any` se o elemento for tipado como `ReactElement`. Isso não afeta você se você passar um argumento de tipo para `ReactElement`:
 
 ```ts
 type Example2 = ReactElement<{ id: string }>["props"];
 //   ^? { id: string }
 ```
 
-Mas se você confiar no padrão, agora terá que lidar com `unknown`:
+Mas se você depender do padrão, agora terá que lidar com `unknown`:
 
 ```ts
 type Example = ReactElement["props"];
 //   ^? Antes, era 'any', agora 'unknown'
 ```
 
-Você só precisará disso se tiver muito código legado confiando em acesso inconsistente às props do elemento. A introspecção de elementos existe apenas como uma alternativa, e você deve deixar explícito que seu acesso às props é inconsistente por meio de um explícito `any`.
+Você só deve precisar disso se você tiver muito código legado dependendo de acesso inseguro às props de elemento. A introspecção de elementos existe apenas como uma saída, e você deve deixar explícito que seu acesso às props é inseguro através de um `any` explícito.
 
 ### O namespace JSX no TypeScript {/*the-jsx-namespace-in-typescript*/}
-Esta mudança está incluída no preset `react-19` codemod como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
+Essa mudança está incluída no preset `react-19` codemod como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
 
-Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais que impede conflitos entre diferentes bibliotecas de UI que aproveitam JSX.
+Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a evitar a poluição de tipos globais, o que previne conflitos entre diferentes bibliotecas de UI que utilizam JSX.
 
-Agora você precisará envolver a augmentação de módulo do namespace JSX em `declare module "....":
+Você agora precisará encapsular a alteração de módulo do namespace JSX em `declare module "....":
 
 ```diff
 // global.d.ts
@@ -596,24 +596,24 @@ Agora você precisará envolver a augmentação de módulo do namespace JSX em `
 + }
 ```
 
-O especifier exato do módulo depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
+O especificador de módulo exato depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
 
 - Para `"jsx": "react-jsx"` seria `react/jsx-runtime`.
 - Para `"jsx": "react-jsxdev"` seria `react/jsx-dev-runtime`.
 - Para `"jsx": "react"` e `"jsx": "preserve"` seria `react`.
 
-### Melhores tipagens para `useReducer` {/*better-usereducer-typings*/}
+### Melhorias na tipagem do `useReducer` {/*better-usereducer-typings*/}
 
-`useReducer` agora possui inferência de tipos melhorada graças a [@mfp22](https://github.com/mfp22).
+`useReducer` agora tem inferência de tipo melhorada graças ao [@mfp22](https://github.com/mfp22).
 
-No entanto, isso exigiu uma mudança quebradora onde `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos os tipos de estado e ação.
+No entanto, isso exigiu uma mudança que quebra a compatibilidade onde `useReducer` não aceita o tipo completo do redutor como parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos, o tipo de estado e o tipo de ação.
 
 A nova melhor prática é _não_ passar argumentos de tipo para `useReducer`.
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer(reducer)
 ```
-Isso pode não funcionar em casos limite onde você pode tipar explicitamente o estado e a ação, passando o `Action` em uma tupla:
+Isso pode não funcionar em casos extremos onde você pode tipar explicitamente o estado e a ação, passando o `Action` em uma tupla:
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer<State, [Action]>(reducer)
@@ -623,7 +623,7 @@ Se você definir o redutor inline, recomendamos anotar os parâmetros da funçã
 - useReducer<React.Reducer<State, Action>>((state, action) => state)
 + useReducer((state: State, action: Action) => state)
 ```
-Isso é também o que você precisaria fazer se mover o redutor para fora da chamada `useReducer`:
+Isso também é o que você terá que fazer se mover o redutor para fora da chamada `useReducer`:
 
 ```ts
 const reducer = (state: State, action: Action) => state;
@@ -631,7 +631,7 @@ const reducer = (state: State, action: Action) => state;
 
 ## Changelog {/*changelog*/}
 
-### Outras mudanças quebradoras {/*other-breaking-changes*/}
+### Outras mudanças que quebram a compatibilidade {/*other-breaking-changes*/}
 
 - **react-dom**: Erro para URLs javascript em src/href [#26507](https://github.com/facebook/react/pull/26507)
 - **react-dom**: Remover `errorInfo.digest` de `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
@@ -639,19 +639,19 @@ const reducer = (state: State, action: Action) => state;
 - **react-dom**: Remover `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
 - **react-dom**: Remover `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
 - **react-dom**: Remover `unstable_runWithPrioirty` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-is**: Remover métodos depreciados de `react-is` [28224](https://github.com/facebook/react/pull/28224)
+- **react-is**: Remover métodos obsoletos de `react-is` [28224](https://github.com/facebook/react/pull/28224)
 
 ### Outras mudanças notáveis {/*other-notable-changes*/}
 
-- **react**: Loteamento síncrono, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
-- **react**: Não pré-renderizar irmãos do componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
+- **react**: Lotes síncronos, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
+- **react**: Não pré-renderizar irmãos de componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
 - **react**: Detectar loops de atualização infinitos causados por atualizações na fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
 - **react-dom**: Transições em popstate agora são síncronas [#26025](https://github.com/facebook/react/pull/26025)
 - **react-dom**: Remover aviso de efeito de layout durante SSR [#26395](https://github.com/facebook/react/pull/26395)
-- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags de âncora) [#28124](https://github.com/facebook/react/pull/28124)
+- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags âncora) [#28124](https://github.com/facebook/react/pull/28124)
 
 Publicaremos o changelog completo com o lançamento estável do React 19.
 
 ---
 
-Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) por revisar e editar este post.
+Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits), e [Sebastian Silbermann](https://twitter.com/sebsilbermann) por revisar e editar este post.

--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -1,86 +1,86 @@
 ---
-title: "React 19 Beta Upgrade Guide"
+title: "Guia de Atualização para o Beta do React 19"
 author: Ricky Hanlon
 date: 2024/04/25
-description: The improvements added to React 19 require some breaking changes, but we've worked to make the upgrade as smooth as possible and we don't expect the changes to impact most apps. In this post, we will guide you through the steps for upgrading libraries to React 19 beta.
+description: As melhorias adicionadas ao React 19 requerem algumas mudanças que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo através das etapas para atualizar bibliotecas para a versão beta do React 19.
 ---
 
-April 25, 2024 by [Ricky Hanlon](https://twitter.com/rickhanlonii)
+25 de abril de 2024 por [Ricky Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
 <Note>
 
-This beta release is for libraries to prepare for React 19. App developers should upgrade to 18.3.0 and wait for React 19 stable as we work with libraries and make changes based on feedback.
+Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos alterações com base no feedback.
 
 </Note>
 
 
 <Intro>
 
-The improvements added to React 19 require some breaking changes, but we've worked to make the upgrade as smooth as possible and we don't expect the changes to impact most apps.
+As melhorias adicionadas ao React 19 requerem algumas mudanças que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
 
-To help make the upgrade easier, today we are also publishing React 18.3.
+Para ajudar a tornar a atualização mais fácil, hoje também estamos publicando o React 18.3.
 
 </Intro>
 
 <Note>
 
-#### React 18.3 has also been published {/*react-18-3*/}
+#### O React 18.3 também foi publicado {/*react-18-3*/}
 
-To help make the upgrade to React 19 easier, we've published a `react@18.3` release that is identical to 18.2 but adds warnings for deprecated APIs and other changes that are needed for React 19. 
+Para ajudar a facilitar a atualização para o React 19, publicamos um lançamento `react@18.3` que é idêntico ao 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças necessárias para o React 19. 
 
-We recommend upgrading to React 18.3 first to help identify any issues before upgrading to React 19.
+Recomendamos atualizar para o React 18.3 primeiro para ajudar a identificar quaisquer problemas antes de atualizar para o React 19.
 
-For a list of changes in 18.3 see the [Release Notes](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Para uma lista de mudanças no 18.3, consulte as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
 
 </Note>
 
-In this post, we will guide you through the steps for upgrading libraries to React 19 beta:
+Neste post, vamos guiá-lo através das etapas para atualizar bibliotecas para a versão beta do React 19:
 
-- [Installing](#installing)
-- [Breaking changes](#breaking-changes)
-- [New deprecations](#new-deprecations)
-- [Notable changes](#notable-changes)
-- [TypeScript changes](#typescript-changes)
-- [Changelog](#changelog)
+- [Instalando](#installing)
+- [Mudanças quebrando a compatibilidade](#breaking-changes)
+- [Novas desativações](#new-deprecations)
+- [Mudanças notáveis](#notable-changes)
+- [Mudanças no TypeScript](#typescript-changes)
+- [Notas de versão](#changelog)
 
-If you'd like to help us test React 19, follow the steps in this upgrade guide and [report any issues](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) you encounter. For a list of new features added to React 19 beta, see the [React 19 release post](/blog/2024/04/25/react-19).
+Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, consulte o [post de lançamento do React 19](/blog/2024/04/25/react-19).
 
 ---
-## Installing {/*installing*/}
+## Instalando {/*installing*/}
 
 <Note>
 
-#### New JSX Transform is now required {/*new-jsx-transform-is-now-required*/}
+#### Novo JSX Transform agora é obrigatório {/*new-jsx-transform-is-now-required*/}
 
-We introduced a [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) in 2020 to improve bundle size and use JSX without importing React. In React 19, we're adding additional improvements like using ref as a prop and JSX speed improvements that require the new transform.
+Introduzimos um [novo transformador JSX](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias de velocidade do JSX, que requerem o novo transformador.
 
-If the new transform is not enabled, you will see this warning:
+Se o novo transformador não estiver habilitado, você verá o seguinte aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform
+Seu aplicativo (ou uma de suas dependências) está usando um transformador JSX obsoleto. Atualize para o transformador JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
 
-We expect most apps will not be affected since the transform is enabled in most environments already. For manual instructions on how to upgrade, please see the [announcement post](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Esperamos que a maioria dos aplicativos não seja afetada, pois o transformador já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, consulte o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
 </Note>
 
 
-To install the latest version of React and React DOM:
+Para instalar a versão mais recente do React e do React DOM:
 
 ```bash
 npm install react@beta react-dom@beta
 ```
 
-If you're using TypeScript, you also need to update the types. Once React 19 is released as stable, you can install the types as usual from `@types/react` and `@types/react-dom`.  During the beta period, the types are available in different packages which need to be enforced in your `package.json`:
+Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim que o React 19 for lançado como estável, você pode instalar os tipos normalmente de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser forçados no seu `package.json`:
 
 ```json
 {
@@ -95,47 +95,47 @@ If you're using TypeScript, you also need to update the types. Once React 19 is 
 }
 ```
 
-We're also including a codemod for the most common replacements. See [TypeScript changes](#typescript-changes) below.
+Estamos também incluindo um codemod para as substituições mais comuns. Consulte as [mudanças no TypeScript](#typescript-changes) abaixo.
 
 
-## Breaking changes {/*breaking-changes*/}
+## Mudanças quebrando a compatibilidade {/*breaking-changes*/}
 
-### Errors in render are not re-thrown {/*errors-in-render-are-not-re-thrown*/}
+### Erros na renderização não são re-lançados {/*errors-in-render-are-not-re-thrown*/}
 
-In previous versions of React, errors thrown during render were caught and rethrown. In DEV, we would also log to `console.error`, resulting in duplicate error logs. 
+Nas versões anteriores do React, erros lançados durante a renderização eram capturados e relançados. Em DEV, também registrávamos em `console.error`, resultando em registros de erro duplicados. 
 
-In React 19, we've [improved how errors are handled](/blog/2024/04/25/react-19#error-handling) to reduce duplication by not re-throwing:
+No React 19, [melhoramos como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação, não relançando:
 
-- **Uncaught Errors**: Errors that are not caught by an Error Boundary are reported to `window.reportError`.
-- **Caught Errors**: Errors that are caught by an Error Boundary are reported to `console.error`.
+- **Erros Não Capturados**: Erros que não são capturados por um Boundary de Erro são relatados para `window.reportError`.
+- **Erros Capturados**: Erros que são capturados por um Boundary de Erro são relatados para `console.error`.
 
-This change should not impact most apps, but if your production error reporting relies on errors being re-thrown, you may need to update your error handling. To support this, we've added new methods to `createRoot` and `hydrateRoot` for custom error handling:
+Essa mudança não deve impactar a maioria dos aplicativos, mas se sua relatória de erros em produção depende de erros sendo relançados, você pode precisar atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erros personalizado:
 
 ```js [[1, 2, "onUncaughtError"], [2, 5, "onCaughtError"]]
 const root = createRoot(container, {
   onUncaughtError: (error, errorInfo) => {
-    // ... log error report
+    // ... registrar relatório de erro
   },
   onCaughtError: (error, errorInfo) => {
-    // ... log error report
+    // ... registrar relatório de erro
   }
 });
 ```
 
-For more info, see the docs for [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) and [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
+Para mais informações, consulte a documentação para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
 
 
-### Removed deprecated React APIs {/*removed-deprecated-react-apis*/}
+### APIs obsoletas do React removidas {/*removed-deprecated-react-apis*/}
 
-#### Removed: `propTypes` and `defaultProps` for functions {/*removed-proptypes-and-defaultprops*/}
-`PropTypes` were deprecated in [April 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
+#### Removido: `propTypes` e `defaultProps` para funções {/*removed-proptypes-and-defaultprops*/}
+`PropTypes` foram descontinuados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
 
-In React 19, we're removing the `propType` checks from the React package, and using them will be silently ignored. If you're using `propTypes`, we recommend migrating to TypeScript or another type-checking solution.
+No React 19, estamos removendo as verificações de `propType` do pacote React, e seu uso será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
 
-We're also removing `defaultProps` from function components in place of ES6 default parameters. Class components will continue to support `defaultProps` since there is no ES6 alternative.
+Estamos também removendo `defaultProps` de componentes de função em lugar de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, já que não há alternativa no ES6.
 
 ```js
-// Before
+// Antes
 import PropTypes from 'prop-types';
 
 function Heading({text}) {
@@ -149,7 +149,7 @@ Heading.defaultProps = {
 };
 ```
 ```ts
-// After
+// Depois
 interface Props {
   text?: string;
 }
@@ -158,16 +158,16 @@ function Heading({text = 'Hello, world!'}: Props) {
 }
 ```
 
-#### Removed: Legacy Context using `contextTypes` and `getChildContext` {/*removed-removing-legacy-context*/}
+#### Removido: Contexto Legado usando `contextTypes` e `getChildContext` {/*removed-removing-legacy-context*/}
 
-Legacy Context was deprecated in [October 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
+O Contexto Legado foi descontinuado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
 
-Legacy Context was only available in class components using the APIs `contextTypes` and `getChildContext`, and was replaced with `contextType` due to subtle bugs that were easy to miss. In React 19, we're removing Legacy Context to make React slightly smaller and faster.
+O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React um pouco menor e mais rápido.
 
-If you're still using Legacy Context in class components, you'll need to migrate to the new `contextType` API:
+Se você ainda estiver usando o Contexto Legado em componentes de classe, precisará migrar para a nova API `contextType`:
 
 ```js {5-11,19-21}
-// Before
+// Antes
 import PropTypes from 'prop-types';
 
 class Parent extends React.Component {
@@ -196,7 +196,7 @@ class Child extends React.Component {
 ```
 
 ```js {2,7,9,15}
-// After
+// Depois
 const FooContext = React.createContext();
 
 class Parent extends React.Component {
@@ -218,15 +218,15 @@ class Child extends React.Component {
 }
 ```
 
-#### Removed: string refs {/*removed-string-refs*/}
-String refs were deprecated in [March, 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+#### Removido: refs de string {/*removed-string-refs*/}
+Refs de string foram descontinuados em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
-Class components supported string refs before being replaced by ref callbacks due to [multiple downsides](https://github.com/facebook/react/issues/1373). In React 19, we're removing string refs to make React simpler and easier to understand.
+Componentes de classe suportavam refs de string antes de serem substituídos por callbacks de ref devido a [vários contratempos](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo refs de string para simplificar o React e torná-lo mais fácil de entender.
 
-If you're still using string refs in class components, you'll need to migrate to ref callbacks:
+Se você ainda estiver usando refs de string em componentes de classe, precisará migrar para callbacks de ref:
 
 ```js {4,8}
-// Before
+// Antes
 class MyComponent extends React.Component {
   componentDidMount() {
     this.refs.input.focus();
@@ -239,7 +239,7 @@ class MyComponent extends React.Component {
 ```
 
 ```js {4,8}
-// After
+// Depois
 class MyComponent extends React.Component {
   componentDidMount() {
     this.input.focus();
@@ -253,49 +253,49 @@ class MyComponent extends React.Component {
 
 <Note>
 
-To help with the migration, we will be publishing a [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) to automatically replace string refs with `ref` callbacks. Follow [this PR](https://github.com/reactjs/react-codemod/pull/309) for updates and to try it out.
+Para ajudar com a migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de `ref`. Siga [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para testá-lo.
 
 </Note>
 
-#### Removed: Module pattern factories {/*removed-module-pattern-factories*/}
-Module pattern factories were deprecated in [August 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
+#### Removido: Fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
+Fábricas de padrão de módulo foram descontinuadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
 
-This pattern was rarely used and supporting it causes React to be slightly larger and slower than necessary. In React 19, we're removing support for module pattern factories, and you'll need to migrate to regular functions:
+Esse padrão era raramente usado e seu suporte fazia com que o React fosse ligeiramente maior e mais lento do que o necessário. No React 19, estamos removendo o suporte a fábricas de padrão de módulo, e você precisará migrar para funções regulares:
 
 ```js
-// Before
+// Antes
 function FactoryComponent() {
   return { render() { return <div />; } }
 }
 ```
 
 ```js
-// After
+// Depois
 function FactoryComponent() {
   return <div />;
 }
 ```
 
-#### Removed: `React.createFactory` {/*removed-createfactory*/}
-`createFactory` was deprecated in [February 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
+#### Removido: `React.createFactory` {/*removed-createfactory*/}
+`createFactory` foi descontinuado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
 
-Using `createFactory` was common before broad support for JSX, but it's rarely used today and can be replaced with JSX. In React 19, we're removing `createFactory` and you'll need to migrate to JSX:
+Usar `createFactory` era comum antes do amplo suporte ao JSX, mas hoje é raramente utilizado e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
 
 ```js
-// Before
+// Antes
 import { createFactory } from 'react';
 
 const button = createFactory('button');
 ```
 
 ```js
-// After
+// Depois
 const button = <button />;
 ```
 
-#### Removed: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
+#### Removido: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
 
-In React 18, we updated `react-test-renderer/shallow` to re-export [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). In React 19, we're removing `react-test-render/shallow` to prefer installing the package directly:
+No React 18, atualizamos `react-test-renderer/shallow` para re-exportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir instalar o pacote diretamente:
 
 ```bash
 npm install react-shallow-renderer --save-dev
@@ -307,92 +307,92 @@ npm install react-shallow-renderer --save-dev
 
 <Note>
 
-##### Please reconsider shallow rendering {/*please-reconsider-shallow-rendering*/}
+##### Por favor, reconsidere a renderização superficial {/*please-reconsider-shallow-rendering*/}
 
-Shallow rendering depends on React internals and can block you from future upgrades. We recommend migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
+A renderização superficial depende dos internos do React e pode bloqueá-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
 
 </Note>
 
-### Removed deprecated React DOM APIs {/*removed-deprecated-react-dom-apis*/}
+### APIs obsoletas do React DOM removidas {/*removed-deprecated-react-dom-apis*/}
 
-#### Removed: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
+#### Removido: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
 
-We've moved `act` from `react-dom/test-utils` to the `react` package:
+Movemos `act` de `react-dom/test-utils` para o pacote `react`:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-`ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.
+`ReactDOMTestUtils.act` está obsoleto em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Consulte https://react.dev/warnings/react-dom-test-utils para mais informações.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-To fix this warning, you can import `act` from `react`:
+Para corrigir esse aviso, você pode importar `act` de `react`:
 
 ```diff
 - import {act} from 'react-dom/test-utils'
 + import {act} from 'react';
 ```
 
-All other `test-utils` functions have been removed. These utilities were uncommon, and made it too easy to depend on low level implementation details of your components and React. In React 19, these functions will error when called and their exports will be removed in a future version.
+Todas as outras funções de `test-utils` foram removidas. Essas utilidades eram incomuns e facilitavam demais a dependência de detalhes de implementação de baixo nível dos seus componentes e do React. No React 19, essas funções gerarão erro quando chamadas e suas exportações serão removidas em uma versão futura.
 
-See the [warning page](https://react.dev/warnings/react-dom-test-utils) for alternatives.
+Consulte a [página de aviso](https://react.dev/warnings/react-dom-test-utils) para alternativas.
 
-#### Removed: `ReactDOM.render` {/*removed-reactdom-render*/}
+#### Removido: `ReactDOM.render` {/*removed-reactdom-render*/}
 
-`ReactDOM.render` was deprecated in [March 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). In React 19, we're removing `ReactDOM.render` and you'll need to migrate to using [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
+`ReactDOM.render` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para usar [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
 
 ```js
-// Before
+// Antes
 import {render} from 'react-dom';
 render(<App />, document.getElementById('root'));
 
-// After
+// Depois
 import {createRoot} from 'react-dom/client';
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);
 ```
 
-#### Removed: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
+#### Removido: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
 
-`ReactDOM.hydrate` was deprecated in [March 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). In React 19, we're removing `ReactDOM.hydrate` you'll need to migrate to using [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
+`ReactDOM.hydrate` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para usar [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
 
 ```js
-// Before
+// Antes
 import {hydrate} from 'react-dom';
 hydrate(<App />, document.getElementById('root'));
 
-// After
+// Depois
 import {hydrateRoot} from 'react-dom/client';
 hydrateRoot(document.getElementById('root'), <App />);
 ```
 
 
-#### Removed: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
+#### Removido: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
 
-`ReactDOM.unmountComponentAtNode` was deprecated in [March 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). In React 19, you'll need to migrate to using `root.unmount()`.
+`ReactDOM.unmountComponentAtNode` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para usar `root.unmount()`.
 
 
 ```js
-// Before
+// Antes
 unmountComponentAtNode(document.getElementById('root'));
 
-// After
+// Depois
 root.unmount();
 ```
 
-For more see `root.unmount()` for [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) and [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
+Para mais informações, consulte `root.unmount()` para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
 
 
-#### Removed: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
-`ReactDOM.findDOMNode` was [deprecated in October 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
+#### Removido: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
+`ReactDOM.findDOMNode` foi [descontinuado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
 
-We're removing `findDOMNode` because it was a legacy escape hatch that was slow to execute, fragile to refactoring, only returned the first child, and broke abstraction levels (see more [here](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). You can replace `ReactDOM.findDOMNode` with [DOM refs](/learn/manipulating-the-dom-with-refs):
+Estamos removendo `findDOMNode` porque era uma saída de legado que era lenta para executar, frágil a refatorações, retornava apenas o primeiro filho e quebrava os níveis de abstração (consulte mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
 
 ```js
-// Before
+// Antes
 import {findDOMNode} from 'react-dom';
 
 function AutoselectingInput() {
@@ -406,7 +406,7 @@ function AutoselectingInput() {
 ```
 
 ```js
-// After
+// Depois
 function AutoselectingInput() {
   const ref = useRef(null);
   useEffect(() => {
@@ -417,47 +417,47 @@ function AutoselectingInput() {
 }
 ```
 
-## New deprecations {/*new-deprecations*/}
+## Novas desativações {/*new-deprecations*/}
 
-### Deprecated: `element.ref` {/*deprecated-element-ref*/}
+### Obsoleto: `element.ref` {/*deprecated-element-ref*/}
 
-React 19 supports [`ref` as a prop](/blog/2024/04/25/react-19#ref-as-a-prop), so we're deprecating the `element.ref` in place of `element.props.ref`.
+O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos descontinuando o `element.ref` em lugar de `element.props.ref`.
 
-Accessing `element.ref` will warn:
+Acessar `element.ref` gerará aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Accessing element.ref is no longer supported. ref is now a regular prop. It will be removed from the JSX Element type in a future release.
+Acessar element.ref não é mais suportado. ref agora é uma prop regular. Ele será removido do tipo Elemento JSX em uma versão futura.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### Deprecated: `react-test-renderer` {/*deprecated-react-test-renderer*/}
+### Obsoleto: `react-test-renderer` {/*deprecated-react-test-renderer*/}
 
-We are deprecating `react-test-renderer` because it implements its own renderer environment that doesn't match the environment users use, promotes testing implementation details, and relies on introspection of React's internals.
+Estamos descontinuando `react-test-renderer` porque implementa seu próprio ambiente de renderização que não corresponde ao ambiente que os usuários usam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
 
-The test renderer was created before there were more viable testing strategies available like [React Testing Library](https://testing-library.com), and we now recommend using a modern testing library instead.
+O test renderer foi criado antes que estratégias de teste mais viáveis estivessem disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de teste moderna.
 
-In React 19, `react-test-renderer` logs a deprecation warning, and has switched to concurrent rendering. We recommend migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) for a modern and well supported testing experience.
+No React 19, `react-test-renderer` registra um aviso de desativação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
 
-## Notable changes {/*notable-changes*/}
+## Mudanças notáveis {/*notable-changes*/}
 
-### StrictMode changes {/*strict-mode-improvements*/}
+### Mudanças no StrictMode {/*strict-mode-improvements*/}
 
-React 19 includes several fixes and improvements to Strict Mode.
+O React 19 inclui várias correções e melhorias ao Strict Mode.
 
-When double rendering in Strict Mode in development, `useMemo` and `useCallback` will reuse the memoized results from the first render during the second render. Components that are already Strict Mode compatible should not notice a difference in behavior.
+Ao fazer a renderização dupla no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem perceber nenhuma diferença no comportamento.
 
-As with all Strict Mode behaviors, these features are designed to proactively surface bugs in your components during development so you can fix them before they are shipped to production. For example, during development, Strict Mode will double-invoke ref callback functions on initial mount, to simulate what happens when a mounted component is replaced by a Suspense fallback.
+Como em todos os comportamentos do Strict Mode, esses recursos são projetados para proativamente expor bugs em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode invocará em dobro funções de callback de refs na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
 
-### UMD builds removed {/*umd-builds-removed*/}
+### Builds UMD removidas {/*umd-builds-removed*/}
 
-UMD was widely used in the past as a convenient way to load React without a build step. Now, there are modern alternatives for loading modules as scripts in HTML documents. Starting with React 19, React will no longer produce UMD builds to reduce the complexity of its testing and release process. 
+UMD foi amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais builds UMD para reduzir a complexidade de seu processo de teste e lançamento. 
 
-To load React 19 with a script tag, we recommend using an ESM-based CDN such as [esm.sh](https://esm.sh/).
+Para carregar o React 19 com uma tag de script, recomendamos usar uma CDN baseada em ESM como [esm.sh](https://esm.sh/).
 
 ```html
 <script type="module">
@@ -467,32 +467,32 @@ To load React 19 with a script tag, we recommend using an ESM-based CDN such as 
 </script>
 ```
 
-### Libraries depending on React internals may block upgrades {/*libraries-depending-on-react-internals-may-block-upgrades*/}
+### Bibliotecas que dependem dos internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
 
-This release includes changes to React internals that may impact libraries that ignore our pleas to not use internals like `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. These changes are necessary to land improvements in React 19, and will not break libraries that follow our guidelines.
+Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para realizar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
 
-Based on our [Versioning Policy](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), these updates are not listed as breaking changes, and we are not including docs for how to upgrade them. The recommendation is to remove any code that depends on internals.
+Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não são listadas como mudanças quebrando a compatibilidade, e não estamos incluindo documentos para como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
 
-To reflect the impact of using internals, we have renamed the `SECRET_INTERNALS` suffix to: 
+Para refletir o impacto de usar internos, renomeamos o sufixo `SECRET_INTERNALS` para: 
 
 `_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`
 
-In the future we will more aggressively block accessing internals from React to discourage usage and ensure users are not blocked from upgrading.
+No futuro, bloquearemos mais agressivamente o acesso a internos do React para desencorajar o uso e garantir que os usuários não sejam bloqueados de atualizar.
 
-## TypeScript changes {/*typescript-changes*/}
+## Mudanças no TypeScript {/*typescript-changes*/}
 
 ### Removed deprecated TypeScript types {/*removed-deprecated-typescript-types*/}
 
-We've cleaned up the TypeScript types based on the removed APIs in React 19. Some of the removed have types been moved to more relevant packages, and others are no longer needed to describe React's behavior.
+Limpeza dos tipos TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
 
 <Note>
-We've published [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) to migrate most type related breaking changes:
+Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças quebrando a compatibilidade relacionadas a tipos:
 
 ```bash
 npx types-react-codemod@latest preset-19 ./path-to-app
 ```
 
-If you have a lot of unsound access to `element.props`, you can run this additional codemod:
+Se você tem muito acesso não seguro a `element.props`, pode executar este codemod adicional:
 
 ```bash
 npx types-react-codemod@latest react-element-default-any-props ./path-to-your-react-ts-files
@@ -500,50 +500,49 @@ npx types-react-codemod@latest react-element-default-any-props ./path-to-your-re
 
 </Note>
 
-Check out [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) for a list of supported replacements. If you feel a codemod is missing, it can be tracked in the [list of missing React 19 codemods](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
+Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você achar que falta um codemod, isso pode ser rastreado na [lista de codemods do React 19 que estão faltando](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
 
 
-### `ref` cleanups required {/*ref-cleanup-required*/}
+### Limpeza de `ref` necessária {/*ref-cleanup-required*/}
 
-_This change is included in the `react-19` codemod preset as [`no-implicit-ref-callback-return
-`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
+_Essa mudança está incluída no preset codemod `react-19` como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
 
-Due to the introduction of ref cleanup functions, returning anything else from a ref callback will now be rejected by TypeScript. The fix is usually to stop using implicit returns:
+Devido à introdução de funções de limpeza de refs, retornar qualquer outra coisa de um callback de ref será agora rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-The original code returned the instance of the `HTMLDivElement` and TypeScript wouldn't know if this was supposed to be a cleanup function or not.
+O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
 
-### `useRef` requires an argument {/*useref-requires-argument*/}
+### `useRef` requer um argumento {/*useref-requires-argument*/}
 
-_This change is included in the `react-19` codemod preset as [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
+_Essa mudança está incluída no preset codemod `react-19` como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
 
-A long-time complaint of how TypeScript and React work has been `useRef`. We've changed the types so that `useRef` now requires an argument. This significantly simplifies its type signature. It'll now behave more like `createContext`.
+Uma reclamação de longa data sobre como TypeScript e React funcionam foi `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
 
 ```ts
-// @ts-expect-error: Expected 1 argument but saw none
+// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
 useRef();
-// Passes
+// Passa
 useRef(undefined);
-// @ts-expect-error: Expected 1 argument but saw none
+// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
 createContext();
-// Passes
+// Passa
 createContext(undefined);
 ```
 
-This now also means that all refs are mutable. You'll no longer hit the issue where you can't mutate a ref because you initialised it with `null`:
+Isso agora também significa que todas as refs são mutáveis. Você não encontrará mais o problema em que não pode mutar uma ref porque você a inicializou com `null`:
 
 ```ts
 const ref = useRef<number>(null);
 
-// Cannot assign to 'current' because it is a read-only property
+// Não é possível atribuir a 'current' porque é uma propriedade de somente leitura
 ref.current = 1;
 ```
 
-`MutableRef` is now deprecated in favor of a single `RefObject` type which `useRef` will always return:
+`MutableRef` agora está obsoleto em favor de um único tipo `RefObject` que `useRef` sempre retornará:
 
 ```ts
 interface RefObject<T> {
@@ -553,36 +552,36 @@ interface RefObject<T> {
 declare function useRef<T>: RefObject<T>
 ```
 
-`useRef` still has a convenience overload for `useRef<T>(null)` that automatically returns `RefObject<T | null>`. To ease migration due to the required argument for `useRef`, a convenience overload for `useRef(undefined)` was added that automatically returns `RefObject<T | undefined>`.
+`useRef` ainda tem uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento necessário para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que automáticamente retorna `RefObject<T | undefined>`.
 
-Check out [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) for prior discussions about this change.
+Consulte [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
 
-### Changes to the `ReactElement` TypeScript type {/*changes-to-the-reactelement-typescript-type*/}
+### Mudanças no tipo TypeScript `ReactElement` {/*changes-to-the-reactelement-typescript-type*/}
 
-_This change is included in the [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props) codemod._
+_Essa mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
 
-The `props` of React elements now default to `unknown` instead of `any` if the element is typed as `ReactElement`. This does not affect you if you pass a type argument to `ReactElement`:
+As `props` dos elementos React agora têm como padrão `unknown` em vez de `any` se o elemento for tipado como `ReactElement`. Isso não o afeta se você passar um argumento de tipo para `ReactElement`:
 
 ```ts
 type Example2 = ReactElement<{ id: string }>["props"];
 //   ^? { id: string }
 ```
 
-But if you relied on the default, you now have to handle `unknown`:
+Mas se você confiava no padrão, agora precisa lidar com `unknown`:
 
 ```ts
 type Example = ReactElement["props"];
-//   ^? Before, was 'any', now 'unknown'
+//   ^? Antes, era 'any', agora 'unknown'
 ```
 
-You should only need it if you have a lot of legacy code relying on unsound access of element props. Element introspection only exists as an escape hatch, and you should make it explicit that your props access is unsound via an explicit `any`.
+Você só deve precisar disso se tiver muito código legado dependendo do acesso não seguro das props do elemento. A introspecção de elementos existe apenas como uma saída e você deve deixar explícito que seu acesso a props é inseguro através de um `any` explícito.
 
-### The JSX namespace in TypeScript {/*the-jsx-namespace-in-typescript*/}
-This change is included in the `react-19` codemod preset as [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
+### O namespace JSX no TypeScript {/*the-jsx-namespace-in-typescript*/}
+Essa mudança está incluída no preset codemod `react-19` como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
 
-A long-time request is to remove the global `JSX` namespace from our types in favor of `React.JSX`. This helps prevent pollution of global types which prevents conflicts between different UI libraries that leverage JSX.
+Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a evitar poluição de tipos globais que impede conflitos entre diferentes bibliotecas de UI que usam JSX.
 
-You'll now need to wrap module augmentation of the JSX namespace in `declare module "....":
+Agora você precisará envolver a augmentação de módulo do namespace JSX em `declare module "....":
 
 ```diff
 // global.d.ts
@@ -597,62 +596,62 @@ You'll now need to wrap module augmentation of the JSX namespace in `declare mod
 + }
 ```
 
-The exact module specifier depends on the JSX runtime you specified in the `compilerOptions` of your `tsconfig.json`:
+O especificador de módulo exato depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
 
-- For `"jsx": "react-jsx"` it would be `react/jsx-runtime`.
-- For `"jsx": "react-jsxdev"` it would be `react/jsx-dev-runtime`.
-- For `"jsx": "react"` and `"jsx": "preserve"` it would be `react`.
+- Para `"jsx": "react-jsx"` seria `react/jsx-runtime`.
+- Para `"jsx": "react-jsxdev"` seria `react/jsx-dev-runtime`.
+- Para `"jsx": "react"` e `"jsx": "preserve"` seria `react`.
 
-### Better `useReducer` typings {/*better-usereducer-typings*/}
+### Melhores tipagens para `useReducer` {/*better-usereducer-typings*/}
 
-`useReducer` now has improved type inference thanks to [@mfp22](https://github.com/mfp22).
+`useReducer` agora tem melhor inferência de tipo graças a [@mfp22](https://github.com/mfp22).
 
-However, this required a breaking change where `useReducer` doesn't accept the full reducer type as a type parameter but instead either needs none (and rely on contextual typing) or needs both the state and action type.
+No entanto, isso exigiu uma mudança quebrando a compatibilidade onde `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos os tipos de estado e ação.
 
-The new best practice is _not_ to pass type arguments to `useReducer`.
+A nova melhor prática é _não_ passar argumentos de tipo para `useReducer`.
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer(reducer)
 ```
-This may not work in edge cases where you can explicitly type the state and action, by passing in the `Action` in a tuple:
+Isso pode não funcionar em casos extremos onde você pode tipar explicitamente o estado e a ação, passando a `Action` em uma tupla:
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer<State, [Action]>(reducer)
 ```
-If you define the reducer inline, we encourage to annotate the function parameters instead:
+Se você definir o redutor inline, incentivamos a anotar os parâmetros da função em vez disso:
 ```diff
 - useReducer<React.Reducer<State, Action>>((state, action) => state)
 + useReducer((state: State, action: Action) => state)
 ```
-This is also what you'd also have to do if you move the reducer outside of the `useReducer` call:
+Isso também é o que você teria que fazer se mover o redutor para fora da chamada de `useReducer`:
 
 ```ts
 const reducer = (state: State, action: Action) => state;
 ```
 
-## Changelog {/*changelog*/}
+## Notas de versão {/*changelog*/}
 
-### Other breaking changes {/*other-breaking-changes*/}
+### Outras mudanças quebrando a compatibilidade {/*other-breaking-changes*/}
 
-- **react-dom**: Error for javascript URLs in src/href [#26507](https://github.com/facebook/react/pull/26507)
-- **react-dom**: Remove `errorInfo.digest` from `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
-- **react-dom**: Remove `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
-- **react-dom**: Remove `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-dom**: Remove `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-dom**: Remove `unstable_runWithPrioirty` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-is**: Remove deprecated methods from `react-is` [28224](https://github.com/facebook/react/pull/28224)
+- **react-dom**: Erro para URLs JavaScript em src/href [#26507](https://github.com/facebook/react/pull/26507)
+- **react-dom**: Remover `errorInfo.digest` de `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
+- **react-dom**: Remover `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
+- **react-dom**: Remover `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
+- **react-dom**: Remover `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
+- **react-dom**: Remover `unstable_runWithPrioirty` [#28271](https://github.com/facebook/react/pull/28271)
+- **react-is**: Remover métodos obsoletos de `react-is` [28224](https://github.com/facebook/react/pull/28224)
 
-### Other notable changes {/*other-notable-changes*/}
+### Outras mudanças notáveis {/*other-notable-changes*/}
 
-- **react**: Batch sync, default and continuous lanes [#25700](https://github.com/facebook/react/pull/25700)
-- **react**: Don't prerender siblings of suspended component [#26380](https://github.com/facebook/react/pull/26380)
-- **react**: Detect infinite update loops caused by render phase updates [#26625](https://github.com/facebook/react/pull/26625)
-- **react-dom**: Transitions in popstate are now synchronous [#26025](https://github.com/facebook/react/pull/26025)
-- **react-dom**: Remove layout effect warning during SSR [#26395](https://github.com/facebook/react/pull/26395)
-- **react-dom**: Warn and don’t set empty string for src/href (except anchor tags) [#28124](https://github.com/facebook/react/pull/28124)
+- **react**: Lotes sincronos, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
+- **react**: Não pré-renderizar irmãos de componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
+- **react**: Detectar loops de atualização infinitos causados por atualizações da fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
+- **react-dom**: Transições em popstate agora são síncronas [#26025](https://github.com/facebook/react/pull/26025)
+- **react-dom**: Remover aviso de efeito de layout durante SSR [#26395](https://github.com/facebook/react/pull/26395)
+- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags de anexo) [#28124](https://github.com/facebook/react/pull/28124)
 
-We'll publish the full changelog with the stable release of React 19.
+Publicaremos o changelog completo com o lançamento estável do React 19.
 
 ---
 
-Thanks to [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits), and [Sebastian Silbermann](https://twitter.com/sebsilbermann) for reviewing and editing this post.
+Obrigado a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) pela revisão e edição deste post.

--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -1,78 +1,77 @@
 ---
-
 title: "Guia de Atualização do React 19 Beta"
 author: Ricky Hanlon
 date: 2024/04/25
-description: As melhorias adicionadas ao React 19 requerem algumas mudanças incompatíveis, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, iremos guiá-lo através das etapas para atualizar bibliotecas para o React 19 beta.
+description: As melhorias adicionadas ao React 19 requerem algumas alterações que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta.
 ---
 
 25 de abril de 2024 por [Ricky Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
-<Nota>
+<Note>
 
-Este lançamento beta é para que as bibliotecas se preparem para o React 19. Desenvolvedores de aplicativos devem atualizar para a versão 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos alterações com base no feedback.
+Esta versão beta é para bibliotecas se prepararem para o React 19. Os desenvolvedores de aplicativos devem atualizar para a versão 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com as bibliotecas e fazemos alterações com base no feedback.
 
-</Nota>
+</Note>
 
 
-<Introdução>
+<Intro>
 
-As melhorias adicionadas ao React 19 requerem algumas mudanças incompatíveis, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
+As melhorias adicionadas ao React 19 requerem algumas alterações que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
 
-Para ajudar a tornar a atualização mais fácil, estamos também publicando o React 18.3 hoje.
+Para ajudar a tornar a atualização mais fácil, hoje também estamos publicando o React 18.3.
 
-</Introdução>
+</Intro>
 
-<Nota>
+<Note>
 
 #### O React 18.3 também foi publicado {/*react-18-3*/}
 
-Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças que são necessárias para o React 19. 
+Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças que são necessárias para o React 19.
 
 Recomendamos atualizar para o React 18.3 primeiro para ajudar a identificar quaisquer problemas antes de atualizar para o React 19.
 
 Para uma lista de mudanças na 18.3, consulte as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
 
-</Nota>
+</Note>
 
-Neste post, iremos guiá-lo através das etapas para atualizar bibliotecas para o React 19 beta:
+Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta:
 
-- [Instalando](#installing)
-- [Mudanças incompatíveis](#breaking-changes)
-- [Novas obsolescências](#new-deprecations)
+- [Instalação](#installing)
+- [Alterações quebradoras](#breaking-changes)
+- [Novas desativações](#new-deprecations)
 - [Mudanças notáveis](#notable-changes)
 - [Mudanças no TypeScript](#typescript-changes)
 - [Changelog](#changelog)
 
-Se você gostaria de nos ajudar a testar o React 19, siga as etapas neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, consulte o [post de lançamento do React 19](/blog/2024/04/25/react-19).
+Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, consulte o [post de lançamento do React 19](/blog/2024/04/25/react-19).
 
 ---
-## Instalando {/*installing*/}
+## Instalação {/*installing*/}
 
-<Nota>
+<Note>
 
-#### Novo Transform do JSX agora é obrigatório {/*new-jsx-transform-is-now-required*/}
+#### Novo JSX Transform agora é necessário {/*new-jsx-transform-is-now-required*/}
 
-Introduzimos um [novo transform do JSX](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do bundle e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias na velocidade do JSX que requerem o novo transform.
+Introduzimos um [novo JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias na velocidade do JSX que exigem o novo transform.
 
-Se o novo transform não estiver habilitado, você verá o seguinte aviso:
+Se o novo transform não estiver habilitado, você verá este aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Seu aplicativo (ou uma de suas dependências) está usando um transform do JSX desatualizado. Atualize para o transform moderno do JSX para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
+Seu aplicativo (ou uma de suas dependências) está usando um transform JSX desatualizado. Atualize para o transform JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
 
-Esperamos que a maioria dos aplicativos não seja afetada, uma vez que o transform já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, veja o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Esperamos que a maioria dos aplicativos não seja afetada, pois o transform já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, consulte o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
-</Nota>
+</Note>
 
 
 Para instalar a versão mais recente do React e do React DOM:
@@ -81,7 +80,7 @@ Para instalar a versão mais recente do React e do React DOM:
 npm install react@beta react-dom@beta
 ```
 
-Se você estiver usando TypeScript, também precisa atualizar os tipos. Assim que o React 19 for liberado como estável, você poderá instalar os tipos normalmente a partir de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser impostos no seu `package.json`:
+Se você estiver usando TypeScript, você também precisa atualizar os tipos. Uma vez que o React 19 seja lançado como estável, você pode instalar os tipos normalmente de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser impostos no seu `package.json`:
 
 ```json
 {
@@ -96,44 +95,44 @@ Se você estiver usando TypeScript, também precisa atualizar os tipos. Assim qu
 }
 ```
 
-Estamos também incluindo um codemod para as substituições mais comuns. Veja [Mudanças no TypeScript](#typescript-changes) abaixo.
+Também estamos incluindo um codemod para as substituições mais comuns. Consulte [Mudanças no TypeScript](#typescript-changes) abaixo.
 
 
-## Mudanças incompatíveis {/*breaking-changes*/}
+## Alterações quebradoras {/*breaking-changes*/}
 
-### Erros no render não são mais relançados {/*errors-in-render-are-not-re-thrown*/}
+### Erros durante a renderização não são mais relançados {/*errors-in-render-are-not-re-thrown*/}
 
-Nas versões anteriores do React, erros lançados durante o render eram capturados e relançados. No modo DEV, também faríamos logs para `console.error`, resultando em logs de erro duplicados. 
+Nas versões anteriores do React, os erros lançados durante a renderização eram capturados e relançados. No modo DEV, nós também registraríamos no `console.error`, resultando em logs de erro duplicados.
 
-No React 19, melhoramos como os erros são tratados [/blog/2024/04/25/react-19#error-handling] para reduzir a duplicação ao não relançar:
+No React 19, [melhoramos como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação ao não relançar:
 
-- **Erros Não Capturados**: Erros que não são capturados por um Error Boundary são reportados para `window.reportError`.
-- **Erros Capturados**: Erros que são capturados por um Error Boundary são reportados para `console.error`.
+- **Erros não capturados**: Erros que não são capturados por um Error Boundary são relatados para `window.reportError`.
+- **Erros capturados**: Erros que são capturados por um Error Boundary são relatados para `console.error`.
 
-Essa mudança não deve impactar a maioria dos aplicativos, mas se sua contabilidade de erro em produção depende de erros serem relançados, talvez você precise atualizar seu tratamento de erro. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erro personalizado:
+Essa mudança não deve impactar a maioria dos aplicativos, mas se o seu relatório de erros em produção depender do relançamento de erros, pode ser necessário atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erros personalizado:
 
 ```js [[1, 2, "onUncaughtError"], [2, 5, "onCaughtError"]]
 const root = createRoot(container, {
   onUncaughtError: (error, errorInfo) => {
-    // ... log erro
+    // ... registrar relatório de erro
   },
   onCaughtError: (error, errorInfo) => {
-    // ... log erro
+    // ... registrar relatório de erro
   }
 });
 ```
 
-Para mais informações, consulte a documentação para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
+Para mais informações, consulte a documentação de [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
 
 
 ### APIs do React obsoletas removidas {/*removed-deprecated-react-apis*/}
 
 #### Removido: `propTypes` e `defaultProps` para funções {/*removed-proptypes-and-defaultprops*/}
-`PropTypes` foram obsoletados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
+`PropTypes` foram descontinuados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
 
-No React 19, estamos removendo as verificações de `propType` do pacote React, e usá-las será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipo.
+No React 19, estamos removendo as verificações `propType` do pacote React e usá-las será silenciosamente ignorado. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
 
-Estamos também removendo `defaultProps` de componentes de função em vez de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, uma vez que não há alternativa do ES6.
+Também estamos removendo `defaultProps` de componentes de função em favor de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, uma vez que não há alternativa do ES6.
 
 ```js
 // Antes
@@ -146,7 +145,7 @@ Heading.propTypes = {
   text: PropTypes.string,
 };
 Heading.defaultProps = {
-  text: 'Olá, mundo!',
+  text: 'Hello, world!',
 };
 ```
 ```ts
@@ -154,16 +153,16 @@ Heading.defaultProps = {
 interface Props {
   text?: string;
 }
-function Heading({text = 'Olá, mundo!'}: Props) {
+function Heading({text = 'Hello, world!'}: Props) {
   return <h1>{text}</h1>;
 }
 ```
 
 #### Removido: Contexto Legado usando `contextTypes` e `getChildContext` {/*removed-removing-legacy-context*/}
 
-O Contexto Legado foi obsoleto em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
+O Contexto Legado foi descontinuado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
 
-O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a erros sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React um pouco menor e mais rápido.
+O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React um pouco menor e mais rápido.
 
 Se você ainda estiver usando o Contexto Legado em componentes de classe, precisará migrar para a nova API `contextType`:
 
@@ -219,12 +218,12 @@ class Child extends React.Component {
 }
 ```
 
-#### Removido: refs de string {/*removed-string-refs*/}
-Refs de string foram obsoletos em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+#### Removido: referências de string {/*removed-string-refs*/}
+Referências de string foram descontinuadas em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
-Componentes de classe suportavam refs de string antes de serem substituídos por callbacks de ref devido a [múltiplas desvantagens](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo o uso de refs de string para tornar o React mais simples e fácil de entender.
+Componentes de classe suportavam referências de string antes de serem substituídas por callbacks de ref devido a [múltiplas desvantagens](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo referências de string para tornar o React mais simples e fácil de entender.
 
-Se você ainda estiver usando refs de string em componentes de classe, precisará migrar para callbacks de ref:
+Se você ainda estiver usando referências de string em componentes de classe, precisará migrar para callbacks de ref:
 
 ```js {4,8}
 // Antes
@@ -252,16 +251,16 @@ class MyComponent extends React.Component {
 }
 ```
 
-<Nota>
+<Note>
 
-Para ajudar com a migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de `ref`. Acompanhe [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-lo.
+Para ajudar na migração, estaremos publicando um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente referências de string por callbacks de `ref`. Siga [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-lo.
 
-</Nota>
+</Note>
 
-#### Removido: Fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
-Fábricas de padrão de módulo foram obsoletas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
+#### Removido: fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
+Fábricas de padrão de módulo foram descontinuadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
 
-Esse padrão era raramente utilizado e seu suporte faz com que o React seja um pouco maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrão de módulo, e você precisará migrar para funções regulares:
+Esse padrão era raramente utilizado e seu suporte faz com que o React seja ligeiramente maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrão de módulo, e você precisará migrar para funções regulares:
 
 ```js
 // Antes
@@ -278,9 +277,9 @@ function FactoryComponent() {
 ```
 
 #### Removido: `React.createFactory` {/*removed-createfactory*/}
-`createFactory` foi obsoleto em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
+`createFactory` foi descontinuado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
 
-Usar `createFactory` era comum antes do amplo suporte a JSX, mas agora é raramente utilizado e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
+O uso de `createFactory` era comum antes do amplo suporte ao JSX, mas é raramente utilizado hoje e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
 
 ```js
 // Antes
@@ -296,7 +295,7 @@ const button = <button />;
 
 #### Removido: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
 
-No React 18, atualizamos `react-test-renderer/shallow` para reexportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir instalar o pacote diretamente:
+No React 18, atualizamos `react-test-renderer/shallow` para re-exportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir a instalação do pacote diretamente:
 
 ```bash
 npm install react-shallow-renderer --save-dev
@@ -306,44 +305,44 @@ npm install react-shallow-renderer --save-dev
 + import ShallowRenderer from 'react-shallow-renderer';
 ```
 
-<Nota>
+<Note>
 
-##### Por favor, repense a renderização superficial {/*please-reconsider-shallow-rendering*/}
+##### Por favor, reconsidere a renderização superficial {/*please-reconsider-shallow-rendering*/}
 
-A renderização superficial depende de internos do React e pode bloqueá-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
+A renderização superficial depende dos internos do React e pode bloqueá-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started).
 
-</Nota>
+</Note>
 
 ### APIs do React DOM obsoletas removidas {/*removed-deprecated-react-dom-apis*/}
 
 #### Removido: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
 
-Movemos `act` de `react-dom/test-utils` para o pacote `react`:
+Mudamos `act` de `react-dom/test-utils` para o pacote `react`:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-`ReactDOMTestUtils.act` está obsoleto em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
+`ReactDOMTestUtils.act` está obsoleta em favor de `React.act`. Importar `act` do `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Para corrigir esse aviso, você pode importar `act` de `react`:
+Para corrigir esse aviso, você pode importar `act` do `react`:
 
 ```diff
 - import {act} from 'react-dom/test-utils'
 + import {act} from 'react';
 ```
 
-Todas as outras funções `test-utils` foram removidas. Essas utilidades eram incomuns e facilitavam demais depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão erro quando chamadas e suas exportações serão removidas em uma versão futura.
+Todas as outras funções de `test-utils` foram removidas. Essas utilidades eram incomuns e tornavam muito fácil depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão um erro quando chamadas e suas exportações serão removidas em uma versão futura.
 
-Veja a [página de avisos](https://react.dev/warnings/react-dom-test-utils) para alternativas.
+Consulte a [página de avisos](https://react.dev/warnings/react-dom-test-utils) para alternativas.
 
 #### Removido: `ReactDOM.render` {/*removed-reactdom-render*/}
 
-`ReactDOM.render` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
+`ReactDOM.render` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para o uso de [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
 
 ```js
 // Antes
@@ -358,7 +357,7 @@ root.render(<App />);
 
 #### Removido: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
 
-`ReactDOM.hydrate` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
+`ReactDOM.hydrate` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para o uso de [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
 
 ```js
 // Antes
@@ -373,7 +372,8 @@ hydrateRoot(document.getElementById('root'), <App />);
 
 #### Removido: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
 
-`ReactDOM.unmountComponentAtNode` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para `root.unmount()`.
+`ReactDOM.unmountComponentAtNode` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para o uso de `root.unmount()`.
+
 
 ```js
 // Antes
@@ -387,9 +387,9 @@ Para mais informações, consulte `root.unmount()` para [`createRoot`](https://r
 
 
 #### Removido: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
-`ReactDOM.findDOMNode` foi [obsoleto em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
+`ReactDOM.findDOMNode` foi [descontinuado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode).
 
-Estamos removendo `findDOMNode` porque era um escape hatch legado que era lento para executar, frágil à refatoração, retornava apenas o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
+Estamos removendo `findDOMNode` porque era uma válvula de escape legada que era lenta para executar, frágil para refatoração, retornava apenas o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
 
 ```js
 // Antes
@@ -417,19 +417,19 @@ function AutoselectingInput() {
 }
 ```
 
-## Novas obsolescências {/*new-deprecations*/}
+## Novas desativações {/*new-deprecations*/}
 
 ### Obsoleto: `element.ref` {/*deprecated-element-ref*/}
 
-O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos tornando obsoleto `element.ref` em vez de `element.props.ref`.
+O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos descontinuando o `element.ref` em favor de `element.props.ref`.
 
-Acessar `element.ref` irá gerar um aviso:
+Acessar `element.ref` gerará um aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Acesso a element.ref não é mais suportado. ref é agora uma prop comum. Ele será removido do tipo JSX Element em um futuro lançamento.
+Acessar element.ref não é mais suportado. ref agora é uma prop regular. Será removido do tipo JSX Element em uma versão futura.
 
 </ConsoleLogLine>
 
@@ -437,11 +437,11 @@ Acesso a element.ref não é mais suportado. ref é agora uma prop comum. Ele se
 
 ### Obsoleto: `react-test-renderer` {/*deprecated-react-test-renderer*/}
 
-Estamos tornando `react-test-renderer` obsoleto porque implementa seu próprio ambiente de renderizador que não coincidem com o ambiente que os usuários utilizam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
+Estamos descontinuando `react-test-renderer` porque implementa seu próprio ambiente de renderização que não corresponde ao ambiente usado pelos usuários, promove o teste de detalhes de implementação e depende da introspecção dos internos do React.
 
-O renderizador de teste foi criado antes que houvesse estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de testes moderna.
+O test renderer foi criado antes que houvesse estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos o uso de uma biblioteca de teste moderna em vez disso.
 
-No React 19, `react-test-renderer` gera um aviso de obsolescência e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
+No React 19, `react-test-renderer` registra um aviso de descontinuação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
 
 ## Mudanças notáveis {/*notable-changes*/}
 
@@ -449,15 +449,15 @@ No React 19, `react-test-renderer` gera um aviso de obsolescência e mudou para 
 
 O React 19 inclui várias correções e melhorias no Strict Mode.
 
-Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem notar uma diferença no comportamento.
+Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem notar nenhuma diferença no comportamento.
 
-Como com todos os comportamentos do Strict Mode, esses recursos são projetados para destacar proativamente erros em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode chamará duas vezes as funções de callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
+Como em todos os comportamentos do Strict Mode, esses recursos são projetados para ativar proativamente bugs em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes que sejam enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode chamará duas vezes as funções de callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
 
-### Construtores UMD removidos {/*umd-builds-removed*/}
+### Construções UMD removidas {/*umd-builds-removed*/}
 
-UMD era amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais construtores UMD para reduzir a complexidade de seu processo de teste e lançamento. 
+UMD foi amplamente utilizado no passado como uma maneira conveniente de carregar o React sem um passo de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais construções UMD para reduzir a complexidade de seu processo de teste e lançamento.
 
-Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado em ESM, como [esm.sh](https://esm.sh/).
+Para carregar o React 19 com uma tag de script, recomendamos o uso de uma CDN baseada em ESM, como [esm.sh](https://esm.sh/).
 
 ```html
 <script type="module">
@@ -467,45 +467,45 @@ Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado
 </script>
 ```
 
-### Bibliotecas dependendo de internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
+### Bibliotecas que dependem dos internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
 
-Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para a melhoria de recursos no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
+Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos pedidos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para implementar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
 
-Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças incompatíveis, e não estamos incluindo documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
+Com base na nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças quebradoras e não estamos incluindo documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
 
-Para refletir o impacto de usar internos, renomeamos o sufixo `SECRET_INTERNALS` para: 
+Para refletir o impacto de usar internos, renomeamos o sufixo `SECRET_INTERNALS` para:
 
 `_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`
 
-No futuro, bloquearemos mais agressivamente o acesso a internos do React para desencorajar o uso e garantir que os usuários não sejam bloqueados de atualizar.
+No futuro, bloquearemos mais agressivamente o acesso aos internos do React para desencorajar o uso e garantir que os usuários não fiquem bloqueados nas atualizações.
 
 ## Mudanças no TypeScript {/*typescript-changes*/}
 
 ### Tipos TypeScript obsoletos removidos {/*removed-deprecated-typescript-types*/}
 
-Limparamos os tipos TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
+Limparamos os tipos do TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
 
-<Nota>
-Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças de quebra relacionadas a tipos:
+<Note>
+Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças quebradoras relacionadas a tipos:
 
 ```bash
 npx types-react-codemod@latest preset-19 ./path-to-app
 ```
 
-Se você tiver um acesso muito inseguro a `element.props`, pode executar esse codemod adicional:
+Se você tiver muito acesso inseguro a `element.props`, pode executar este codemod adicional:
 
 ```bash
 npx types-react-codemod@latest react-element-default-any-props ./path-to-your-react-ts-files
 ```
 
-</Nota>
+</Note>
 
-Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você sentir que um codemod está faltando, isso pode ser rastreado na [lista de codemods faltantes do React 19](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
+Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você sentir que um codemod está faltando, isso pode ser rastreado na [lista de codemods do React 19 que estão faltando](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
 
 
 ### Limpezas de `ref` necessárias {/*ref-cleanup-required*/}
 
-_Essa mudança está incluída no preset codemod `react-19` como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
+_Esta mudança está incluída no preset codemod `react-19` como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
 
 Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de uma callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
 
@@ -514,31 +514,31 @@ Devido à introdução de funções de limpeza de ref, retornar qualquer outra c
 + <div ref={current => {instance = current}} />
 ```
 
-O código original retornou a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
+O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
 
 ### `useRef` requer um argumento {/*useref-requires-argument*/}
 
-_Essa mudança está incluída no preset codemod `react-19` como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
+_Esta mudança está incluída no preset codemod `react-19` como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
 
-Uma reclamação de longa data sobre como TypeScript e React funcionam era sobre `useRef`. Mudamos os tipos para que `useRef` agora requeira um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
+Uma longa reclamação sobre como o TypeScript e o React funcionam tem sido o `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
 
 ```ts
-// @ts-expect-error: Expected 1 argument but saw none
+// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
 useRef();
 // Passa
 useRef(undefined);
-// @ts-expect-error: Expected 1 argument but saw none
+// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
 createContext();
 // Passa
 createContext(undefined);
 ```
 
-Isso também significa que todas as refs são mutáveis. Você não encontrará mais o problema em que não pode mutar uma ref porque a inicializou com `null`:
+Isso agora também significa que todas as refs são mutáveis. Você não terá mais o problema em que não pode mutar uma ref porque a inicializou com `null`:
 
 ```ts
 const ref = useRef<number>(null);
 
-// Cannot assign to 'current' because it is a read-only property
+// Não é possível atribuir a 'current' porque é uma propriedade somente leitura
 ref.current = 1;
 ```
 
@@ -552,36 +552,36 @@ interface RefObject<T> {
 declare function useRef<T>: RefObject<T>
 ```
 
-`useRef` ainda possui uma sobrecarga de conveniência para `useRef<T>(null)` que retorna automaticamente `RefObject<T | null>`. Para facilitar a migração devido ao argumento necessário para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que retorna automaticamente `RefObject<T | undefined>`.
+`useRef` ainda tem uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento requerido para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que automaticamente retorna `RefObject<T | undefined>`.
 
-Confira [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
+Confira [[RFC] Fazer todas as refs mutáveis](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
 
 ### Mudanças no tipo TypeScript `ReactElement` {/*changes-to-the-reactelement-typescript-type*/}
 
-_Essa mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
+_Esta mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
 
-As `props` dos elementos React agora padrão para `unknown` em vez de `any` se o elemento estiver tipado como `ReactElement`. Isso não o afeta se você passar um argumento de tipo para `ReactElement`:
+As `props` dos elementos React agora padrão para `unknown` em vez de `any` se o elemento for tipado como `ReactElement`. Isso não afeta você se você passar um argumento de tipo para `ReactElement`:
 
 ```ts
 type Example2 = ReactElement<{ id: string }>["props"];
 //   ^? { id: string }
 ```
 
-Mas se você confiou no padrão, agora precisa lidar com `unknown`:
+Mas se você contava com o padrão, agora precisa lidar com `unknown`:
 
 ```ts
 type Example = ReactElement["props"];
 //   ^? Antes, era 'any', agora 'unknown'
 ```
 
-Você só precisará disso se tiver muito código legado dependendo do acesso inseguro das props do elemento. A introspecção de elementos existe apenas como um escape hatch, e você deve deixar explícito que seu acesso às props é inseguro por meio de um `any` explícito.
+Você só deve precisar disso se tiver muito código legado dependendo do acesso inseguro às `props` do elemento. A introspecção do elemento existe apenas como uma válvula de escape, e você deve deixar explícito que seu acesso às `props` é inseguro via `any` explícito.
 
 ### O namespace JSX no TypeScript {/*the-jsx-namespace-in-typescript*/}
-Essa mudança está incluída no preset codemod `react-19` como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
+Esta mudança está incluída no preset codemod `react-19` como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
 
-Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais, o que impede conflitos entre diferentes bibliotecas de UI que utilizam JSX.
+Um pedido antigo é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais, que previne conflitos entre diferentes bibliotecas de UI que utilizam JSX.
 
-Você agora precisará envolver a alteração de módulo do namespace JSX em `declare module "....":
+Agora você precisará encapsular a ampliação do módulo do namespace JSX em `declare module "....`:
 
 ```diff
 // global.d.ts
@@ -602,28 +602,28 @@ O especificador exato do módulo depende do runtime JSX que você especificou na
 - Para `"jsx": "react-jsxdev"` seria `react/jsx-dev-runtime`.
 - Para `"jsx": "react"` e `"jsx": "preserve"` seria `react`.
 
-### Melhores tipos para `useReducer` {/*better-usereducer-typings*/}
+### Melhores typings para `useReducer` {/*better-usereducer-typings*/}
 
 `useReducer` agora tem uma inferência de tipo melhorada graças a [@mfp22](https://github.com/mfp22).
 
-No entanto, isso exigiu uma mudança incompatível em que `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e depender da tipagem contextual) ou precisa de ambos, o tipo de estado e o tipo de ação.
+No entanto, isso exigiu uma mudança quebradora onde `useReducer` não aceita o tipo completo do reduzidor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos os tipos de estado e ação.
 
 A nova melhor prática é _não_ passar argumentos de tipo para `useReducer`.
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer(reducer)
 ```
-Isso pode não funcionar em casos extremos onde você pode digitar explicitamente o estado e a ação, passando o `Action` em uma tupla:
+Isso pode não funcionar em casos extremos onde você pode tipar explicitamente o estado e a ação, passando o `Action` em uma tupla:
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer<State, [Action]>(reducer)
 ```
-Se você definir o redutor em linha, aconselhamos a anotar os parâmetros da função:
+Se você definir o reduzidor inline, recomendamos anotar os parâmetros da função em vez disso:
 ```diff
 - useReducer<React.Reducer<State, Action>>((state, action) => state)
 + useReducer((state: State, action: Action) => state)
 ```
-Isso também é o que você teria que fazer se movesse o redutor para fora da chamada `useReducer`:
+Isso também é o que você também teria que fazer se mover o reduzidor para fora da chamada `useReducer`:
 
 ```ts
 const reducer = (state: State, action: Action) => state;
@@ -631,10 +631,10 @@ const reducer = (state: State, action: Action) => state;
 
 ## Changelog {/*changelog*/}
 
-### Outras mudanças incompatíveis {/*other-breaking-changes*/}
+### Outras mudanças quebradoras {/*other-breaking-changes*/}
 
 - **react-dom**: Erro para URLs javascript em src/href [#26507](https://github.com/facebook/react/pull/26507)
-- **react-dom**: Remover `errorInfo.digest` de `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
+- **react-dom**: Remover `errorInfo.digest` do `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
 - **react-dom**: Remover `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
 - **react-dom**: Remover `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
 - **react-dom**: Remover `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
@@ -643,15 +643,15 @@ const reducer = (state: State, action: Action) => state;
 
 ### Outras mudanças notáveis {/*other-notable-changes*/}
 
-- **react**: Lanes de sync, default e contínuas [#25700](https://github.com/facebook/react/pull/25700)
+- **react**: Lotes síncronos, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
 - **react**: Não pré-renderizar irmãos do componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
 - **react**: Detectar loops de atualização infinitos causados por atualizações na fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
 - **react-dom**: Transições em popstate agora são síncronas [#26025](https://github.com/facebook/react/pull/26025)
 - **react-dom**: Remover aviso de efeito de layout durante SSR [#26395](https://github.com/facebook/react/pull/26395)
-- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags ancla) [#28124](https://github.com/facebook/react/pull/28124)
+- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags âncora) [#28124](https://github.com/facebook/react/pull/28124)
 
 Publicaremos o changelog completo com o lançamento estável do React 19.
 
 ---
 
-Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) por revisar e editar este post.
+Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) pela revisão e edição deste post.

--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -1,8 +1,8 @@
 ---
-title: "Guia de Atualização do React 19 Beta"
+title: "Guia de Atualização para o React 19 Beta"
 author: Ricky Hanlon
 date: 2024/04/25
-description: As melhorias adicionadas ao React 19 requerem algumas alterações que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta.
+description: As melhorias adicionadas ao React 19 exigem algumas mudanças quebradoras, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta.
 ---
 
 25 de abril de 2024 por [Ricky Hanlon](https://twitter.com/rickhanlonii)
@@ -11,16 +11,16 @@ description: As melhorias adicionadas ao React 19 requerem algumas alterações 
 
 <Note>
 
-Esta versão beta é para bibliotecas se prepararem para o React 19. Os desenvolvedores de aplicativos devem atualizar para a versão 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com as bibliotecas e fazemos alterações com base no feedback.
+Esta versão beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
 
 <Intro>
 
-As melhorias adicionadas ao React 19 requerem algumas alterações que quebram a compatibilidade, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
+As melhorias adicionadas ao React 19 exigem algumas mudanças quebradoras, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
 
-Para ajudar a tornar a atualização mais fácil, hoje também estamos publicando o React 18.3.
+Para ajudar a facilitar a atualização, hoje também estamos publicando o React 18.3.
 
 </Intro>
 
@@ -28,48 +28,48 @@ Para ajudar a tornar a atualização mais fácil, hoje também estamos publicand
 
 #### O React 18.3 também foi publicado {/*react-18-3*/}
 
-Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças que são necessárias para o React 19.
+Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs depreciadas e outras mudanças necessárias para o React 19. 
 
 Recomendamos atualizar para o React 18.3 primeiro para ajudar a identificar quaisquer problemas antes de atualizar para o React 19.
 
-Para uma lista de mudanças na 18.3, consulte as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Para uma lista de mudanças na 18.3, veja as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
 
 </Note>
 
 Neste post, vamos guiá-lo pelos passos para atualizar bibliotecas para o React 19 beta:
 
 - [Instalação](#installing)
-- [Alterações quebradoras](#breaking-changes)
-- [Novas desativações](#new-deprecations)
+- [Mudanças quebradoras](#breaking-changes)
+- [Novas deprecações](#new-deprecations)
 - [Mudanças notáveis](#notable-changes)
 - [Mudanças no TypeScript](#typescript-changes)
 - [Changelog](#changelog)
 
-Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, consulte o [post de lançamento do React 19](/blog/2024/04/25/react-19).
+Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [reporte quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao React 19 beta, veja o [post de lançamento do React 19](/blog/2024/04/25/react-19).
 
 ---
 ## Instalação {/*installing*/}
 
 <Note>
 
-#### Novo JSX Transform agora é necessário {/*new-jsx-transform-is-now-required*/}
+#### Novo transformador JSX agora é necessário {/*new-jsx-transform-is-now-required*/}
 
-Introduzimos um [novo JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias na velocidade do JSX que exigem o novo transform.
+Introduzimos um [novo transformador JSX](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias de velocidade do JSX que requerem o novo transformador.
 
-Se o novo transform não estiver habilitado, você verá este aviso:
+Se o novo transformador não estiver habilitado, você verá este aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Seu aplicativo (ou uma de suas dependências) está usando um transform JSX desatualizado. Atualize para o transform JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
+Seu aplicativo (ou uma de suas dependências) está usando um transformador JSX desatualizado. Atualize para o transformador JSX moderno para um desempenho mais rápido: https://react.dev/link/new-jsx-transform
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
 
-Esperamos que a maioria dos aplicativos não seja afetada, pois o transform já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, consulte o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Esperamos que a maioria dos aplicativos não seja afetada, pois o transformador já está habilitado na maioria dos ambientes. Para instruções manuais sobre como atualizar, veja o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
 </Note>
 
@@ -80,7 +80,7 @@ Para instalar a versão mais recente do React e do React DOM:
 npm install react@beta react-dom@beta
 ```
 
-Se você estiver usando TypeScript, você também precisa atualizar os tipos. Uma vez que o React 19 seja lançado como estável, você pode instalar os tipos normalmente de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser impostos no seu `package.json`:
+Se você estiver usando TypeScript, também precisará atualizar os tipos. Assim que o React 19 for lançado como estável, você pode instalar os tipos como de costume de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser impostos em seu `package.json`:
 
 ```json
 {
@@ -95,21 +95,21 @@ Se você estiver usando TypeScript, você também precisa atualizar os tipos. Um
 }
 ```
 
-Também estamos incluindo um codemod para as substituições mais comuns. Consulte [Mudanças no TypeScript](#typescript-changes) abaixo.
+Também estamos incluindo um codemod para as substituições mais comuns. Veja [Mudanças no TypeScript](#typescript-changes) abaixo.
 
 
-## Alterações quebradoras {/*breaking-changes*/}
+## Mudanças quebradoras {/*breaking-changes*/}
 
-### Erros durante a renderização não são mais relançados {/*errors-in-render-are-not-re-thrown*/}
+### Erros na renderização não são mais relançados {/*errors-in-render-are-not-re-thrown*/}
 
-Nas versões anteriores do React, os erros lançados durante a renderização eram capturados e relançados. No modo DEV, nós também registraríamos no `console.error`, resultando em logs de erro duplicados.
+Nas versões anteriores do React, erros lançados durante a renderização eram capturados e relançados. No ambiente de desenvolvimento (DEV), também registrávamos no `console.error`, resultando em logs de erro duplicados. 
 
-No React 19, [melhoramos como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação ao não relançar:
+No React 19, melhoramos [como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação ao não relançar:
 
-- **Erros não capturados**: Erros que não são capturados por um Error Boundary são relatados para `window.reportError`.
-- **Erros capturados**: Erros que são capturados por um Error Boundary são relatados para `console.error`.
+- **Erros Não Capturados**: Erros que não são capturados por um Error Boundary são reportados para `window.reportError`.
+- **Erros Capturados**: Erros que são capturados por um Error Boundary são reportados para `console.error`.
 
-Essa mudança não deve impactar a maioria dos aplicativos, mas se o seu relatório de erros em produção depender do relançamento de erros, pode ser necessário atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erros personalizado:
+Essa mudança não deve impactar a maioria dos aplicativos, mas se o seu relatório de erro em produção depender do relançamento de erros, pode ser necessário atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erro personalizado:
 
 ```js [[1, 2, "onUncaughtError"], [2, 5, "onCaughtError"]]
 const root = createRoot(container, {
@@ -122,17 +122,17 @@ const root = createRoot(container, {
 });
 ```
 
-Para mais informações, consulte a documentação de [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
+Para mais informações, veja a documentação de [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
 
 
-### APIs do React obsoletas removidas {/*removed-deprecated-react-apis*/}
+### APIs React depreciadas removidas {/*removed-deprecated-react-apis*/}
 
 #### Removido: `propTypes` e `defaultProps` para funções {/*removed-proptypes-and-defaultprops*/}
-`PropTypes` foram descontinuados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
+`PropTypes` foram depreciados em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
 
-No React 19, estamos removendo as verificações `propType` do pacote React e usá-las será silenciosamente ignorado. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
+No React 19, estamos removendo as verificações `propType` do pacote React, e usá-las será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
 
-Também estamos removendo `defaultProps` de componentes de função em favor de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, uma vez que não há alternativa do ES6.
+Estamos também removendo `defaultProps` de componentes de função em favor de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, pois não há uma alternativa em ES6.
 
 ```js
 // Antes
@@ -160,9 +160,9 @@ function Heading({text = 'Hello, world!'}: Props) {
 
 #### Removido: Contexto Legado usando `contextTypes` e `getChildContext` {/*removed-removing-legacy-context*/}
 
-O Contexto Legado foi descontinuado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
+O Contexto Legado foi depreciado em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
 
-O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React um pouco menor e mais rápido.
+O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para tornar o React ligeiramente menor e mais rápido.
 
 Se você ainda estiver usando o Contexto Legado em componentes de classe, precisará migrar para a nova API `contextType`:
 
@@ -218,12 +218,12 @@ class Child extends React.Component {
 }
 ```
 
-#### Removido: referências de string {/*removed-string-refs*/}
-Referências de string foram descontinuadas em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+#### Removido: refs de string {/*removed-string-refs*/}
+Refs de string foram depreciadas em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
-Componentes de classe suportavam referências de string antes de serem substituídas por callbacks de ref devido a [múltiplas desvantagens](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo referências de string para tornar o React mais simples e fácil de entender.
+Componentes de classe suportavam refs de string antes de serem substituídas por callbacks de ref devido a [vários problemas](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo refs de string para simplificar o React e torná-lo mais fácil de entender.
 
-Se você ainda estiver usando referências de string em componentes de classe, precisará migrar para callbacks de ref:
+Se você ainda estiver usando refs de string em componentes de classe, precisará migrar para callbacks de ref:
 
 ```js {4,8}
 // Antes
@@ -253,14 +253,14 @@ class MyComponent extends React.Component {
 
 <Note>
 
-Para ajudar na migração, estaremos publicando um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente referências de string por callbacks de `ref`. Siga [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-lo.
+Para ajudar na migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de `ref`. Siga [este PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentá-lo.
 
 </Note>
 
-#### Removido: fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
-Fábricas de padrão de módulo foram descontinuadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
+#### Removido: Fábricas de padrões de módulo {/*removed-module-pattern-factories*/}
+Fábricas de padrões de módulo foram depreciadas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
 
-Esse padrão era raramente utilizado e seu suporte faz com que o React seja ligeiramente maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrão de módulo, e você precisará migrar para funções regulares:
+Esse padrão foi raramente usado e seu suporte faz o React ser um pouco maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrões de módulo, e você precisará migrar para funções regulares:
 
 ```js
 // Antes
@@ -277,9 +277,9 @@ function FactoryComponent() {
 ```
 
 #### Removido: `React.createFactory` {/*removed-createfactory*/}
-`createFactory` foi descontinuado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
+`createFactory` foi depreciado em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
 
-O uso de `createFactory` era comum antes do amplo suporte ao JSX, mas é raramente utilizado hoje e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
+Usar `createFactory` era comum antes do amplo suporte ao JSX, mas é raramente usado hoje e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
 
 ```js
 // Antes
@@ -295,7 +295,7 @@ const button = <button />;
 
 #### Removido: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
 
-No React 18, atualizamos `react-test-renderer/shallow` para re-exportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir a instalação do pacote diretamente:
+No React 18, atualizamos `react-test-renderer/shallow` para re-exportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir instalar o pacote diretamente:
 
 ```bash
 npm install react-shallow-renderer --save-dev
@@ -309,11 +309,11 @@ npm install react-shallow-renderer --save-dev
 
 ##### Por favor, reconsidere a renderização superficial {/*please-reconsider-shallow-rendering*/}
 
-A renderização superficial depende dos internos do React e pode bloqueá-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started).
+A renderização superficial depende de internos do React e pode bloquear futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
 
 </Note>
 
-### APIs do React DOM obsoletas removidas {/*removed-deprecated-react-dom-apis*/}
+### APIs React DOM depreciadas removidas {/*removed-deprecated-react-dom-apis*/}
 
 #### Removido: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
 
@@ -323,26 +323,26 @@ Mudamos `act` de `react-dom/test-utils` para o pacote `react`:
 
 <ConsoleLogLine level="error">
 
-`ReactDOMTestUtils.act` está obsoleta em favor de `React.act`. Importar `act` do `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
+`ReactDOMTestUtils.act` é depreciado em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Para corrigir esse aviso, você pode importar `act` do `react`:
+Para corrigir este aviso, você pode importar `act` de `react`:
 
 ```diff
 - import {act} from 'react-dom/test-utils'
 + import {act} from 'react';
 ```
 
-Todas as outras funções de `test-utils` foram removidas. Essas utilidades eram incomuns e tornavam muito fácil depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão um erro quando chamadas e suas exportações serão removidas em uma versão futura.
+Todas as outras funções de `test-utils` foram removidas. Esses utilitários eram incomuns e tornavam muito fácil depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão um erro quando chamadas e suas exportações serão removidas em uma versão futura.
 
-Consulte a [página de avisos](https://react.dev/warnings/react-dom-test-utils) para alternativas.
+Veja a [página de aviso](https://react.dev/warnings/react-dom-test-utils) para alternativas.
 
 #### Removido: `ReactDOM.render` {/*removed-reactdom-render*/}
 
-`ReactDOM.render` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para o uso de [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
+`ReactDOM.render` foi depreciado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para usar [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
 
 ```js
 // Antes
@@ -357,7 +357,7 @@ root.render(<App />);
 
 #### Removido: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
 
-`ReactDOM.hydrate` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para o uso de [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
+`ReactDOM.hydrate` foi depreciado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate`, você precisará migrar para usar [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
 
 ```js
 // Antes
@@ -372,7 +372,7 @@ hydrateRoot(document.getElementById('root'), <App />);
 
 #### Removido: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
 
-`ReactDOM.unmountComponentAtNode` foi descontinuado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para o uso de `root.unmount()`.
+`ReactDOM.unmountComponentAtNode` foi depreciado em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para usar `root.unmount()`.
 
 
 ```js
@@ -383,13 +383,13 @@ unmountComponentAtNode(document.getElementById('root'));
 root.unmount();
 ```
 
-Para mais informações, consulte `root.unmount()` para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
+Para mais informações, veja `root.unmount()` para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
 
 
 #### Removido: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
-`ReactDOM.findDOMNode` foi [descontinuado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode).
+`ReactDOM.findDOMNode` foi [depreciado em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
 
-Estamos removendo `findDOMNode` porque era uma válvula de escape legada que era lenta para executar, frágil para refatoração, retornava apenas o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
+Estamos removendo `findDOMNode` porque era uma alternativa legada que era lenta para executar, frágil à refatoração, apenas retornava o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
 
 ```js
 // Antes
@@ -417,11 +417,11 @@ function AutoselectingInput() {
 }
 ```
 
-## Novas desativações {/*new-deprecations*/}
+## Novas deprecações {/*new-deprecations*/}
 
-### Obsoleto: `element.ref` {/*deprecated-element-ref*/}
+### Depecado: `element.ref` {/*deprecated-element-ref*/}
 
-O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos descontinuando o `element.ref` em favor de `element.props.ref`.
+O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos depreciando `element.ref` em vez de `element.props.ref`.
 
 Acessar `element.ref` gerará um aviso:
 
@@ -429,19 +429,19 @@ Acessar `element.ref` gerará um aviso:
 
 <ConsoleLogLine level="error">
 
-Acessar element.ref não é mais suportado. ref agora é uma prop regular. Será removido do tipo JSX Element em uma versão futura.
+Acessar element.ref não é mais suportado. ref agora é uma prop regular. Ele será removido do tipo JSX Element em uma versão futura.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### Obsoleto: `react-test-renderer` {/*deprecated-react-test-renderer*/}
+### Depecado: `react-test-renderer` {/*deprecated-react-test-renderer*/}
 
-Estamos descontinuando `react-test-renderer` porque implementa seu próprio ambiente de renderização que não corresponde ao ambiente usado pelos usuários, promove o teste de detalhes de implementação e depende da introspecção dos internos do React.
+Estamos depreciando `react-test-renderer` porque implementa seu próprio ambiente de renderização que não corresponde ao ambiente que os usuários usam, promove testes de detalhes de implementação e depende da introspecção dos internos do React.
 
-O test renderer foi criado antes que houvesse estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos o uso de uma biblioteca de teste moderna em vez disso.
+O renderizador de teste foi criado antes que houvesse estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de teste moderna em vez disso.
 
-No React 19, `react-test-renderer` registra um aviso de descontinuação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
+No React 19, `react-test-renderer` registra um aviso de deprecação e mudou para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
 
 ## Mudanças notáveis {/*notable-changes*/}
 
@@ -449,15 +449,15 @@ No React 19, `react-test-renderer` registra um aviso de descontinuação e mudou
 
 O React 19 inclui várias correções e melhorias no Strict Mode.
 
-Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem notar nenhuma diferença no comportamento.
+Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não devem notar diferença no comportamento.
 
-Como em todos os comportamentos do Strict Mode, esses recursos são projetados para ativar proativamente bugs em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes que sejam enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode chamará duas vezes as funções de callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
+Como acontece com todos os comportamentos do Strict Mode, esses recursos são projetados para detectar proativamente erros em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode invocará duas vezes as funções de callback de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback de Suspense.
 
-### Construções UMD removidas {/*umd-builds-removed*/}
+### Builds UMD removidas {/*umd-builds-removed*/}
 
-UMD foi amplamente utilizado no passado como uma maneira conveniente de carregar o React sem um passo de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais construções UMD para reduzir a complexidade de seu processo de teste e lançamento.
+UMD era amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais builds UMD para reduzir a complexidade de seu processo de teste e lançamento. 
 
-Para carregar o React 19 com uma tag de script, recomendamos o uso de uma CDN baseada em ESM, como [esm.sh](https://esm.sh/).
+Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado em ESM como [esm.sh](https://esm.sh/).
 
 ```html
 <script type="module">
@@ -467,23 +467,23 @@ Para carregar o React 19 com uma tag de script, recomendamos o uso de uma CDN ba
 </script>
 ```
 
-### Bibliotecas que dependem dos internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
+### Bibliotecas dependendo de internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
 
-Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos pedidos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para implementar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
+Este lançamento inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossos apelos para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para implementar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
 
-Com base na nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças quebradoras e não estamos incluindo documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
+Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças quebradoras e não incluiremos documentação sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
 
-Para refletir o impacto de usar internos, renomeamos o sufixo `SECRET_INTERNALS` para:
+Para refletir o impacto do uso de internos, renomeamos o sufixo `SECRET_INTERNALS` para: 
 
 `_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`
 
-No futuro, bloquearemos mais agressivamente o acesso aos internos do React para desencorajar o uso e garantir que os usuários não fiquem bloqueados nas atualizações.
+No futuro, bloquearemos de forma mais agressiva o acesso a internos do React para desencorajar o uso e garantir que os usuários não sejam bloqueados de atualizar.
 
 ## Mudanças no TypeScript {/*typescript-changes*/}
 
-### Tipos TypeScript obsoletos removidos {/*removed-deprecated-typescript-types*/}
+### Tipos TypeScript depreciados removidos {/*removed-deprecated-typescript-types*/}
 
-Limparamos os tipos do TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
+Limparamos os tipos TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes, e outros não são mais necessários para descrever o comportamento do React.
 
 <Note>
 Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças quebradoras relacionadas a tipos:
@@ -492,7 +492,7 @@ Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemo
 npx types-react-codemod@latest preset-19 ./path-to-app
 ```
 
-Se você tiver muito acesso inseguro a `element.props`, pode executar este codemod adicional:
+Se você tem um acesso inconsistente a `element.props`, pode executar este codemod adicional:
 
 ```bash
 npx types-react-codemod@latest react-element-default-any-props ./path-to-your-react-ts-files
@@ -500,40 +500,40 @@ npx types-react-codemod@latest react-element-default-any-props ./path-to-your-re
 
 </Note>
 
-Confira [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você sentir que um codemod está faltando, isso pode ser rastreado na [lista de codemods do React 19 que estão faltando](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
+Veja [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você achar que um codemod está faltando, ele pode ser rastreado na [lista de codemods ausentes do React 19](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
 
 
-### Limpezas de `ref` necessárias {/*ref-cleanup-required*/}
+### Limpeza de `ref` necessária {/*ref-cleanup-required*/}
 
-_Esta mudança está incluída no preset codemod `react-19` como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
+_Esta mudança está incluída no preset `react-19` codemod como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
 
-Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de uma callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
+Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de um callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
+O código original retornou a instância do `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
 
 ### `useRef` requer um argumento {/*useref-requires-argument*/}
 
-_Esta mudança está incluída no preset codemod `react-19` como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
+_Esta mudança está incluída no preset `react-19` codemod como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
 
-Uma longa reclamação sobre como o TypeScript e o React funcionam tem sido o `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
+Uma reclamação de longa data sobre como TypeScript e React funcionam tem sido o `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
 
 ```ts
-// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
+// @ts-expect-error: Esperava 1 argumento mas não viu nenhum
 useRef();
-// Passa
+// Aceita
 useRef(undefined);
-// @ts-expect-error: Esperado 1 argumento mas nenhum foi visto
+// @ts-expect-error: Esperava 1 argumento mas não viu nenhum
 createContext();
-// Passa
+// Aceita
 createContext(undefined);
 ```
 
-Isso agora também significa que todas as refs são mutáveis. Você não terá mais o problema em que não pode mutar uma ref porque a inicializou com `null`:
+Isso agora também significa que todas as refs são mutáveis. Você não encontrará mais o problema em que não pode mutar uma ref porque você a inicializou com `null`:
 
 ```ts
 const ref = useRef<number>(null);
@@ -542,7 +542,7 @@ const ref = useRef<number>(null);
 ref.current = 1;
 ```
 
-`MutableRef` agora está obsoleto em favor de um único tipo `RefObject` que `useRef` sempre retornará:
+`MutableRef` agora é depreciado em favor de um único tipo `RefObject` que `useRef` sempre retornará:
 
 ```ts
 interface RefObject<T> {
@@ -552,36 +552,36 @@ interface RefObject<T> {
 declare function useRef<T>: RefObject<T>
 ```
 
-`useRef` ainda tem uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento requerido para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que automaticamente retorna `RefObject<T | undefined>`.
+`useRef` ainda possui uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento requerido para `useRef`, uma sobrecarga de conveniência para `useRef(undefined)` foi adicionada que automaticamente retorna `RefObject<T | undefined>`.
 
-Confira [[RFC] Fazer todas as refs mutáveis](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
+Veja [[RFC] Faça todas as refs mutáveis](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
 
 ### Mudanças no tipo TypeScript `ReactElement` {/*changes-to-the-reactelement-typescript-type*/}
 
 _Esta mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
 
-As `props` dos elementos React agora padrão para `unknown` em vez de `any` se o elemento for tipado como `ReactElement`. Isso não afeta você se você passar um argumento de tipo para `ReactElement`:
+As `props` de elementos React agora padrão para `unknown` em vez de `any` se o elemento estiver tipado como `ReactElement`. Isso não afetará você se passar um argumento de tipo para `ReactElement`:
 
 ```ts
 type Example2 = ReactElement<{ id: string }>["props"];
 //   ^? { id: string }
 ```
 
-Mas se você contava com o padrão, agora precisa lidar com `unknown`:
+Mas se você confiar no padrão, agora terá que lidar com `unknown`:
 
 ```ts
 type Example = ReactElement["props"];
 //   ^? Antes, era 'any', agora 'unknown'
 ```
 
-Você só deve precisar disso se tiver muito código legado dependendo do acesso inseguro às `props` do elemento. A introspecção do elemento existe apenas como uma válvula de escape, e você deve deixar explícito que seu acesso às `props` é inseguro via `any` explícito.
+Você só precisará disso se tiver muito código legado confiando em acesso inconsistente às props do elemento. A introspecção de elementos existe apenas como uma alternativa, e você deve deixar explícito que seu acesso às props é inconsistente por meio de um explícito `any`.
 
 ### O namespace JSX no TypeScript {/*the-jsx-namespace-in-typescript*/}
-Esta mudança está incluída no preset codemod `react-19` como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
+Esta mudança está incluída no preset `react-19` codemod como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
 
-Um pedido antigo é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais, que previne conflitos entre diferentes bibliotecas de UI que utilizam JSX.
+Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais que impede conflitos entre diferentes bibliotecas de UI que aproveitam JSX.
 
-Agora você precisará encapsular a ampliação do módulo do namespace JSX em `declare module "....`:
+Agora você precisará envolver a augmentação de módulo do namespace JSX em `declare module "....":
 
 ```diff
 // global.d.ts
@@ -596,34 +596,34 @@ Agora você precisará encapsular a ampliação do módulo do namespace JSX em `
 + }
 ```
 
-O especificador exato do módulo depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
+O especifier exato do módulo depende do runtime JSX que você especificou nas `compilerOptions` do seu `tsconfig.json`:
 
 - Para `"jsx": "react-jsx"` seria `react/jsx-runtime`.
 - Para `"jsx": "react-jsxdev"` seria `react/jsx-dev-runtime`.
 - Para `"jsx": "react"` e `"jsx": "preserve"` seria `react`.
 
-### Melhores typings para `useReducer` {/*better-usereducer-typings*/}
+### Melhores tipagens para `useReducer` {/*better-usereducer-typings*/}
 
-`useReducer` agora tem uma inferência de tipo melhorada graças a [@mfp22](https://github.com/mfp22).
+`useReducer` agora possui inferência de tipos melhorada graças a [@mfp22](https://github.com/mfp22).
 
-No entanto, isso exigiu uma mudança quebradora onde `useReducer` não aceita o tipo completo do reduzidor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos os tipos de estado e ação.
+No entanto, isso exigiu uma mudança quebradora onde `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa de ambos os tipos de estado e ação.
 
 A nova melhor prática é _não_ passar argumentos de tipo para `useReducer`.
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer(reducer)
 ```
-Isso pode não funcionar em casos extremos onde você pode tipar explicitamente o estado e a ação, passando o `Action` em uma tupla:
+Isso pode não funcionar em casos limite onde você pode tipar explicitamente o estado e a ação, passando o `Action` em uma tupla:
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer<State, [Action]>(reducer)
 ```
-Se você definir o reduzidor inline, recomendamos anotar os parâmetros da função em vez disso:
+Se você definir o redutor inline, recomendamos anotar os parâmetros da função em vez disso:
 ```diff
 - useReducer<React.Reducer<State, Action>>((state, action) => state)
 + useReducer((state: State, action: Action) => state)
 ```
-Isso também é o que você também teria que fazer se mover o reduzidor para fora da chamada `useReducer`:
+Isso é também o que você precisaria fazer se mover o redutor para fora da chamada `useReducer`:
 
 ```ts
 const reducer = (state: State, action: Action) => state;
@@ -634,24 +634,24 @@ const reducer = (state: State, action: Action) => state;
 ### Outras mudanças quebradoras {/*other-breaking-changes*/}
 
 - **react-dom**: Erro para URLs javascript em src/href [#26507](https://github.com/facebook/react/pull/26507)
-- **react-dom**: Remover `errorInfo.digest` do `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
+- **react-dom**: Remover `errorInfo.digest` de `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
 - **react-dom**: Remover `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
 - **react-dom**: Remover `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
 - **react-dom**: Remover `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
 - **react-dom**: Remover `unstable_runWithPrioirty` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-is**: Remover métodos obsoletos de `react-is` [28224](https://github.com/facebook/react/pull/28224)
+- **react-is**: Remover métodos depreciados de `react-is` [28224](https://github.com/facebook/react/pull/28224)
 
 ### Outras mudanças notáveis {/*other-notable-changes*/}
 
-- **react**: Lotes síncronos, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
+- **react**: Loteamento síncrono, lanes padrão e contínuas [#25700](https://github.com/facebook/react/pull/25700)
 - **react**: Não pré-renderizar irmãos do componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
 - **react**: Detectar loops de atualização infinitos causados por atualizações na fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
 - **react-dom**: Transições em popstate agora são síncronas [#26025](https://github.com/facebook/react/pull/26025)
 - **react-dom**: Remover aviso de efeito de layout durante SSR [#26395](https://github.com/facebook/react/pull/26395)
-- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags âncora) [#28124](https://github.com/facebook/react/pull/28124)
+- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags de âncora) [#28124](https://github.com/facebook/react/pull/28124)
 
 Publicaremos o changelog completo com o lançamento estável do React 19.
 
 ---
 
-Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) pela revisão e edição deste post.
+Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) por revisar e editar este post.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.