### PR TITLE
Translate `react-19.md` to pt-br

### DIFF
--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -2,45 +2,45 @@
 title: "React 19 Beta"
 author: The React Team
 date: 2024/04/25
-description: React 19 Beta is now available on npm! In this post, we'll give an overview of the new features in React 19, and how you can adopt them.
+description: React 19 Beta agora está disponível no npm! Neste post, faremos uma visão geral das novas funcionalidades no React 19 e como você pode adotá-las.
 ---
 
-April 25, 2024 by [The React Team](/community/team)
+25 de abril de 2024 por [The React Team](/community/team)
 
 ---
 
 <Note>
 
-This beta release is for libraries to prepare for React 19. App developers should upgrade to 18.3.0 and wait for React 19 stable as we work with libraries and make changes based on feedback.
+Esta versão beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar o React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
 <Intro>
 
-React 19 Beta is now available on npm!
+React 19 Beta agora está disponível no npm!
 
 </Intro>
 
-In our [React 19 Beta Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide), we shared step-by-step instructions for upgrading your app to React 19 Beta. In this post, we'll give an overview of the new features in React 19, and how you can adopt them.
+No nosso [Guia de Atualização do React 19 Beta](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19 Beta. Neste post, faremos uma visão geral das novas funcionalidades no React 19 e como você pode adotá-las.
 
-- [What's new in React 19](#whats-new-in-react-19)
-- [Improvements in React 19](#improvements-in-react-19)
-- [How to upgrade](#how-to-upgrade)
+- [O que há de novo no React 19](#whats-new-in-react-19)
+- [Melhorias no React 19](#improvements-in-react-19)
+- [Como atualizar](#how-to-upgrade)
 
-For a list of breaking changes, see the [Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide).
+Para uma lista de mudanças significativas, veja o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
 
 ---
 
-## What's new in React 19 {/*whats-new-in-react-19*/}
+## O que há de novo no React 19 {/*whats-new-in-react-19*/}
 
-### Actions {/*actions*/}
+### Ações {/*actions*/}
 
-A common use case in React apps is to perform a data mutation and then update state in response. For example, when a user submits a form to change their name, you will make an API request, and then handle the response. In the past, you would need to handle pending states, errors, optimistic updates, and sequential requests manually.
+Um caso de uso comum em aplicativos React é executar uma mutação de dados e, em seguida, atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para alterar seu nome, você fará uma solicitação de API e, em seguida, lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
 
-For example, you could handle the pending and error state in `useState`:
+Por exemplo, você poderia lidar com o estado pendente e o erro em `useState`:
 
 ```js
-// Before Actions
+// Antes das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -61,7 +61,7 @@ function UpdateName({}) {
     <div>
       <input value={name} onChange={(event) => setName(event.target.value)} />
       <button onClick={handleSubmit} disabled={isPending}>
-        Update
+        Atualizar
       </button>
       {error && <p>{error}</p>}
     </div>
@@ -69,12 +69,12 @@ function UpdateName({}) {
 }
 ```
 
-In React 19, we're adding support for using async functions in transitions to handle pending states, errors, forms, and optimistic updates automatically.
+No React 19, estamos adicionando suporte ao uso de funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
 
-For example, you can use `useTransition` to handle the pending state for you:
+Por exemplo, você pode usar `useTransition` para lidar com o estado pendente para você:
 
 ```js
-// Using pending state from Actions
+// Usando estado pendente das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -95,7 +95,7 @@ function UpdateName({}) {
     <div>
       <input value={name} onChange={(event) => setName(event.target.value)} />
       <button onClick={handleSubmit} disabled={isPending}>
-        Update
+        Atualizar
       </button>
       {error && <p>{error}</p>}
     </div>
@@ -103,27 +103,27 @@ function UpdateName({}) {
 }
 ```
 
-The async transition will immediately set the `isPending` state to true, make the async request(s), and switch `isPending` to false after any transitions. This allows you to keep the current UI responsive and interactive while the data is changing.
+A transição assíncrona definirá imediatamente o estado `isPending` como verdadeiro, fará a(s) solicitação(ões) assíncrona(s) e mudará `isPending` para falso após qualquer transição. Isso permite que você mantenha a UI atual responsiva e interativa enquanto os dados estão mudando.
 
 <Note>
 
-#### By convention, functions that use async transitions are called "Actions". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
+#### Por convenção, funções que usam transições assíncronas são chamadas de "Ações". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
 
-Actions automatically manage submitting data for you:
+Ações gerenciam automaticamente o envio de dados para você:
 
-- **Pending state**: Actions provide a pending state that starts at the beginning of a request and automatically resets when the final state update is committed.
-- **Optimistic updates**: Actions support the new [`useOptimistic`](#new-hook-optimistic-updates) hook so you can show users instant feedback while the requests are submitting.
-- **Error handling**: Actions provide error handling so you can display Error Boundaries when a request fails, and revert optimistic updates to their original value automatically.
-- **Forms**: `<form>` elements now support passing functions to the `action` and `formAction` props. Passing functions to the `action` props use Actions by default and reset the form automatically after submission.
+- **Estado pendente**: Ações fornecem um estado pendente que começa no início de uma solicitação e reinicia automaticamente quando a atualização final do estado é comprometida.
+- **Atualizações otimistas**: Ações suportam o novo hook [`useOptimistic`](#new-hook-optimistic-updates) para que você possa mostrar aos usuários um feedback instantâneo enquanto as solicitações estão sendo enviadas.
+- **Tratamento de erros**: Ações fornecem tratamento de erros para que você possa exibir Limites de Erro quando uma solicitação falha e reverter automaticamente atualizações otimistas para seus valores originais.
+- **Formulários**: Elementos `<form>` agora suportam a passagem de funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e reinicia o formulário automaticamente após a submissão.
 
 </Note>
 
-Building on top of Actions, React 19 introduces [`useOptimistic`](#new-hook-optimistic-updates) to manage optimistic updates, and a new hook [`React.useActionState`](#new-hook-useactionstate) to handle common cases for Actions. In `react-dom` we're adding [`<form>` Actions](#form-actions) to manage forms automatically and [`useFormStatus`](#new-hook-useformstatus) to support the common cases for Actions in forms.
+Construindo em cima das Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns para Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar os casos comuns de Ações em formulários.
 
-In React 19, the above example can be simplified to:
+No React 19, o exemplo acima pode ser simplificado para:
 
 ```js
-// Using <form> Actions and useActionState
+// Usando <form> Ações e useActionState
 function ChangeName({ name, setName }) {
   const [error, submitAction, isPending] = useActionState(
     async (previousState, formData) => {
@@ -140,63 +140,63 @@ function ChangeName({ name, setName }) {
   return (
     <form action={submitAction}>
       <input type="text" name="name" />
-      <button type="submit" disabled={isPending}>Update</button>
+      <button type="submit" disabled={isPending}>Atualizar</button>
       {error && <p>{error}</p>}
     </form>
   );
 }
 ```
 
-In the next section, we'll break down each of the new Action features in React 19.
+Na próxima seção, vamos detalhar cada uma das novas funcionalidades das Ações no React 19.
 
-### New hook: `useActionState` {/*new-hook-useactionstate*/}
+### Novo hook: `useActionState` {/*new-hook-useactionstate*/}
 
-To make the common cases easier for Actions, we've added a new hook called `useActionState`:
+Para facilitar os casos comuns para Ações, adicionamos um novo hook chamado `useActionState`:
 
 ```js
 const [error, submitAction, isPending] = useActionState(
   async (previousState, newName) => {
     const error = await updateName(newName);
     if (error) {
-      // You can return any result of the action.
-      // Here, we return only the error.
+      // Você pode retornar qualquer resultado da ação.
+      // Aqui, retornamos apenas o erro.
       return error;
     }
 
-    // handle success
+    // lidar com sucesso
     return null;
   },
   null,
 );
 ```
 
-`useActionState` accepts a function (the "Action"), and returns a wrapped Action to call. This works because Actions compose. When the wrapped Action is called, `useActionState` will return the last result of the Action as `data`, and the pending state of the Action as `pending`. 
+`useActionState` aceita uma função (a "Ação") e retorna uma Ação encapsulada a ser chamada. Isso funciona porque as Ações se compõem. Quando a Ação encapsulada é chamada, `useActionState` retornará o último resultado da Ação como `data` e o estado pendente da Ação como `pending`. 
 
 <Note>
 
-`React.useActionState` was previously called `ReactDOM.useFormState` in the Canary releases, but we've renamed it and deprecated `useFormState`.
+`React.useActionState` foi anteriormente chamado de `ReactDOM.useFormState` nas versões Canary, mas o renomeamos e depreciamos `useFormState`.
 
-See [#28491](https://github.com/facebook/react/pull/28491) for more info.
+Veja [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
 
 </Note>
 
-For more information, see the docs for [`useActionState`](/reference/react/useActionState).
+Para mais informações, veja a documentação para [`useActionState`](/reference/react/useActionState).
 
-### React DOM: `<form>` Actions {/*form-actions*/}
+### React DOM: `<form>` Ações {/*form-actions*/}
 
-Actions are also integrated with React 19's new `<form>` features for `react-dom`. We've added support for passing functions as the `action` and `formAction` props of `<form>`, `<input>`, and `<button>` elements to automatically submit forms with Actions:
+As Ações também estão integradas com as novas funcionalidades de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como as props `action` e `formAction` de `<form>`, `<input>` e `<button>` para enviar automaticamente formulários com Ações:
 
 ```js [[1,1,"actionFunction"]]
 <form action={actionFunction}>
 ```
 
-When a `<form>` Action succeeds, React will automatically reset the form for uncontrolled components. If you need to reset the `<form>` manually, you can call the new `requestFormReset` React DOM API.
+Quando uma Ação de `<form>` tem sucesso, o React automaticamente reinicia o formulário para componentes não controlados. Se você precisar reiniciar o `<form>` manualmente, pode chamar a nova API React DOM `requestFormReset`.
 
-For more information, see the `react-dom` docs for [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input), and `<button>`.
+Para mais informações, veja a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input) e `<button>`.
 
-### React DOM: New hook: `useFormStatus` {/*new-hook-useformstatus*/}
+### React DOM: Novo hook: `useFormStatus` {/*new-hook-useformstatus*/}
 
-In design systems, it's common to write design components that need access to information about the `<form>` they're in, without drilling props down to the component. This can be done via Context, but to make the common case easier, we've added a new hook `useFormStatus`:
+Em sistemas de design, é comum escrever componentes de design que precisam de acesso a informações sobre o `<form>` em que estão, sem passar props adiante para o componente. Isso pode ser feito via Contexto, mas para facilitar o caso comum, adicionamos um novo hook `useFormStatus`:
 
 ```js [[1, 4, "pending"], [1, 5, "pending"]]
 import {useFormStatus} from 'react-dom';
@@ -207,13 +207,13 @@ function DesignButton() {
 }
 ```
 
-`useFormStatus` reads the status of the parent `<form>` as if the form was a Context provider.
+`useFormStatus` lê o status do `<form>` pai como se o formulário fosse um provedor de Contexto.
 
-For more information, see the `react-dom` docs for [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+Para mais informações, veja a documentação do `react-dom` para [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
 
-### New hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
+### Novo hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
 
-Another common UI pattern when performing a data mutation is to show the final state optimistically while the async request is underway. In React 19, we're adding a new hook called `useOptimistic` to make this easier:
+Outro padrão de UI comum ao realizar uma mutação de dados é mostrar o estado final de maneira otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
 
 ```js {2,6,13,19}
 function ChangeName({currentName, onUpdateName}) {
@@ -228,9 +228,9 @@ function ChangeName({currentName, onUpdateName}) {
 
   return (
     <form action={submitAction}>
-      <p>Your name is: {optimisticName}</p>
+      <p>Seu nome é: {optimisticName}</p>
       <p>
-        <label>Change Name:</label>
+        <label>Alterar Nome:</label>
         <input
           type="text"
           name="name"
@@ -242,30 +242,30 @@ function ChangeName({currentName, onUpdateName}) {
 }
 ```
 
-The `useOptimistic` hook will immediately render the `optimisticName` while the `updateName` request is in progress. When the update finishes or errors, React will automatically switch back to the `currentName` value.
+O hook `useOptimistic` renderizará imediatamente o `optimisticName` enquanto a solicitação `updateName` estiver em andamento. Quando a atualização termina ou falha, o React mudará automaticamente de volta para o valor `currentName`.
 
-For more information, see the docs for [`useOptimistic`](/reference/react/useOptimistic).
+Para mais informações, veja a documentação para [`useOptimistic`](/reference/react/useOptimistic).
 
-### New API: `use` {/*new-feature-use*/}
+### Nova API: `use` {/*new-feature-use*/}
 
-In React 19 we're introducing a new API to read resources in render: `use`.
+No React 19, estamos introduzindo uma nova API para ler recursos durante a renderização: `use`.
 
-For example, you can read a promise with `use`, and React will Suspend until the promise resolves:
+Por exemplo, você pode ler uma promessa com `use`, e o React fará Suspense até que a promessa se resolva:
 
 ```js {1,5}
 import {use} from 'react';
 
 function Comments({commentsPromise}) {
-  // `use` will suspend until the promise resolves.
+  // `use` suspenderá até que a promessa se resolva.
   const comments = use(commentsPromise);
   return comments.map(comment => <p key={comment.id}>{comment}</p>);
 }
 
 function Page({commentsPromise}) {
-  // When `use` suspends in Comments,
-  // this Suspense boundary will be shown.
+  // Quando `use` suspender em Comentários,
+  // este limite de Suspense será mostrado.
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<div>Carregando...</div>}>
       <Comments commentsPromise={commentsPromise} />
     </Suspense>
   )
@@ -274,25 +274,25 @@ function Page({commentsPromise}) {
 
 <Note>
 
-#### `use` does not support promises created in render. {/*use-does-not-support-promises-created-in-render*/}
+#### `use` não suporta promessas criadas na renderização. {/*use-does-not-support-promises-created-in-render*/}
 
-If you try to pass a promise created in render to `use`, React will warn:
+Se você tentar passar uma promessa criada na renderização para `use`, o React avisará:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.
+Um componente foi suspenso por uma promessa não cacheada. Criar promessas dentro de um Componente Cliente ou hook ainda não é suportado, exceto via uma biblioteca ou framework compatível com Suspense.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-To fix, you need to pass a promise from a suspense powered library or framework that supports caching for promises. In the future we plan to ship features to make it easier to cache promises in render.
+Para corrigir, você precisa passar uma promessa de uma biblioteca ou framework alimentado por suspense que suporte cache para promessas. No futuro, planejamos lançar funcionalidades para facilitar o cache de promessas na renderização.
 
 </Note>
 
-You can also read context with `use`, allowing you to read Context conditionally such as after early returns:
+Você também pode ler o contexto com `use`, permitindo que você leia o Contexto condicionalmente, como após retornos antecipados:
 
 ```js {1,11}
 import {use} from 'react';
@@ -303,8 +303,8 @@ function Heading({children}) {
     return null;
   }
   
-  // This would not work with useContext
-  // because of the early return.
+  // Isso não funcionaria com useContext
+  // por causa do retorno antecipado.
   const theme = use(ThemeContext);
   return (
     <h1 style={{color: theme.color}}>
@@ -314,58 +314,56 @@ function Heading({children}) {
 }
 ```
 
-The `use` API can only be called in render, similar to hooks. Unlike hooks, `use` can be called conditionally. In the future we plan to support more ways to consume resources in render with `use`.
+A API `use` só pode ser chamada na renderização, semelhante aos hooks. Ao contrário dos hooks, `use` pode ser chamado condicionalmente. No futuro, planejamos suportar mais maneiras de consumir recursos durante a renderização com `use`.
 
-For more information, see the docs for [`use`](/reference/react/use).
-
-
-## React Server Components {/*react-server-components*/}
-
-### Server Components {/*server-components*/}
-
-Server Components are a new option that allows rendering components ahead of time, before bundling, in an environment separate from your client application or SSR server. This separate environment is the "server" in React Server Components. Server Components can run once at build time on your CI server, or they can be run for each request using a web server.
-
-React 19 includes all of the React Server Components features included from the Canary channel. This means libraries that ship with Server Components can now target React 19 as a peer dependency with a `react-server` [export condition](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) for use in frameworks that support the [Full-stack React Architecture](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
+Para mais informações, veja a documentação para [`use`](/reference/react/use).
 
 
-<Note>
+## Componentes do Servidor React {/*react-server-components*/}
 
-#### How do I build support for Server Components? {/*how-do-i-build-support-for-server-components*/}
+### Componentes do Servidor {/*server-components*/}
 
-While React Server Components in React 19 are stable and will not break between major versions, the underlying APIs used to implement a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x. 
+Os Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes de realizar o bundling, em um ambiente separado do seu aplicativo cliente ou servidor SSR. Este ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção no seu servidor CI, ou podem ser executados para cada solicitação usando um servidor web.
 
-To support React Server Components as a bundler or framework, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize the APIs used to implement React Server Components in the future.
-
-</Note>
-
-
-For more, see the docs for [React Server Components](/reference/rsc/server-components).
-
-### Server Actions {/*server-actions*/}
-
-Server Actions allow Client Components to call async functions executed on the server.
-
-When a Server Action is defined with the `"use server"` directive, your framework will automatically create a reference to the server function, and pass that reference to the Client Component. When that function is called on the client, React will send a request to the server to execute the function, and return the result.
+O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos no canal Canary. Isso significa que bibliotecas que são enviadas com Componentes do Servidor agora podem direcionar o React 19 como uma dependência peer com uma condição de exportação `react-server` [condicional](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura React Full-stack](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
 
 <Note>
 
-#### There is no directive for Server Components. {/*there-is-no-directive-for-server-components*/}
+#### Como posso construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
 
-A common misunderstanding is that Server Components are denoted by `"use server"`, but there is no directive for Server Components. The `"use server"` directive is used for Server Actions.
+Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um bundler ou framework de Componentes do Servidor React não seguem semver e podem quebrar entre versões menores no React 19.x. 
 
-For more info, see the docs for [Directives](/reference/rsc/directives).
+Para suportar os Componentes do Servidor React como um bundler ou framework, recomendamos que você fixo a uma versão específica do React ou use a versão Canary. Continuaremos trabalhando com bundlers e frameworks para estabilizar as APIs utilizadas para implementar os Componentes do Servidor React no futuro.
 
 </Note>
 
-Server Actions can be created in Server Components and passed as props to Client Components, or they can be imported and used in Client Components.
+Para mais, veja a documentação para [Componentes do Servidor React](/reference/rsc/server-components).
 
-For more, see the docs for [React Server Actions](/reference/rsc/server-actions).
+### Ações do Servidor {/*server-actions*/}
 
-## Improvements in React 19 {/*improvements-in-react-19*/}
+As Ações do Servidor permitem que Componentes Cliente chamem funções assíncronas executadas no servidor.
 
-### `ref` as a prop {/*ref-as-a-prop*/}
+Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência à função do servidor e passará essa referência para o Componente Cliente. Quando essa função for chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
 
-Starting in React 19, you can now access `ref` as a prop for function components:
+<Note>
+
+#### Não há diretiva para Componentes do Servidor. {/*there-is-no-directive-for-server-components*/}
+
+Uma compreensão comum é que os Componentes do Servidor são denotados por `"use server"`, mas não há diretiva para os Componentes do Servidor. A diretiva `"use server"` é usada para Ações do Servidor.
+
+Para mais informações, veja a documentação para [Diretivas](/reference/rsc/directives).
+
+</Note>
+
+As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes Cliente, ou podem ser importadas e usadas em Componentes Cliente.
+
+Para mais, veja a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
+
+## Melhorias no React 19 {/*improvements-in-react-19*/}
+
+### `ref` como uma prop {/*ref-as-a-prop*/}
+
+Começando no React 19, você agora pode acessar `ref` como uma prop para componentes de função:
 
 ```js [[1, 1, "ref"], [1, 2, "ref", 45], [1, 6, "ref", 14]]
 function MyInput({placeholder, ref}) {
@@ -376,87 +374,86 @@ function MyInput({placeholder, ref}) {
 <MyInput ref={ref} />
 ```
 
-New function components will no longer need `forwardRef`, and we will be publishing a codemod to automatically update your components to use the new `ref` prop. In future versions we will deprecate and remove `forwardRef`.
+Novos componentes de função não precisarão mais de `forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova prop `ref`. Nas versões futuras, iremos depreciar e remover `forwardRef`.
 
 <Note>
 
-`refs` passed to classes are not passed as props since they reference the component instance.
+`refs` passados para classes não são passados como props, pois fazem referência à instância do componente.
 
 </Note>
 
-### Diffs for hydration errors {/*diffs-for-hydration-errors*/}
+### Diferenças para erros de hidratação {/*diffs-for-hydration-errors*/}
 
-We also improved error reporting for hydration errors in `react-dom`. For example, instead of logging multiple errors in DEV without any information about the mismatch:
+Também melhoramos a reportagem de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar múltiplos erros em DEV sem nenhuma informação sobre a discrepância:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Warning: Text content did not match. Server: "Server" Client: "Client"
-{'  '}at span
-{'  '}at App
+Aviso: O conteúdo de texto não correspondia. Servidor: "Servidor" Cliente: "Cliente"
+{'  '}em span
+{'  '}em App
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Warning: An error occurred during hydration. The server HTML was replaced with client content in \<div\>.
+Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Warning: Text content did not match. Server: "Server" Client: "Client"
-{'  '}at span
-{'  '}at App
+Aviso: O conteúdo de texto não correspondia. Servidor: "Servidor" Cliente: "Cliente"
+{'  '}em span
+{'  '}em App
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Warning: An error occurred during hydration. The server HTML was replaced with client content in \<div\>.
+Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: Text content does not match server-rendered HTML.
-{'  '}at checkForUnmatchedText
+Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado no servidor.
+{'  '}em checkForUnmatchedText
 {'  '}...
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-We now log a single message with a diff of the mismatch:
-
+Agora registramos uma única mensagem com uma diferença da discrepância:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if an SSR-ed Client Component used:{'\n'}
-\- A server/client branch `if (typeof window !== 'undefined')`.
-\- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
-\- Date formatting in a user's locale which doesn't match the server.
-\- External changing data without sending a snapshot of it along with the HTML.
-\- Invalid HTML tag nesting.{'\n'}
-It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.{'\n'}
+Erro não capturado: A hidratação falhou porque o HTML renderizado pelo servidor não correspondesse ao cliente. Como resultado, esta árvore será regenerada no cliente. Isso pode acontecer se um Componente Cliente SSR-ed usou:{'\n'}
+\- Um branch servidor/clente `if (typeof window !== 'undefined')`.
+\- Entrada variável como `Date.now()` ou `Math.random()` que muda a cada chamada.
+\- Formatação de data na localidade de um usuário que não corresponde ao servidor.
+\- Dados externos que mudam sem enviar um instantâneo junto com o HTML.
+\- Aninhamento inválido de tags HTML.{'\n'}
+Isso também pode acontecer se o cliente tiver uma extensão do navegador instalada que baguncem o HTML antes do React carregar.{'\n'}
 https://react.dev/link/hydration-mismatch {'\n'}
 {'  '}\<App\>
 {'    '}\<span\>
-{'+    '}Client
-{'-    '}Server{'\n'}
-{'  '}at throwOnHydrationMismatch
+{'+    '}Cliente
+{'-    '}Servidor{'\n'}
+{'  '}em throwOnHydrationMismatch
 {'  '}...
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### `<Context>` as a provider {/*context-as-a-provider*/}
+### `<Context>` como um provedor {/*context-as-a-provider*/}
 
-In React 19, you can render `<Context>` as a provider instead of `<Context.Provider>`:
+No React 19, você pode renderizar `<Context>` como um provedor em vez de `<Context.Provider>`:
 
 
 ```js {5,7}
@@ -471,56 +468,55 @@ function App({children}) {
 }
 ```
 
-New Context providers can use `<Context>` and we will be publishing a codemod to convert existing providers. In future versions we will deprecate `<Context.Provider>`.
+Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod para converter provedores existentes. Nas versões futuras, iremos depreciar `<Context.Provider>`.
 
-### Cleanup functions for refs {/*cleanup-functions-for-refs*/}
+### Funções de limpeza para refs {/*cleanup-functions-for-refs*/}
 
-We now support returning a cleanup function from `ref` callbacks:
+Agora suportamos retornar uma função de limpeza dos callbacks de `ref`:
 
 ```js {7-9}
 <input
   ref={(ref) => {
-    // ref created
+    // ref criada
 
-    // NEW: return a cleanup function to reset
-    // the ref when element is removed from DOM.
+    // NOVO: retornar uma função de limpeza para redefinir
+    // a ref quando o elemento for removido do DOM.
     return () => {
-      // ref cleanup
+      // limpeza da ref
     };
   }}
 />
 ```
 
-When the component unmounts, React will call the cleanup function returned from the `ref` callback. This works for DOM refs, refs to class components, and `useImperativeHandle`. 
+Quando o componente é desmontado, o React chamará a função de limpeza retornada do callback de `ref`. Isso funciona para refs de DOM, refs para componentes de classe e `useImperativeHandle`. 
 
 <Note>
 
-Previously, React would call `ref` functions with `null` when unmounting the component. If your `ref` returns a cleanup function, React will now skip this step.
+Anteriormente, o React chamaria funções de `ref` com `null` ao desmontar o componente. Se sua `ref` retornar uma função de limpeza, o React agora ignorará essa etapa.
 
-In future versions, we will deprecate calling refs with `null` when unmounting components.
+Nas versões futuras, iremos depreciar a chamada de refs com `null` ao desmontar componentes.
 
 </Note>
 
-Due to the introduction of ref cleanup functions, returning anything else from a `ref` callback will now be rejected by TypeScript. The fix is usually to stop using implicit returns, for example:
+Devido à introdução de funções de limpeza de refs, retornar qualquer outra coisa de um callback de `ref` será agora rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos, por exemplo:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-The original code returned the instance of the `HTMLDivElement` and TypeScript wouldn't know if this was _supposed_ to be a cleanup function or if you didn't want to return a cleanup function.
+O código original retornou a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _suposto_ ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
 
-You can codemod this pattern with [`no-implicit-ref-callback-return
-`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
+Você pode codemodificar esse padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
 
-### `useDeferredValue` initial value {/*use-deferred-value-initial-value*/}
+### `useDeferredValue` valor inicial {/*use-deferred-value-initial-value*/}
 
-We've added an `initialValue` option to `useDeferredValue`:
+Adicionamos uma opção `initialValue` a `useDeferredValue`:
 
 ```js [[1, 1, "deferredValue"], [1, 4, "deferredValue"], [2, 4, "''"]]
 function Search({deferredValue}) {
-  // On initial render the value is ''.
-  // Then a re-render is scheduled with the deferredValue.
+  // Na renderização inicial, o valor é ''.
+  // Em seguida, uma nova renderização é agendada com o deferredValue.
   const value = useDeferredValue(deferredValue, '');
   
   return (
@@ -529,15 +525,15 @@ function Search({deferredValue}) {
 }
 ````
 
-When <CodeStep step={2}>initialValue</CodeStep> is provided, `useDeferredValue` will return it as `value` for the initial render of the component, and schedules a re-render in the background with the <CodeStep step={1}>deferredValue</CodeStep> returned.
+Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` o retornará como `value` para a renderização inicial do componente, e agenda uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
 
-For more, see [`useDeferredValue`](/reference/react/useDeferredValue).
+Para mais, veja [`useDeferredValue`](/reference/react/useDeferredValue).
 
-### Support for Document Metadata {/*support-for-metadata-tags*/}
+### Suporte para Metadados de Documento {/*support-for-metadata-tags*/}
 
-In HTML, document metadata tags like `<title>`, `<link>`, and `<meta>` are reserved for placement in the `<head>` section of the document. In React, the component that decides what metadata is appropriate for the app may be very far from the place where you render the `<head>` or React does not render the `<head>` at all. In the past, these elements would need to be inserted manually in an effect, or by libraries like [`react-helmet`](https://github.com/nfl/react-helmet), and required careful handling when server rendering a React application. 
+Em HTML, as tags de metadados de documento, como `<title>`, `<link>` e `<meta>`, são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do local onde você renderiza o `<head>` ou o React não renderiza o `<head>` de maneira alguma. No passado, esses elementos precisariam ser inseridos manualmente em um efeito ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor. 
 
-In React 19, we're adding support for rendering document metadata tags in components natively:
+No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes nativamente:
 
 ```js {5-8}
 function BlogPost({post}) {
@@ -549,35 +545,35 @@ function BlogPost({post}) {
       <link rel="author" href="https://twitter.com/joshcstory/" />
       <meta name="keywords" content={post.keywords} />
       <p>
-        Eee equals em-see-squared...
+        Eee é igual a em-see-quadrado...
       </p>
     </article>
   );
 }
 ```
 
-When React renders this component, it will see the `<title>` `<link>` and `<meta>` tags, and automatically hoist them to the `<head>` section of document. By supporting these metadata tags natively, we're able to ensure they work with client-only apps, streaming SSR, and Server Components.
+Quando o React renderiza este componente, verá as tags `<title>`, `<link>` e `<meta>`, e automaticamente as elevará para a seção `<head>` do documento. Ao suportar essas tags de metadados nativamente, conseguimos garantir que funcionem com aplicativos apenas de cliente, SSR com streaming e Componentes do Servidor.
 
 <Note>
 
-#### You may still want a Metadata library {/*you-may-still-want-a-metadata-library*/}
+#### Você ainda pode querer uma biblioteca de Metadados {/*you-may-still-want-a-metadata-library*/}
 
-For simple use cases, rendering Document Metadata as tags may be suitable, but libraries can offer more powerful features like overriding generic metadata with specific metadata based on the current route. These features make it easier for frameworks and libraries like [`react-helmet`](https://github.com/nfl/react-helmet) to support metadata tags, rather than replace them.
+Para casos de uso simples, renderizar Metadados de Documento como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como substituir metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam o suporte a tags de metadados para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), em vez de substituí-las.
 
 </Note>
 
-For more info, see the docs for [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link), and [`<meta>`](/reference/react-dom/components/meta).
+Para mais informações, veja a documentação para [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link) e [`<meta>`](/reference/react-dom/components/meta).
 
-### Support for stylesheets {/*support-for-stylesheets*/}
+### Suporte para folhas de estilo {/*support-for-stylesheets*/}
 
-Stylesheets, both externally linked (`<link rel="stylesheet" href="...">`) and inline (`<style>...</style>`), require careful positioning in the DOM due to style precedence rules. Building a stylesheet capability that allows for composability within components is hard, so users often end up either loading all of their styles far from the components that may depend on them, or they use a style library which encapsulates this complexity.
+Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto inline (`<style>...</style>`), exigem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permita a composibilidade dentro de componentes é difícil, então os usuários geralmente acabam carregando todas as suas estilos longe dos componentes que podem depender deles ou usam uma biblioteca de estilo que encapsula essa complexidade.
 
-In React 19, we're addressing this complexity and providing even deeper integration into Concurrent Rendering on the Client and Streaming Rendering on the Server with built in support for stylesheets. If you tell React the `precedence` of your stylesheet it will manage the insertion order of the stylesheet in the DOM and ensure that the stylesheet (if external) is loaded before revealing content that depends on those style rules.
+No React 19, estamos abordando essa complexidade e oferecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e na Renderização por Streaming no Servidor com suporte incorporado para folhas de estilo. Se você informar ao React a `precedência` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar o conteúdo que depende dessas regras de estilo.
 
 ```js {4,5,17}
 function ComponentOne() {
   return (
-    <Suspense fallback="loading...">
+    <Suspense fallback="carregando...">
       <link rel="stylesheet" href="foo" precedence="default" />
       <link rel="stylesheet" href="bar" precedence="high" />
       <article class="foo-class bar-class">
@@ -591,44 +587,44 @@ function ComponentTwo() {
   return (
     <div>
       <p>{...}</p>
-      <link rel="stylesheet" href="baz" precedence="default" />  <-- will be inserted between foo & bar
+      <link rel="stylesheet" href="baz" precedence="default" />  <-- será inserido entre foo & bar
     </div>
   )
 }
 ```
 
-During Server Side Rendering React will include the stylesheet in the `<head>`, which ensures that the browser will not paint until it has loaded. If the stylesheet is discovered late after we've already started streaming, React will ensure that the stylesheet is inserted into the `<head>` on the client before revealing the content of a Suspense boundary that depends on that stylesheet.
+Durante a Renderização do Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não pintará até que tenha carregado. Se a folha de estilo for descoberta tarde, após já termos começado a fazer streaming, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de um limite de Suspense que depende daquela folha de estilo.
 
-During Client Side Rendering React will wait for newly rendered stylesheets to load before committing the render. If you render this component from multiple places within your application React will only include the stylesheet once in the document:
+Durante a Renderização do Lado do Cliente, o React aguardará que as novas folhas de estilo renderizadas carreguem antes de comprometer a renderização. Se você renderizar este componente de múltiplos locais dentro da sua aplicação, o React incluirá a folha de estilo apenas uma vez no documento:
 
 ```js {5}
 function App() {
   return <>
     <ComponentOne />
     ...
-    <ComponentOne /> // won't lead to a duplicate stylesheet link in the DOM
+    <ComponentOne /> // não levará a uma duplicata da folha de estilo no DOM
   </>
 }
 ```
 
-For users accustomed to loading stylesheets manually this is an opportunity to locate those stylesheets alongside the components that depend on them allowing for better local reasoning and an easier time ensuring you only load the stylesheets that you actually depend on.
+Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade de localizar essas folhas de estilo ao lado dos componentes dos quais dependem, permitindo um melhor raciocínio local e uma maneira mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
 
-Style libraries and style integrations with bundlers can also adopt this new capability so even if you don't directly render your own stylesheets, you can still benefit as your tools are upgraded to use this feature.
+Bibliotecas de estilo e integrações de estilo com bundlers também podem adotar essa nova capacidade, para que mesmo que você não renderize suas próprias folhas de estilo diretamente, ainda possa se beneficiar à medida que suas ferramentas forem atualizadas para usar essa funcionalidade.
 
-For more details, read the docs for [`<link>`](/reference/react-dom/components/link) and [`<style>`](/reference/react-dom/components/style).
+Para mais detalhes, consulte a documentação para [`<link>`](/reference/react-dom/components/link) e [`<style>`](/reference/react-dom/components/style).
 
-### Support for async scripts {/*support-for-async-scripts*/}
+### Suporte para scripts assíncronos {/*support-for-async-scripts*/}
 
-In HTML normal scripts (`<script src="...">`) and deferred scripts (`<script defer="" src="...">`) load in document order which makes rendering these kinds of scripts deep within your component tree challenging. Async scripts (`<script async="" src="...">`) however will load in arbitrary order.
+Em HTML, scripts normais (`<script src="...">`) e scripts diferidos (`<script defer="" src="...">`) carregam na ordem do documento, o que torna desafiador renderizar esses tipos de scripts dentro de sua árvore de componentes. No entanto, scripts assíncronos (`<script async="" src="...">`) podem ser carregados em ordem arbitrária.
 
-In React 19 we've included better support for async scripts by allowing you to render them anywhere in your component tree, inside the components that actually depend on the script, without having to manage relocating and deduplicating script instances.
+No React 19, incluímos um suporte melhor para scripts assíncronos, permitindo que você os renderize em qualquer lugar de sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem precisar gerenciar o realocamento e deduplicação de instâncias de script.
 
 ```js {4,15}
 function MyComponent() {
   return (
     <div>
       <script async={true} src="..." />
-      Hello World
+      Olá Mundo
     </div>
   )
 }
@@ -638,39 +634,39 @@ function App() {
     <body>
       <MyComponent>
       ...
-      <MyComponent> // won't lead to duplicate script in the DOM
+      <MyComponent> // não levará a um script duplicado no DOM
     </body>
   </html>
 }
 ```
 
-In all rendering environments, async scripts will be deduplicated so that React will only load and execute the script once even if it is rendered by multiple different components.
+Em todos os ambientes de renderização, os scripts assíncronos serão deduplicados, de modo que o React carregue e execute o script apenas uma vez, mesmo que seja renderizado por múltiplos componentes diferentes.
 
-In Server Side Rendering, async scripts will be included in the `<head>` and prioritized behind more critical resources that block paint such as stylesheets, fonts, and image preloads.
+Na Renderização do Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados após recursos mais críticos que bloqueiam a pintura, como folhas de estilo, fontes e pré-carregamentos de imagens.
 
-For more details, read the docs for [`<script>`](/reference/react-dom/components/script).
+Para mais detalhes, consulte a documentação para [`<script>`](/reference/react-dom/components/script).
 
-### Support for preloading resources {/*support-for-preloading-resources*/}
+### Suporte para pré-carregamento de recursos {/*support-for-preloading-resources*/}
 
-During initial document load and on client side updates, telling the Browser about resources that it will likely need to load as early as possible can have a dramatic effect on page performance.
+Durante o carregamento inicial do documento e em atualizações do lado do cliente, informar ao navegador sobre os recursos que provavelmente precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
 
-React 19 includes a number of new APIs for loading and preloading Browser resources to make it as easy as possible to build great experiences that aren't held back by inefficient resource loading.
+O React 19 inclui várias novas APIs para carregar e pré-carregar recursos do navegador para facilitar a construção de experiências excelentes que não sejam bloqueadas por um carregamento de recursos ineficiente.
 
 ```js
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 function MyComponent() {
-  preinit('https://.../path/to/some/script.js', {as: 'script' }) // loads and executes this script eagerly
-  preload('https://.../path/to/font.woff', { as: 'font' }) // preloads this font
-  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // preloads this stylesheet
-  prefetchDNS('https://...') // when you may not actually request anything from this host
-  preconnect('https://...') // when you will request something but aren't sure what
+  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script ansiosamente
+  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega essa fonte
+  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega essa folha de estilo
+  prefetchDNS('https://...') // quando você pode não realmente requerer nada desse host
+  preconnect('https://...') // quando você requisitará algo mas não tem certeza do que
 }
 ```
 ```html
-<!-- the above would result in the following DOM/HTML -->
+<!-- o acima resultaria no seguinte DOM/HTML -->
 <html>
   <head>
-    <!-- links/scripts are prioritized by their utility to early loading, not call order -->
+    <!-- links/scripts são priorizados pela sua utilidade para o carregamento inicial, e não pela ordem de chamada -->
     <link rel="prefetch-dns" href="https://...">
     <link rel="preconnect" href="https://...">
     <link rel="preload" as="font" href="https://.../path/to/font.woff">
@@ -683,100 +679,97 @@ function MyComponent() {
 </html>
 ```
 
-These APIs can be used to optimize initial page loads by moving discovery of additional resources like fonts out of stylesheet loading. They can also make client updates faster by prefetching a list of resources used by an anticipated navigation and then eagerly preloading those resources on click or even on hover.
+Essas APIs podem ser usadas para otimizar os carregamentos iniciais da página, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento da folha de estilo. Elas também podem tornar atualizações do cliente mais rápidas pré-carregando uma lista de recursos usados em uma navegação antecipada e, em seguida, pré-carregando esses recursos ansiosamente ao clicar ou até mesmo ao passar o mouse.
 
-For more details see [Resource Preloading APIs](/reference/react-dom#resource-preloading-apis).
+Para mais detalhes, veja [APIs de Pré-Carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
 
-### Compatibility with third-party scripts and extensions {/*compatibility-with-third-party-scripts-and-extensions*/}
+### Compatibilidade com scripts e extensões de terceiros {/*compatibility-with-third-party-scripts-and-extensions*/}
 
-We've improved hydration to account for third-party scripts and browser extensions.
+Melhoramos a hidratação para levar em conta scripts de terceiros e extensões do navegador.
 
-When hydrating, if an element that renders on the client doesn't match the element found in the HTML from the server, React will force a client re-render to fix up the content. Previously, if an element was inserted by third-party scripts or browser extensions, it would trigger a mismatch error and client render.
+Ao hidratar, se um elemento que renderiza no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização do cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões do navegador, isso acionaria um erro de discrepância e uma renderização no cliente.
 
-In React 19, unexpected tags in the `<head>` and `<body>` will be skipped over, avoiding the mismatch errors. If React needs to re-render the entire document due to an unrelated hydration mismatch, it will leave in place stylesheets inserted by third-party scripts and browser extensions.
+No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando erros de discrepância. Se o React precisar re-renderizar todo o documento devido a uma discrepância de hidratação não relacionada, ele deixará no lugar folhas de estilos inseridas por scripts de terceiros e extensões do navegador.
 
-### Better error reporting {/*error-handling*/}
+### Melhorias na reportagem de erros {/*error-handling*/}
 
-We improved error handling in React 19 to remove duplication and provide options for handling caught and uncaught errors. For example, when there's an error in render caught by an Error Boundary, previously React would throw the error twice (once for the original error, then again after failing to automatically recover), and then call `console.error` with info about where the error occurred. 
+Melhoramos o manuseio de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização que é capturado por um Limite de Erro, anteriormente o React lançava o erro duas vezes (uma vez para o erro original, depois novamente após falhar em se recuperar automaticamente) e em seguida chamava `console.error` com informações sobre onde o erro ocorreu. 
 
-This resulted in three errors for every caught error:
+Isso resultava em três erros para cada erro capturado:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: hit
-{'  '}at Throws
-{'  '}at renderWithHooks
+Erro não capturado: hit
+{'  '}em Throws
+{'  '}em renderWithHooks
 {'  '}...
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicate</span>
-{'  '}at Throws
-{'  '}at renderWithHooks
+Erro não capturado: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
+{'  '}em Throws
+{'  '}em renderWithHooks
 {'  '}...
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-The above error occurred in the Throws component:
-{'  '}at Throws
-{'  '}at ErrorBoundary
-{'  '}at App{'\n'}
-React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary.
+O erro acima ocorreu no componente Throws:
+{'  '}em Throws
+{'  '}em ErrorBoundary
+{'  '}em App{'\n'}
+O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-In React 19, we log a single error with all the error information included:
+No React 19, registramos um único erro com todas as informações do erro incluídas:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Error: hit
-{'  '}at Throws
-{'  '}at renderWithHooks
+Erro: hit
+{'  '}em Throws
+{'  '}em renderWithHooks
 {'  '}...{'\n'}
-The above error occurred in the Throws component:
-{'  '}at Throws
-{'  '}at ErrorBoundary
-{'  '}at App{'\n'}
-React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary.
-{'  '}at ErrorBoundary
-{'  '}at App
+O erro acima ocorreu no componente Throws:
+{'  '}em Throws
+{'  '}em ErrorBoundary
+{'  '}em App{'\n'}
+O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
+{'  '}em ErrorBoundary
+{'  '}em App
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Additionally, we've added two new root options to complement `onRecoverableError`:
+Além disso, adicionamos duas novas opções de raiz para complementar `onRecoverableError`:
 
-- `onCaughtError`: called when React catches an error in an Error Boundary.
-- `onUncaughtError`: called when an error is thrown and not caught by an Error Boundary.
-- `onRecoverableError`: called when an error is thrown and automatically recovered.
+- `onCaughtError`: chamado quando o React captura um erro em um Limite de Erro.
+- `onUncaughtError`: chamado quando um erro é lançado e não capturado por um Limite de Erro.
+- `onRecoverableError`: chamado quando um erro é lançado e recuperado automaticamente.
 
-For more info and examples, see the docs for [`createRoot`](/reference/react-dom/client/createRoot) and [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
+Para mais informações e exemplos, veja a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
 
-### Support for Custom Elements {/*support-for-custom-elements*/}
+### Suporte para Elementos Customizados {/*support-for-custom-elements*/}
 
-React 19 adds full support for custom elements and passes all tests on [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
+O React 19 adiciona suporte completo para elementos customizados e passa em todos os testes em [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
 
-In past versions, using Custom Elements in React has been difficult because React treated unrecognized props as attributes rather than properties. In React 19, we've added support for properties that works on the client and during SSR with the following strategy:
+Em versões anteriores, usar Elementos Customizados no React tem sido difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte a propriedades que funcionam no cliente e durante SSR com a seguinte estratégia:
 
-- **Server Side Rendering**: props passed to a custom element will render as attributes if their type is a primitive value like `string`, `number`, or the value is `true`. Props with non-primitive types like `object`, `symbol`, `function`, or value `false` will be omitted.
-- **Client Side Rendering**: props that match a property on the Custom Element instance will be assigned as properties, otherwise they will be assigned as attributes.
+- **Renderização do Lado do Servidor**: props passadas para um elemento customizado serão renderizadas como atributos se seu tipo for um valor primitivo, como `string`, `number` ou o valor for `true`. Props com tipos não primitivos, como `object`, `symbol`, `function` ou valor `false` serão omitidas.
+- **Renderização do Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Customizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
 
-Thanks to [Joey Arhar](https://github.com/josepharhar) for driving the design and implementation of Custom Element support in React.
-
-
-#### How to upgrade {/*how-to-upgrade*/}
-See the [React 19 Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide) for step-by-step instructions and a full list of breaking and notable changes.
+Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por liderar o projeto e a implementação do suporte a Elementos Customizados no React.
 
 
-
+#### Como atualizar {/*how-to-upgrade*/}
+Veja o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para instruções passo a passo e uma lista completa de mudanças significativas e notáveis.

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -2,7 +2,7 @@
 title: "React 19 Beta"
 author: The React Team
 date: 2024/04/25
-description: O React 19 Beta já está disponível no npm! Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
+description: O React 19 Beta já está disponível no npm! Neste post, daremos uma visão geral dos novos recursos no React 19 e como você pode adotá-los.
 ---
 
 25 de abril de 2024 por [The React Team](/community/team)
@@ -11,7 +11,7 @@ description: O React 19 Beta já está disponível no npm! Neste post, daremos u
 
 <Note>
 
-Esta versão beta é para bibliotecas se prepararem para o React 19. Os desenvolvedores de aplicativos devem atualizar para a versão 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos alterações com base no feedback.
+Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar o React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
@@ -21,13 +21,13 @@ O React 19 Beta já está disponível no npm!
 
 </Intro>
 
-Em nosso [Guia de Atualização do React 19 Beta](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19 Beta. Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
+Em nosso [Guia de Atualização do React 19 Beta](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19 Beta. Neste post, daremos uma visão geral dos novos recursos no React 19 e como você pode adotá-los.
 
 - [O que há de novo no React 19](#whats-new-in-react-19)
 - [Melhorias no React 19](#improvements-in-react-19)
 - [Como atualizar](#how-to-upgrade)
 
-Para uma lista de mudanças quebradoras, consulte o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
+Para uma lista de mudanças que quebram a compatibilidade, veja o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
 
 ---
 
@@ -35,9 +35,9 @@ Para uma lista de mudanças quebradoras, consulte o [Guia de Atualização](/blo
 
 ### Ações {/*actions*/}
 
-Um caso de uso comum em aplicativos React é realizar uma mutação de dados e depois atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para mudar seu nome, você fará uma solicitação de API e depois lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
+Um caso de uso comum em aplicativos React é realizar uma mutação de dados e depois atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para mudar seu nome, você fará uma solicitação de API e depois lidará com a resposta. No passado, você precisaria gerenciar manualmente os estados de pendência, erros, atualizações otimistas e solicitações sequenciais.
 
-Por exemplo, você poderia lidar com o estado pendente e erros no `useState`:
+Por exemplo, você poderia lidar com o estado de pendência e erro em `useState`:
 
 ```js
 // Antes das Ações
@@ -69,12 +69,12 @@ function UpdateName({}) {
 }
 ```
 
-No React 19, estamos adicionando suporte para usar funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
+No React 19, estamos adicionando suporte para usar funções assíncronas em transições para lidar com estados de pendência, erros, formulários e atualizações otimistas automaticamente.
 
-Por exemplo, você pode usar `useTransition` para lidar com o estado pendente para você:
+Por exemplo, você pode usar `useTransition` para lidar com o estado de pendência por você:
 
 ```js
-// Usando o estado pendente das Ações
+// Usando estado de pendência das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -107,23 +107,23 @@ A transição assíncrona definirá imediatamente o estado `isPending` como verd
 
 <Note>
 
-#### Por convenção, funções que usam transições assíncronas são chamadas de “Ações”. {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
+#### Por convenção, funções que usam transições assíncronas são chamadas de "Ações". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
 
-As Ações gerenciam automaticamente o envio de dados para você:
+As ações gerenciam automaticamente o envio de dados para você:
 
-- **Estado pendente**: As Ações fornecem um estado pendente que começa no início de uma solicitação e redefinem automaticamente quando a atualização final do estado é confirmada.
-- **Atualizações otimistas**: As Ações suportam o novo hook [`useOptimistic`](#new-hook-optimistic-updates) para que você possa mostrar feedback instantâneo aos usuários enquanto as solicitações estão sendo enviadas.
-- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir limites de erro quando uma solicitação falha e reverter atualizações otimistas para seu valor original automaticamente.
-- **Formulários**: Elementos `<form>` agora suportam passar funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e redefine automaticamente o formulário após a submissão.
+- **Estado de pendência**: Ações fornecem um estado de pendência que começa no início de uma solicitação e é redefinido automaticamente quando a atualização final do estado é confirmada.
+- **Atualizações otimistas**: As Ações suportam o novo [`useOptimistic`](#new-hook-optimistic-updates) hook para que você possa mostrar feedback instantâneo aos usuários enquanto as solicitações estão sendo enviadas.
+- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir Limites de Erro quando uma solicitação falha e reverter atualizações otimistas para seu valor original automaticamente.
+- **Formulários**: Elementos `<form>` agora suportam passar funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e redefine o formulário automaticamente após a submissão.
 
 </Note>
 
-Construindo sobre as Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns para Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar casos comuns para Ações em formulários.
+Construindo sobre as Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns de Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar casos comuns de Ações em formulários.
 
 No React 19, o exemplo acima pode ser simplificado para:
 
 ```js
-// Usando Ações de <form> e useActionState
+// Usando <form> Ações e useActionState
 function ChangeName({ name, setName }) {
   const [error, submitAction, isPending] = useActionState(
     async (previousState, formData) => {
@@ -147,11 +147,11 @@ function ChangeName({ name, setName }) {
 }
 ```
 
-Na próxima seção, iremos detalhar cada um dos novos recursos de Ação no React 19.
+Na próxima seção, detalharemos cada um dos novos recursos de Ação no React 19.
 
 ### Novo hook: `useActionState` {/*new-hook-useactionstate*/}
 
-Para tornar os casos comuns mais fáceis para as Ações, adicionamos um novo hook chamado `useActionState`:
+Para facilitar os casos comuns de Ações, adicionamos um novo hook chamado `useActionState`:
 
 ```js
 const [error, submitAction, isPending] = useActionState(
@@ -163,40 +163,40 @@ const [error, submitAction, isPending] = useActionState(
       return error;
     }
 
-    // tratar sucesso
+    // lidar com sucesso
     return null;
   },
   null,
 );
 ```
 
-`useActionState` aceita uma função (a "Ação") e retorna uma Ação envolvida para chamar. Isso funciona porque Ações se compõem. Quando a Ação envolvida é chamada, `useActionState` retornará o último resultado da Ação como `data`, e o estado pendente da Ação como `pending`. 
+`useActionState` aceita uma função (a "Ação") e retorna uma Ação encapsulada para chamar. Isso funciona porque as Ações se compõem. Quando a Ação encapsulada é chamada, `useActionState` retornará o último resultado da Ação como `data` e o estado de pendência da Ação como `pending`.
 
 <Note>
 
-`React.useActionState` era anteriormente chamado de `ReactDOM.useFormState` nas versões Canary, mas renomeamos e descontinuamos `useFormState`.
+`React.useActionState` foi anteriormente chamado de `ReactDOM.useFormState` nas versões Canary, mas mudamos seu nome e descontinuamos o `useFormState`.
 
 Veja [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
 
 </Note>
 
-Para mais informações, consulte a documentação para [`useActionState`](/reference/react/useActionState).
+Para mais informações, veja a documentação para [`useActionState`](/reference/react/useActionState).
 
-### React DOM: Ações de `<form>` {/*form-actions*/}
+### React DOM: `<form>` Ações {/*form-actions*/}
 
-As Ações também estão integradas aos novos recursos de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como props `action` e `formAction` dos elementos `<form>`, `<input>` e `<button>` para enviar automaticamente formulários com Ações:
+As Ações também estão integradas com os novos recursos de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como as props `action` e `formAction` de `<form>`, `<input>` e `<button>` para submeter formulários automaticamente com Ações:
 
 ```js [[1,1,"actionFunction"]]
 <form action={actionFunction}>
 ```
 
-Quando uma Ação de `<form>` é bem-sucedida, o React redefinirá automaticamente o formulário para componentes não controlados. Se você precisar redefinir o `<form>` manualmente, pode chamar a nova API `requestFormReset` do React DOM.
+Quando uma Ação `<form>` tem sucesso, o React redefinirá automaticamente o formulário para componentes não controlados. Se você precisar redefinir o `<form>` manualmente, pode chamar a nova API `requestFormReset` do React DOM.
 
-Para mais informações, consulte a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input) e `<button>`.
+Para mais informações, veja a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input) e `<button>`.
 
 ### React DOM: Novo hook: `useFormStatus` {/*new-hook-useformstatus*/}
 
-Em sistemas de design, é comum escrever componentes de design que precisam acessar informações sobre o `<form>` em que estão, sem precisar passar props para baixo até o componente. Isso pode ser feito via Contexto, mas para facilitar os casos comuns, adicionamos um novo hook `useFormStatus`:
+Em sistemas de design, é comum escrever componentes de design que precisam de acesso a informações sobre o `<form>` no qual estão, sem passar props para baixo até o componente. Isso pode ser feito via Contexto, mas para facilitar o caso comum, adicionamos um novo hook `useFormStatus`:
 
 ```js [[1, 4, "pending"], [1, 5, "pending"]]
 import {useFormStatus} from 'react-dom';
@@ -209,11 +209,11 @@ function DesignButton() {
 
 `useFormStatus` lê o status do `<form>` pai como se o formulário fosse um provedor de Contexto.
 
-Para mais informações, consulte a documentação do `react-dom` para [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+Para mais informações, veja a documentação do `react-dom` para [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
 
 ### Novo hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
 
-Outro padrão comum de UI ao realizar uma mutação de dados é mostrar o estado final de forma otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
+Outro padrão UI comum ao realizar uma mutação de dados é mostrar o estado final de forma otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
 
 ```js {2,6,13,19}
 function ChangeName({currentName, onUpdateName}) {
@@ -242,15 +242,15 @@ function ChangeName({currentName, onUpdateName}) {
 }
 ```
 
-O hook `useOptimistic` irá imediatamente renderizar o `optimisticName` enquanto a solicitação `updateName` está em andamento. Quando a atualização termina ou ocorre um erro, o React automaticamente voltará ao valor de `currentName`.
+O hook `useOptimistic` renderizará imediatamente o `optimisticName` enquanto a solicitação `updateName` estiver em andamento. Quando a atualização terminar ou ocorrer um erro, o React mudará automaticamente de volta para o valor `currentName`.
 
-Para mais informações, consulte a documentação para [`useOptimistic`](/reference/react/useOptimistic).
+Para mais informações, veja a documentação para [`useOptimistic`](/reference/react/useOptimistic).
 
 ### Nova API: `use` {/*new-feature-use*/}
 
-No React 19, estamos introduzindo uma nova API para ler recursos na renderização: `use`.
+No React 19, estamos introduzindo uma nova API para ler recursos durante o render: `use`.
 
-Por exemplo, você pode ler uma promessa com `use`, e o React irá Suspender até que a promessa seja resolvida:
+Por exemplo, você pode ler uma promessa com `use`, e o React suspenderá até que a promessa seja resolvida:
 
 ```js {1,5}
 import {use} from 'react';
@@ -263,7 +263,7 @@ function Comments({commentsPromise}) {
 
 function Page({commentsPromise}) {
   // Quando `use` suspende em Comments,
-  // este limite de Suspense será mostrado.
+  // esta fronteira de Suspense será exibida.
   return (
     <Suspense fallback={<div>Carregando...</div>}>
       <Comments commentsPromise={commentsPromise} />
@@ -274,25 +274,25 @@ function Page({commentsPromise}) {
 
 <Note>
 
-#### `use` não suporta promessas criadas na renderização. {/*use-does-not-support-promises-created-in-render*/}
+#### `use` não suporta promessas criadas durante o render. {/*use-does-not-support-promises-created-in-render*/}
 
-Se você tentar passar uma promessa criada na renderização para `use`, o React avisará:
+Se você tentar passar uma promessa criada durante o render para `use`, o React emitirá um aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Um componente foi suspenso por uma promessa não em cache. Criar promessas dentro de um Componente do Cliente ou hook ainda não é suportado, exceto por meio de uma biblioteca ou framework compatível com Suspense.
+Um componente foi suspenso por uma promessa não armazenada em cache. Criar promessas dentro de um Componente Cliente ou hook ainda não é suportado, exceto por meio de uma biblioteca ou framework compatível com Suspense.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Para corrigir, você precisa passar uma promessa de uma biblioteca ou framework compatível com suspense que suporte caching para promessas. No futuro, planejamos lançar recursos para facilitar o armazenamento em cache de promessas na renderização.
+Para corrigir isso, você precisa passar uma promessa de uma biblioteca ou framework compatível com suspense que suporte armazenamento em cache para promessas. No futuro planejamos implementar recursos para facilitar o armazenamento em cache de promessas durante o render.
 
 </Note>
 
-Você também pode ler contexto com `use`, permitindo que você leia Contexto condicionalmente, como após retornos antecipados:
+Você também pode ler o contexto com `use`, permitindo que você leia o Contexto condicionalmente, como após retornos antecipados:
 
 ```js {1,11}
 import {use} from 'react';
@@ -314,38 +314,35 @@ function Heading({children}) {
 }
 ```
 
-A API `use` só pode ser chamada na renderização, semelhante aos hooks. Ao contrário dos hooks, `use` pode ser chamado condicionalmente. No futuro, planejamos suportar mais formas de consumir recursos na renderização com `use`.
+A API `use` só pode ser chamada no render, semelhante aos hooks. Ao contrário dos hooks, `use` pode ser chamado condicionalmente. No futuro, planejamos suportar mais maneiras de consumir recursos no render com `use`.
 
-Para mais informações, consulte a documentação para [`use`](/reference/react/use).
-
+Para mais informações, veja a documentação para [`use`](/reference/react/use).
 
 ## Componentes do Servidor React {/*react-server-components*/}
 
 ### Componentes do Servidor {/*server-components*/}
 
-Os Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes da compactação, em um ambiente separado da sua aplicação cliente ou servidor SSR. Esse ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção em seu servidor CI, ou podem ser executados para cada solicitação usando um servidor web.
+Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes de empacotar, em um ambiente separado de sua aplicação cliente ou servidor SSR. Esse ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção em seu servidor CI, ou podem ser executados para cada solicitação usando um servidor web.
 
-O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos no canal Canary. Isso significa que bibliotecas que fornecem Componentes do Servidor agora podem direcionar o React 19 como uma dependência par com uma condição de exportação `react-server` [condicional](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura Full-stack React](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
-
+O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos no canal Canary. Isso significa que bibliotecas que enviam com Componentes do Servidor agora podem direcionar o React 19 como uma dependência peer com uma condição de exportação `react-server` [condicional](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura Full-stack do React](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision).
 
 <Note>
 
-#### Como faço para construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
+#### Como posso construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
 
-Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um empacotador ou framework de Componentes do Servidor React não seguem o semver e podem quebrar entre versões menores no React 19.x. 
+Enquanto os Componentes do Servidor no React 19 são estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um empacotador ou framework de Componentes do Servidor React não seguem o semver e podem quebrar entre minores no React 19.x.
 
-Para suportar os Componentes do Servidor React como um empacotador ou framework, recomendamos fixar em uma versão específica do React ou usar a versão Canary. Continuaremos trabalhando com empacotadores e frameworks para estabilizar as APIs usadas para implementar os Componentes do Servidor React no futuro.
+Para suportar os Componentes do Servidor React como um empacotador ou framework, recomendamos fixar em uma versão específica do React ou usar a versão Canary. Continuaremos trabalhando com empacotadores e frameworks para estabilizar as APIs usadas para implementar Componentes do Servidor React no futuro.
 
 </Note>
 
-
-Para mais informações, consulte a documentação para [Componentes do Servidor React](/reference/rsc/server-components).
+Para mais informações, veja a documentação para [Componentes do Servidor React](/reference/rsc/server-components).
 
 ### Ações do Servidor {/*server-actions*/}
 
-As Ações do Servidor permitem que Componentes do Cliente chamem funções assíncronas executadas no servidor.
+Ações do Servidor permitem que Componentes Clientes chamem funções assíncronas executadas no servidor.
 
-Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Componente do Cliente. Quando essa função é chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
+Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Componente Cliente. Quando essa função é chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
 
 <Note>
 
@@ -353,19 +350,19 @@ Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu fra
 
 Um mal-entendido comum é que os Componentes do Servidor são denotados por `"use server"`, mas não há diretiva para Componentes do Servidor. A diretiva `"use server"` é usada para Ações do Servidor.
 
-Para mais informações, consulte a documentação para [Diretivas](/reference/rsc/directives).
+Para mais informações, veja a documentação para [Diretivas](/reference/rsc/directives).
 
 </Note>
 
-As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes do Cliente, ou podem ser importadas e usadas em Componentes do Cliente.
+As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes Clientes, ou podem ser importadas e usadas em Componentes Clientes.
 
-Para mais informações, consulte a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
+Para mais informações, veja a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
 
 ## Melhorias no React 19 {/*improvements-in-react-19*/}
 
 ### `ref` como uma prop {/*ref-as-a-prop*/}
 
-Começando no React 19, agora você pode acessar `ref` como uma prop para componentes de função:
+A partir do React 19, você pode acessar `ref` como uma prop para componentes de função:
 
 ```js [[1, 1, "ref"], [1, 2, "ref", 45], [1, 6, "ref", 14]]
 function MyInput({placeholder, ref}) {
@@ -380,13 +377,13 @@ Novos componentes de função não precisarão mais de `forwardRef`, e publicare
 
 <Note>
 
-`refs` passadas para classes não são passadas como props, pois referenciam a instância do componente.
+`refs` passados para classes não são passados como props, uma vez que eles referenciam a instância do componente.
 
 </Note>
 
 ### Diferenças para erros de hidratação {/*diffs-for-hydration-errors*/}
 
-Também melhoramos a relatória de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar múltiplos erros em DEV sem informações sobre a discrepância:
+Também melhoramos o relato de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar vários erros em DEV sem nenhuma informação sobre a discrepância:
 
 <ConsoleBlockMulti>
 
@@ -400,7 +397,7 @@ Aviso: O conteúdo de texto não corresponde. Servidor: "Servidor" Cliente: "Cli
 
 <ConsoleLogLine level="error">
 
-Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
+Aviso: Um erro ocorreu durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
 
 </ConsoleLogLine>
 
@@ -414,13 +411,13 @@ Aviso: O conteúdo de texto não corresponde. Servidor: "Servidor" Cliente: "Cli
 
 <ConsoleLogLine level="error">
 
-Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
+Aviso: Um erro ocorreu durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado no servidor.
+Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado pelo servidor.
 {'  '}em checkForUnmatchedText
 {'  '}...
 
@@ -430,18 +427,17 @@ Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado n
 
 Agora registramos uma única mensagem com uma diferença da discrepância:
 
-
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Erro: A hidratação falhou porque o HTML renderizado no servidor não corresponde ao cliente. Como resultado, essa árvore será regenerada no cliente. Isso pode acontecer se um componente Cliente SSR usou:{'\n'}
-\- Uma ramificação servidor/clientes `if (typeof window !== 'undefined')`.
-\- Entrada variável como `Date.now()` ou `Math.random()` que muda a cada vez que é chamada.
-\- Formatação de data em um local do usuário que não corresponde ao servidor.
-\- Dados externos em mudança sem enviar um instantâneo deles junto com o HTML.
+Erro: A hidratação falhou porque o HTML renderizado pelo servidor não correspondeu ao cliente. Como resultado, essa árvore será regenerada no cliente. Isso pode acontecer se um Componente Cliente SSR-ed usou:{'\n'}
+\- Um ramo servidor/clente `if (typeof window !== 'undefined')`.
+\- Entrada variável como `Date.now()` ou `Math.random()` que muda cada vez que é chamada.
+\- Formatação de datas na localidade de um usuário que não corresponde ao servidor.
+\- Dados externos mutáveis sem enviar um snapshot deles junto com o HTML.
 \- Aninhamento de tags HTML inválido.{'\n'}
-Isso também pode acontecer se o cliente tiver uma extensão de navegador instalada que interfere no HTML antes do React ser carregado.{'\n'}
+Isso também pode acontecer se o cliente tiver uma extensão de navegador instalada que interfere no HTML antes do React carregar.{'\n'}
 https://react.dev/link/hydration-mismatch {'\n'}
 {'  '}\<App\>
 {'    '}\<span\>
@@ -475,7 +471,7 @@ Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod pa
 
 ### Funções de limpeza para refs {/*cleanup-functions-for-refs*/}
 
-Agora suportamos retornar uma função de limpeza dos callbacks `ref`:
+Agora suportamos retornar uma função de limpeza a partir de callbacks `ref`:
 
 ```js {7-9}
 <input
@@ -483,9 +479,9 @@ Agora suportamos retornar uma função de limpeza dos callbacks `ref`:
     // ref criada
 
     // NOVO: retorne uma função de limpeza para redefinir
-    // o ref quando o elemento for removido do DOM.
+    // a ref quando o elemento for removido do DOM.
     return () => {
-      // limpeza do ref
+      // limpeza da ref
     };
   }}
 />
@@ -495,7 +491,7 @@ Quando o componente é desmontado, o React chamará a função de limpeza retorn
 
 <Note>
 
-Anteriormente, o React chamaria funções `ref` com `null` ao desmontar o componente. Se seu `ref` retorna uma função de limpeza, o React agora pulará essa etapa.
+Anteriormente, o React chamaria funções `ref` com `null` ao desmontar o componente. Se sua `ref` retornar uma função de limpeza, o React agora pulará essa etapa.
 
 Em versões futuras, descontinuaremos chamar refs com `null` ao desmontar componentes.
 
@@ -508,18 +504,18 @@ Devido à introdução de funções de limpeza de ref, retornar qualquer outra c
 + <div ref={current => {instance = current}} />
 ```
 
-O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _suposto_ ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
+O código original retornou a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _supostamente_ uma função de limpeza ou se você não queria retornar uma função de limpeza.
 
-Você pode codemodificar esse padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
+Você pode codemodar este padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
 
 ### `useDeferredValue` valor inicial {/*use-deferred-value-initial-value*/}
 
-Adicionamos uma opção `initialValue` ao `useDeferredValue`:
+Adicionamos uma opção `initialValue` para `useDeferredValue`:
 
 ```js [[1, 1, "deferredValue"], [1, 4, "deferredValue"], [2, 4, "''"]]
 function Search({deferredValue}) {
   // Na renderização inicial o valor é ''.
-  // Em seguida, uma re-renderização é agendada com o deferredValue.
+  // Então, uma re-renderização é agendada com o deferredValue.
   const value = useDeferredValue(deferredValue, '');
   
   return (
@@ -528,15 +524,15 @@ function Search({deferredValue}) {
 }
 ````
 
-Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` retornará como `value` na renderização inicial do componente, e agenda uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
+Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` retornará isso como `value` para a renderização inicial do componente e agendará uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
 
-Para mais informações, consulte [`useDeferredValue`](/reference/react/useDeferredValue).
+Para mais informações, veja [`useDeferredValue`](/reference/react/useDeferredValue).
 
 ### Suporte para Metadados do Documento {/*support-for-metadata-tags*/}
 
-Em HTML, tags de metadados do documento como `<title>`, `<link>` e `<meta>` são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do lugar onde você renderiza o `<head>` ou o React não renderiza o `<head>` de forma alguma. No passado, esses elementos precisariam ser inseridos manualmente em um efeito, ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam manuseio cuidadoso ao renderizar uma aplicação React no servidor.
+No HTML, tags de metadados do documento como `<title>`, `<link>` e `<meta>` são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito distante do lugar onde você renderiza o `<head>` ou o React não renderiza o `<head>` de forma alguma. No passado, esses elementos precisariam ser inseridos manualmente em um efeito ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor. 
 
-No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes de forma nativa:
+No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes nativamente:
 
 ```js {5-8}
 function BlogPost({post}) {
@@ -555,23 +551,23 @@ function BlogPost({post}) {
 }
 ```
 
-Quando o React renderiza este componente, ele verá as tags `<title>`, `<link>` e `<meta>`, e as elevará automaticamente para a seção `<head>` do documento. Ao suportar essas tags de metadados de forma nativa, conseguimos garantir que elas funcionem com aplicativos apenas do cliente, SSR em streaming e Componentes do Servidor.
+Quando o React renderiza este componente, ele verá as tags `<title>`, `<link>` e `<meta>`, e as elevará automaticamente à seção `<head>` do documento. Ao suportar essas tags de metadados nativamente, conseguimos garantir que elas funcionem com aplicativos somente cliente, SSR em streaming e Componentes do Servidor.
 
 <Note>
 
 #### Você ainda pode querer uma biblioteca de Metadados {/*you-may-still-want-a-metadata-library*/}
 
-Para casos de uso simples, renderizar Metadados do Documento como tags pode ser adequado, mas bibliotecas podem oferecer funcionalidades mais poderosas, como substituição de metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet) suportarem tags de metadados, em vez de substituí-las.
+Para casos de uso simples, renderizar Metadados do Documento como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como sobrescrever metadados genéricos com metadados específicos com base na rota atual. Esses recursos facilitam para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet) suportar tags de metadados, em vez de substituí-las.
 
 </Note>
 
-Para mais informações, consulte a documentação para [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link) e [`<meta>`](/reference/react-dom/components/meta).
+Para mais informações, veja a documentação para [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link) e [`<meta>`](/reference/react-dom/components/meta).
 
 ### Suporte para folhas de estilo {/*support-for-stylesheets*/}
 
-Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto internas (`<style>...</style>`), requerem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permite composição dentro de componentes é difícil, então os usuários frequentemente acabam carregando todas as suas folhas de estilo longe dos componentes que podem depender delas, ou usam uma biblioteca de estilo que encapsula essa complexidade.
+Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto inline (`<style>...</style>`), exigem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permita composição dentro de componentes é difícil, então os usuários geralmente acabam carregando todas as suas folhas de estilo longe dos componentes que podem depender delas, ou usam uma biblioteca de estilo que encapsula essa complexidade.
 
-No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e na Renderização em Streaming no Servidor com suporte interno para folhas de estilo. Se você informar ao React a `precedence` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar conteúdo que dependa dessas regras de estilo.
+No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda com a Renderização Concorrente no Cliente e a Renderização em Streaming no Servidor com suporte embutido para folhas de estilo. Se você informar ao React a `precedência` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar conteúdo que depende dessas regras de estilo.
 
 ```js {4,5,17}
 function ComponentOne() {
@@ -596,31 +592,31 @@ function ComponentTwo() {
 }
 ```
 
-Durante a Renderização Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não pinte até que tenha carregado. Se a folha de estilo for descoberta tarde, após já termos iniciado o streaming, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de um limite de Suspense que dependa dessa folha de estilo.
+Durante a Renderização do Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não pintará até que tenha carregado. Se a folha de estilo for descoberta tarde, após já termos começado a transmitir, o React garantirá que a folha de estilo seja inserida no `<head>` do cliente antes de revelar o conteúdo de uma fronteira de Suspense que depende daquela folha de estilo.
 
-Durante a Renderização Lado do Cliente, o React aguardará que as folhas de estilo recém-renderizadas carreguem antes de confirmar a renderização. Se você renderizar este componente de vários lugares dentro de sua aplicação, o React incluirá a folha de estilo apenas uma vez no documento:
+Durante a Renderização do Lado do Cliente, o React esperará que folhas de estilo recém-renderizadas carreguem antes de confirmar a renderização. Se você renderizar este componente de vários lugares dentro de sua aplicação, o React incluirá a folha de estilo no documento apenas uma vez:
 
 ```js {5}
 function App() {
   return <>
     <ComponentOne />
     ...
-    <ComponentOne /> // não levará a uma duplicata da folha de estilo no DOM
+    <ComponentOne /> // não levará a um link duplicado de folha de estilo no DOM
   </>
 }
 ```
 
-Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade para localizar essas folhas de estilo ao lado dos componentes que dependem delas, permitindo um melhor raciocínio local e uma maneira mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
+Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade para localizar essas folhas de estilo ao lado dos componentes que dependem delas, permitindo um melhor raciocínio local e um tempo mais fácil para garantir que você carregue apenas as folhas de estilo das quais realmente depende.
 
-Bibliotecas de estilo e integrações de estilo com empacotadores também podem adotar essa nova capacidade, de modo que mesmo se você não renderizar diretamente suas próprias folhas de estilo, ainda poderá se beneficiar à medida que suas ferramentas forem atualizadas para usar esse recurso.
+Bibliotecas de estilos e integrações de estilo com empacotadores também podem adotar essa nova capacidade, então mesmo que você não renderize diretamente suas próprias folhas de estilo, ainda pode se beneficiar à medida que suas ferramentas sejam atualizadas para usar esse recurso.
 
-Para mais detalhes, consulte a documentação para [`<link>`](/reference/react-dom/components/link) e [`<style>`](/reference/react-dom/components/style).
+Para mais detalhes, veja a documentação para [`<link>`](/reference/react-dom/components/link) e [`<style>`](/reference/react-dom/components/style).
 
 ### Suporte para scripts assíncronos {/*support-for-async-scripts*/}
 
-Em HTML, scripts normais (`<script src="...">`) e scripts diferidos (`<script defer="" src="...">`) carregam em ordem de documento, o que torna desafiador renderizar esses tipos de scripts profundamente dentro da sua árvore de componentes. Scripts assíncronos (`<script async="" src="...">`), no entanto, serão carregados em qualquer ordem.
+No HTML, scripts normais (`<script src="...">`) e scripts adiados (`<script defer="" src="...">`) carregam em ordem de documento, o que torna desafiador renderizar esses tipos de scripts profundamente dentro de sua árvore de componentes. No entanto, scripts assíncronos (`<script async="" src="...">`) carregarão em ordem arbitrária.
 
-No React 19, incluímos melhor suporte para scripts assíncronos, permitindo que você os renderize em qualquer lugar da sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem ter que gerenciar o reposicionamento e a deduplicação das instâncias de script.
+No React 19, incluímos um suporte melhor para scripts assíncronos, permitindo que você os renderize em qualquer lugar de sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem ter que gerenciar o deslocamento e a desduplicação de instâncias de script.
 
 ```js {4,15}
 function MyComponent() {
@@ -643,33 +639,33 @@ function App() {
 }
 ```
 
-Em todos os ambientes de renderização, scripts assíncronos serão deduplicados, de modo que o React carregará e executará o script apenas uma vez, mesmo que seja renderizado por diferentes componentes.
+Em todos os ambientes de renderização, os scripts assíncronos serão desduplicados, para que o React carregue e execute o script apenas uma vez, mesmo que ele seja renderizado por vários componentes diferentes.
 
-Na Renderização Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados atrás de recursos mais críticos que bloqueiam o desenho, como folhas de estilo, fontes e pré-carregamentos de imagem.
+Na Renderização do Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados atrás de recursos mais críticos que bloqueiam a pintura, como folhas de estilo, fontes e pré-carregamentos de imagens.
 
 Para mais detalhes, veja a documentação para [`<script>`](/reference/react-dom/components/script).
 
 ### Suporte para pré-carregamento de recursos {/*support-for-preloading-resources*/}
 
-Durante o carregamento inicial do documento e em atualizações do lado do cliente, informar ao navegador sobre recursos que ele precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
+Durante o carregamento inicial do documento e nas atualizações do lado do cliente, informar ao navegador sobre recursos que provavelmente precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
 
-O React 19 inclui uma série de novas APIs para carregar e pré-carregar recursos do navegador para facilitar a construção de experiências excelentes que não sejam prejudicadas por carregamentos de recursos ineficientes.
+O React 19 inclui uma série de novas APIs para carregar e pré-carregar recursos do navegador para facilitar ao máximo a construção de grandes experiências que não estão limitadas por carregamento ineficiente de recursos.
 
 ```js
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 function MyComponent() {
-  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script de forma ansiosa
-  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega esta fonte
-  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega esta folha de estilo
-  prefetchDNS('https://...') // quando você pode não solicitar nada deste host
-  preconnect('https://...') // quando você solicitar algo, mas não tiver certeza do que
+  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa esse script ansiosamente
+  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega essa fonte
+  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega essa folha de estilo
+  prefetchDNS('https://...') // quando você pode não realmente solicitar nada deste host
+  preconnect('https://...') // quando você fará uma solicitação, mas não tem certeza do que
 }
 ```
 ```html
 <!-- o acima resultaria no seguinte DOM/HTML -->
 <html>
   <head>
-    <!-- links/scripts são priorizados por sua utilidade para carregamento inicial, não pela ordem de chamada -->
+    <!-- links/scripts são priorizados por sua utilidade para carregamentos iniciais, não pela ordem de chamada -->
     <link rel="prefetch-dns" href="https://...">
     <link rel="preconnect" href="https://...">
     <link rel="preload" as="font" href="https://.../path/to/font.woff">
@@ -682,21 +678,21 @@ function MyComponent() {
 </html>
 ```
 
-Essas APIs podem ser usadas para otimizar carregamentos iniciais de página, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento de folhas de estilo. Elas também podem tornar atualizações do lado do cliente mais rápidas, pré-carregando uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregando esses recursos ansiosamente ao clicar ou até mesmo ao passar o mouse.
+Essas APIs podem ser usadas para otimizar os carregamentos iniciais da página, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento da folha de estilo. Elas também podem tornar as atualizações do cliente mais rápidas, pré-carregando uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregando esses recursos de forma ansiosa ao clicar ou até mesmo ao passar o mouse.
 
-Para mais detalhes, consulte [APIs de Pré-carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
+Para mais detalhes veja as [APIs de Pré-carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
 
 ### Compatibilidade com scripts e extensões de terceiros {/*compatibility-with-third-party-scripts-and-extensions*/}
 
-Melhoramos a hidratação para considerar scripts de terceiros e extensões do navegador.
+Melhoramos a hidratação para levar em conta scripts de terceiros e extensões de navegador.
 
-Ao hidratar, se um elemento que é renderizado no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma re-renderização do cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões do navegador, isso acionaria um erro de discrepância e renderização do cliente.
+Ao hidratar, se um elemento que é renderizado no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização no cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões de navegador, isso acionaria um erro de discrepância e a renderização no cliente.
 
-No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando os erros de discrepância. Se o React precisar re-renderizar todo o documento devido a um erro de hidratação não relacionado, ele deixará no lugar folhas de estilo inseridas por scripts de terceiros e extensões do navegador.
+No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando erros de discrepância. Se o React precisar re-renderizar todo o documento devido a uma discrepância de hidratação não relacionada, ele deixará no lugar folhas de estilo inseridas por scripts de terceiros e extensões de navegador.
 
-### Melhor relatória de erros {/*error-handling*/}
+### Melhor relatório de erros {/*error-handling*/}
 
-Melhoramos o tratamento de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização capturado por um Limite de Erro, anteriormente o React lançaria o erro duas vezes (uma vez para o erro original, depois novamente após falhar ao se recuperar automaticamente) e, em seguida, chamaria `console.error` com informações sobre onde o erro ocorreu. 
+Melhoramos o tratamento de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro no render que é capturado por um Limite de Erro, anteriormente o React lançaria o erro duas vezes (uma vez para o erro original, depois novamente após falhar em se recuperar automaticamente) e chamaria `console.error` com informações sobre onde o erro ocorreu.
 
 Isso resultou em três erros para cada erro capturado:
 
@@ -704,7 +700,7 @@ Isso resultou em três erros para cada erro capturado:
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: hit
+Erro não capturado: atingido
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...
@@ -713,7 +709,7 @@ Erro não capturado: hit
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
+Erro não capturado: atingido<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...
@@ -726,19 +722,19 @@ O erro acima ocorreu no componente Throws:
 {'  '}em Throws
 {'  '}em ErrorBoundary
 {'  '}em App{'\n'}
-O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
+O React tentará recriar essa árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-No React 19, registramos um único erro com todas as informações do erro incluídas:
+No React 19, registramos um único erro com todas as informações de erro incluídas:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Erro: hit
+Erro: atingido
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...{'\n'}
@@ -746,7 +742,7 @@ O erro acima ocorreu no componente Throws:
 {'  '}em Throws
 {'  '}em ErrorBoundary
 {'  '}em App{'\n'}
-O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
+O React tentará recriar essa árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
 {'  '}em ErrorBoundary
 {'  '}em App
 
@@ -756,23 +752,23 @@ O React tentará recriar esta árvore de componentes do zero usando o limite de 
 
 Além disso, adicionamos duas novas opções de raiz para complementar `onRecoverableError`:
 
-- `onCaughtError`: chamado quando o React captura um erro em um Limite de Erro.
-- `onUncaughtError`: chamado quando um erro é lançado e não é capturado por um Limite de Erro.
-- `onRecoverableError`: chamado quando um erro é lançado e recuperado automaticamente.
+- `onCaughtError`: chamada quando o React captura um erro em um Limite de Erro.
+- `onUncaughtError`: chamada quando um erro é lançado e não é capturado por um Limite de Erro.
+- `onRecoverableError`: chamada quando um erro é lançado e se recupera automaticamente.
 
-Para mais informações e exemplos, consulte a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
+Para mais informações e exemplos, veja a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
 
 ### Suporte para Elementos Personalizados {/*support-for-custom-elements*/}
 
 O React 19 adiciona suporte total para elementos personalizados e passa em todos os testes em [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
 
-Nas versões anteriores, usar Elementos Personalizados no React era difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte para propriedades que funcionam no cliente e durante o SSR com a seguinte estratégia:
+Em versões anteriores, usar Elementos Personalizados no React era difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte a propriedades que funcionam no cliente e durante o SSR com a seguinte estratégia:
 
-- **Renderização Lado do Servidor**: props passadas para um elemento personalizado renderizarão como atributos se seu tipo for um valor primitivo como `string`, `number` ou o valor for `true`. Props com tipos não primitivos como `object`, `symbol`, `function` ou valor `false` serão omitidas.
-- **Renderização Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Personalizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
+- **Renderização do Lado do Servidor**: props passadas para um elemento personalizado serão renderizadas como atributos se seu tipo for um valor primitivo como `string`, `number` ou se o valor for `true`. Props com tipos não primitivos como `object`, `symbol`, `function`, ou valor `false` serão omitidas.
+- **Renderização do Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Personalizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
 
-Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por conduzir o design e a implementação do suporte a Elementos Personalizados no React.
+Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por dirigir o design e a implementação do suporte a Elementos Personalizados no React.
 
 
 #### Como atualizar {/*how-to-upgrade*/}
-Consulte o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para instruções passo a passo e uma lista completa de mudanças quebradoras e notáveis.
+Veja o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para instruções passo a passo e uma lista completa de mudanças que quebram a compatibilidade e mudanças notáveis.

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -2,7 +2,7 @@
 title: "React 19 Beta"
 author: The React Team
 date: 2024/04/25
-description: React 19 Beta já está disponível no npm! Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
+description: O React 19 Beta já está disponível no npm! Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
 ---
 
 25 de abril de 2024 por [The React Team](/community/team)
@@ -11,13 +11,13 @@ description: React 19 Beta já está disponível no npm! Neste post, daremos uma
 
 <Note>
 
-Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e esperar pelo React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
+Esta versão beta é para bibliotecas se prepararem para o React 19. Os desenvolvedores de aplicativos devem atualizar para a versão 18.3.0 e aguardar a versão estável do React 19 enquanto trabalhamos com bibliotecas e fazemos alterações com base no feedback.
 
 </Note>
 
 <Intro>
 
-React 19 Beta já está disponível no npm!
+O React 19 Beta já está disponível no npm!
 
 </Intro>
 
@@ -27,7 +27,7 @@ Em nosso [Guia de Atualização do React 19 Beta](/blog/2024/04/25/react-19-upgr
 - [Melhorias no React 19](#improvements-in-react-19)
 - [Como atualizar](#how-to-upgrade)
 
-Para uma lista de mudanças que quebram a compatibilidade, consulte o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
+Para uma lista de mudanças quebradoras, consulte o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
 
 ---
 
@@ -35,9 +35,9 @@ Para uma lista de mudanças que quebram a compatibilidade, consulte o [Guia de A
 
 ### Ações {/*actions*/}
 
-Um caso de uso comum em aplicativos React é realizar uma mutação de dados e depois atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para alterar seu nome, você fará uma solicitação à API e, em seguida, lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
+Um caso de uso comum em aplicativos React é realizar uma mutação de dados e depois atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para mudar seu nome, você fará uma solicitação de API e depois lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
 
-Por exemplo, você poderia lidar com o estado pendente e de erro em `useState`:
+Por exemplo, você poderia lidar com o estado pendente e erros no `useState`:
 
 ```js
 // Antes das Ações
@@ -71,10 +71,10 @@ function UpdateName({}) {
 
 No React 19, estamos adicionando suporte para usar funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
 
-Por exemplo, você pode usar `useTransition` para tratar o estado pendente para você:
+Por exemplo, você pode usar `useTransition` para lidar com o estado pendente para você:
 
 ```js
-// Usando estado pendente das Ações
+// Usando o estado pendente das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -103,27 +103,27 @@ function UpdateName({}) {
 }
 ```
 
-A transição assíncrona imediatamente definirá o estado `isPending` como verdadeiro, fará a(s) solicitação(ões) assíncrona(s) e mudará `isPending` para falso após qualquer transição. Isso permite que você mantenha a UI atual responsiva e interativa enquanto os dados estão mudando.
+A transição assíncrona definirá imediatamente o estado `isPending` como verdadeiro, fará a(s) solicitação(ões) assíncrona(s) e mudará `isPending` para falso após quaisquer transições. Isso permite que você mantenha a UI atual responsiva e interativa enquanto os dados estão mudando.
 
 <Note>
 
-#### Por convenção, funções que usam transições assíncronas são chamadas de "Ações". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
+#### Por convenção, funções que usam transições assíncronas são chamadas de “Ações”. {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
 
 As Ações gerenciam automaticamente o envio de dados para você:
 
-- **Estado pendente**: As Ações fornecem um estado pendente que começa no início de uma solicitação e é redefinido automaticamente quando a atualização final do estado é confirmada.
+- **Estado pendente**: As Ações fornecem um estado pendente que começa no início de uma solicitação e redefinem automaticamente quando a atualização final do estado é confirmada.
 - **Atualizações otimistas**: As Ações suportam o novo hook [`useOptimistic`](#new-hook-optimistic-updates) para que você possa mostrar feedback instantâneo aos usuários enquanto as solicitações estão sendo enviadas.
-- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir Boundaries de Erro quando uma solicitação falha e reverter atualizações otimistas ao seu valor original automaticamente.
-- **Formulários**: Elementos `<form>` agora suportam passar funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e redefinirá automaticamente o formulário após o envio.
+- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir limites de erro quando uma solicitação falha e reverter atualizações otimistas para seu valor original automaticamente.
+- **Formulários**: Elementos `<form>` agora suportam passar funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e redefine automaticamente o formulário após a submissão.
 
 </Note>
 
-Com base nas Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns para Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar os casos comuns para Ações em formulários.
+Construindo sobre as Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns para Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar casos comuns para Ações em formulários.
 
 No React 19, o exemplo acima pode ser simplificado para:
 
 ```js
-// Usando <form> Ações e useActionState
+// Usando Ações de <form> e useActionState
 function ChangeName({ name, setName }) {
   const [error, submitAction, isPending] = useActionState(
     async (previousState, formData) => {
@@ -147,11 +147,11 @@ function ChangeName({ name, setName }) {
 }
 ```
 
-Na próxima seção, detalharemos cada um dos novos recursos de Ação no React 19.
+Na próxima seção, iremos detalhar cada um dos novos recursos de Ação no React 19.
 
 ### Novo hook: `useActionState` {/*new-hook-useactionstate*/}
 
-Para facilitar os casos comuns para Ações, adicionamos um novo hook chamado `useActionState`:
+Para tornar os casos comuns mais fáceis para as Ações, adicionamos um novo hook chamado `useActionState`:
 
 ```js
 const [error, submitAction, isPending] = useActionState(
@@ -170,33 +170,33 @@ const [error, submitAction, isPending] = useActionState(
 );
 ```
 
-`useActionState` aceita uma função (a "Ação") e retorna uma Ação envolvida para chamar. Isso funciona porque as Ações se compõem. Quando a Ação envolvida é chamada, `useActionState` retornará o último resultado da Ação como `data`, e o estado pendente da Ação como `pending`. 
+`useActionState` aceita uma função (a "Ação") e retorna uma Ação envolvida para chamar. Isso funciona porque Ações se compõem. Quando a Ação envolvida é chamada, `useActionState` retornará o último resultado da Ação como `data`, e o estado pendente da Ação como `pending`. 
 
 <Note>
 
-`React.useActionState` foi anteriormente chamado `ReactDOM.useFormState` nas versões Canary, mas renomeamos e desaprovamos `useFormState`.
+`React.useActionState` era anteriormente chamado de `ReactDOM.useFormState` nas versões Canary, mas renomeamos e descontinuamos `useFormState`.
 
-Consulte [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
+Veja [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
 
 </Note>
 
 Para mais informações, consulte a documentação para [`useActionState`](/reference/react/useActionState).
 
-### React DOM: `<form>` Ações {/*form-actions*/}
+### React DOM: Ações de `<form>` {/*form-actions*/}
 
-As Ações também estão integradas com os novos recursos de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como props `action` e `formAction` de `<form>`, `<input>` e `<button>` para enviar automaticamente formulários com Ações:
+As Ações também estão integradas aos novos recursos de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como props `action` e `formAction` dos elementos `<form>`, `<input>` e `<button>` para enviar automaticamente formulários com Ações:
 
 ```js [[1,1,"actionFunction"]]
 <form action={actionFunction}>
 ```
 
-Quando uma Ação `<form>` é bem-sucedida, o React redefinirá automaticamente o formulário para componentes não controlados. Se você precisar redefinir o `<form>` manualmente, pode chamar a nova API `requestFormReset` do React DOM.
+Quando uma Ação de `<form>` é bem-sucedida, o React redefinirá automaticamente o formulário para componentes não controlados. Se você precisar redefinir o `<form>` manualmente, pode chamar a nova API `requestFormReset` do React DOM.
 
 Para mais informações, consulte a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input) e `<button>`.
 
 ### React DOM: Novo hook: `useFormStatus` {/*new-hook-useformstatus*/}
 
-Em sistemas de design, é comum escrever componentes de design que precisam acessar informações sobre o `<form>` em que estão, sem precisar passar props para baixo até o componente. Isso pode ser feito via Contexto, mas para facilitar o caso comum, adicionamos um novo hook `useFormStatus`:
+Em sistemas de design, é comum escrever componentes de design que precisam acessar informações sobre o `<form>` em que estão, sem precisar passar props para baixo até o componente. Isso pode ser feito via Contexto, mas para facilitar os casos comuns, adicionamos um novo hook `useFormStatus`:
 
 ```js [[1, 4, "pending"], [1, 5, "pending"]]
 import {useFormStatus} from 'react-dom';
@@ -213,7 +213,7 @@ Para mais informações, consulte a documentação do `react-dom` para [`useForm
 
 ### Novo hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
 
-Outro padrão de UI comum ao realizar uma mutação de dados é mostrar o estado final de forma otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
+Outro padrão comum de UI ao realizar uma mutação de dados é mostrar o estado final de forma otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
 
 ```js {2,6,13,19}
 function ChangeName({currentName, onUpdateName}) {
@@ -242,15 +242,15 @@ function ChangeName({currentName, onUpdateName}) {
 }
 ```
 
-O hook `useOptimistic` renderizará imediatamente o `optimisticName` enquanto a solicitação `updateName` está em andamento. Quando a atualização terminar ou falhar, o React mudará automaticamente de volta para o valor `currentName`.
+O hook `useOptimistic` irá imediatamente renderizar o `optimisticName` enquanto a solicitação `updateName` está em andamento. Quando a atualização termina ou ocorre um erro, o React automaticamente voltará ao valor de `currentName`.
 
 Para mais informações, consulte a documentação para [`useOptimistic`](/reference/react/useOptimistic).
 
 ### Nova API: `use` {/*new-feature-use*/}
 
-No React 19, estamos introduzindo uma nova API para ler recursos durante a renderização: `use`.
+No React 19, estamos introduzindo uma nova API para ler recursos na renderização: `use`.
 
-Por exemplo, você pode ler uma promessa com `use`, e o React suspenderá até que a promessa seja resolvida:
+Por exemplo, você pode ler uma promessa com `use`, e o React irá Suspender até que a promessa seja resolvida:
 
 ```js {1,5}
 import {use} from 'react';
@@ -263,7 +263,7 @@ function Comments({commentsPromise}) {
 
 function Page({commentsPromise}) {
   // Quando `use` suspende em Comments,
-  // esta boundary de Suspense será mostrada.
+  // este limite de Suspense será mostrado.
   return (
     <Suspense fallback={<div>Carregando...</div>}>
       <Comments commentsPromise={commentsPromise} />
@@ -276,23 +276,23 @@ function Page({commentsPromise}) {
 
 #### `use` não suporta promessas criadas na renderização. {/*use-does-not-support-promises-created-in-render*/}
 
-Se você tentar passar uma promessa criada na renderização para `use`, o React alertará:
+Se você tentar passar uma promessa criada na renderização para `use`, o React avisará:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Um componente foi suspenso por uma promessa não armazenada em cache. Criar promessas dentro de um Componente Cliente ou hook ainda não é suportado, exceto via uma biblioteca ou framework compatível com Suspense.
+Um componente foi suspenso por uma promessa não em cache. Criar promessas dentro de um Componente do Cliente ou hook ainda não é suportado, exceto por meio de uma biblioteca ou framework compatível com Suspense.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Para corrigir isso, você precisa passar uma promessa de uma biblioteca ou framework que suporta cache para promessas. No futuro, planejamos lançar recursos para facilitar o cache de promessas na renderização.
+Para corrigir, você precisa passar uma promessa de uma biblioteca ou framework compatível com suspense que suporte caching para promessas. No futuro, planejamos lançar recursos para facilitar o armazenamento em cache de promessas na renderização.
 
 </Note>
 
-Você também pode ler contexto com `use`, permitindo que você leia o Contexto condicionalmente, como após retornos antecipados:
+Você também pode ler contexto com `use`, permitindo que você leia Contexto condicionalmente, como após retornos antecipados:
 
 ```js {1,11}
 import {use} from 'react';
@@ -323,18 +323,18 @@ Para mais informações, consulte a documentação para [`use`](/reference/react
 
 ### Componentes do Servidor {/*server-components*/}
 
-Os Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes do empacotamento, em um ambiente separado do seu aplicativo cliente ou servidor SSR. Esse ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção no seu servidor CI ou podem ser executados a cada solicitação usando um servidor web.
+Os Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes da compactação, em um ambiente separado da sua aplicação cliente ou servidor SSR. Esse ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção em seu servidor CI, ou podem ser executados para cada solicitação usando um servidor web.
 
-O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos do canal Canary. Isso significa que bibliotecas que enviam com Componentes do Servidor podem agora direcionar o React 19 como uma dependência peer com uma condição de exportação `react-server` [conhecida](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura Full-stack do React](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
+O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos no canal Canary. Isso significa que bibliotecas que fornecem Componentes do Servidor agora podem direcionar o React 19 como uma dependência par com uma condição de exportação `react-server` [condicional](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura Full-stack React](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
 
 
 <Note>
 
-#### Como posso construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
+#### Como faço para construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
 
-Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um empacotador ou framework de Componentes do Servidor React não seguem semver e podem quebrar entre versões menores no React 19.x. 
+Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um empacotador ou framework de Componentes do Servidor React não seguem o semver e podem quebrar entre versões menores no React 19.x. 
 
-Para suportar Componentes do Servidor React como um empacotador ou framework, recomendamos que você bloqueie uma versão específica do React ou use a versão Canary. Continuaremos trabalhando com empacotadores e frameworks para estabilizar as APIs usadas para implementar Componentes do Servidor React no futuro.
+Para suportar os Componentes do Servidor React como um empacotador ou framework, recomendamos fixar em uma versão específica do React ou usar a versão Canary. Continuaremos trabalhando com empacotadores e frameworks para estabilizar as APIs usadas para implementar os Componentes do Servidor React no futuro.
 
 </Note>
 
@@ -343,9 +343,9 @@ Para mais informações, consulte a documentação para [Componentes do Servidor
 
 ### Ações do Servidor {/*server-actions*/}
 
-As Ações do Servidor permitem que Componentes Cliente chamem funções assíncronas executadas no servidor.
+As Ações do Servidor permitem que Componentes do Cliente chamem funções assíncronas executadas no servidor.
 
-Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Componente Cliente. Quando essa função é chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
+Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Componente do Cliente. Quando essa função é chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
 
 <Note>
 
@@ -357,7 +357,7 @@ Para mais informações, consulte a documentação para [Diretivas](/reference/r
 
 </Note>
 
-As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes Cliente, ou podem ser importadas e usadas em Componentes Cliente.
+As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes do Cliente, ou podem ser importadas e usadas em Componentes do Cliente.
 
 Para mais informações, consulte a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
 
@@ -365,7 +365,7 @@ Para mais informações, consulte a documentação para [Ações do Servidor Rea
 
 ### `ref` como uma prop {/*ref-as-a-prop*/}
 
-A partir do React 19, você pode acessar `ref` como uma prop para componentes de função:
+Começando no React 19, agora você pode acessar `ref` como uma prop para componentes de função:
 
 ```js [[1, 1, "ref"], [1, 2, "ref", 45], [1, 6, "ref", 14]]
 function MyInput({placeholder, ref}) {
@@ -376,23 +376,23 @@ function MyInput({placeholder, ref}) {
 <MyInput ref={ref} />
 ```
 
-Novos componentes de função não precisarão mais de `forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova prop `ref`. Em versões futuras, desaprovaremos e removeremos `forwardRef`.
+Novos componentes de função não precisarão mais de `forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova prop `ref`. Em versões futuras, descontinuaremos e removeremos `forwardRef`.
 
 <Note>
 
-`refs` passadas para classes não são passadas como props, pois fazem referência à instância do componente.
+`refs` passadas para classes não são passadas como props, pois referenciam a instância do componente.
 
 </Note>
 
-### Diferenças para erros de hidratação {*} 
+### Diferenças para erros de hidratação {/*diffs-for-hydration-errors*/}
 
-Melhoramos a coleta de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar vários erros em DEV sem nenhuma informação sobre a discrepância:
+Também melhoramos a relatória de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar múltiplos erros em DEV sem informações sobre a discrepância:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Aviso: O conteúdo do texto não correspondeu. Servidor: "Servidor" Cliente: "Cliente"
+Aviso: O conteúdo de texto não corresponde. Servidor: "Servidor" Cliente: "Cliente"
 {'  '}em span
 {'  '}em App
 
@@ -406,7 +406,7 @@ Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituí
 
 <ConsoleLogLine level="error">
 
-Aviso: O conteúdo do texto não correspondeu. Servidor: "Servidor" Cliente: "Cliente"
+Aviso: O conteúdo de texto não corresponde. Servidor: "Servidor" Cliente: "Cliente"
 {'  '}em span
 {'  '}em App
 
@@ -420,7 +420,7 @@ Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituí
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: O conteúdo do texto não corresponde ao HTML renderizado no servidor.
+Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado no servidor.
 {'  '}em checkForUnmatchedText
 {'  '}...
 
@@ -435,13 +435,13 @@ Agora registramos uma única mensagem com uma diferença da discrepância:
 
 <ConsoleLogLine level="error">
 
-Erro: A hidratação falhou porque o HTML renderizado no servidor não corresponde ao cliente. Como resultado, esta árvore será regenerada no cliente. Isso pode acontecer se um Componente Cliente SSR-ed usou:{'\n'}
-\- Um ramo servidor/clientes `if (typeof window !== 'undefined')`.
+Erro: A hidratação falhou porque o HTML renderizado no servidor não corresponde ao cliente. Como resultado, essa árvore será regenerada no cliente. Isso pode acontecer se um componente Cliente SSR usou:{'\n'}
+\- Uma ramificação servidor/clientes `if (typeof window !== 'undefined')`.
 \- Entrada variável como `Date.now()` ou `Math.random()` que muda a cada vez que é chamada.
-\- Formatação de data na localidade de um usuário que não corresponde ao servidor.
-\- Dados externos mutáveis sem enviar um instantâneo deles juntamente com o HTML.
+\- Formatação de data em um local do usuário que não corresponde ao servidor.
+\- Dados externos em mudança sem enviar um instantâneo deles junto com o HTML.
 \- Aninhamento de tags HTML inválido.{'\n'}
-Isso também pode acontecer se o cliente tiver uma extensão do navegador instalada que bagunce o HTML antes que o React carregue.{'\n'}
+Isso também pode acontecer se o cliente tiver uma extensão de navegador instalada que interfere no HTML antes do React ser carregado.{'\n'}
 https://react.dev/link/hydration-mismatch {'\n'}
 {'  '}\<App\>
 {'    '}\<span\>
@@ -471,33 +471,33 @@ function App({children}) {
 }
 ```
 
-Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod para converter provedores existentes. Em versões futuras, desaprovaremos `<Context.Provider>`.
+Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod para converter provedores existentes. Em versões futuras, descontinuaremos `<Context.Provider>`.
 
 ### Funções de limpeza para refs {/*cleanup-functions-for-refs*/}
 
-Agora suportamos retornar uma função de limpeza de callbacks `ref`:
+Agora suportamos retornar uma função de limpeza dos callbacks `ref`:
 
 ```js {7-9}
 <input
   ref={(ref) => {
     // ref criada
 
-    // NOVO: retornar uma função de limpeza para redefinir
-    // a ref quando o elemento for removido do DOM.
+    // NOVO: retorne uma função de limpeza para redefinir
+    // o ref quando o elemento for removido do DOM.
     return () => {
-      // limpeza da ref
+      // limpeza do ref
     };
   }}
 />
 ```
 
-Quando o componente é desmontado, o React chamará a função de limpeza retornada do callback `ref`. Isso funciona para refs do DOM, refs para componentes de classe e `useImperativeHandle`. 
+Quando o componente é desmontado, o React chamará a função de limpeza retornada do callback `ref`. Isso funciona para refs DOM, refs para componentes de classe e `useImperativeHandle`. 
 
 <Note>
 
-Anteriormente, o React chamava funções `ref` com `null` quando desmontava o componente. Se sua `ref` retornar uma função de limpeza, o React agora pulará essa etapa.
+Anteriormente, o React chamaria funções `ref` com `null` ao desmontar o componente. Se seu `ref` retorna uma função de limpeza, o React agora pulará essa etapa.
 
-Em versões futuras, desaprovaremos chamar refs com `null` ao desmontar componentes.
+Em versões futuras, descontinuaremos chamar refs com `null` ao desmontar componentes.
 
 </Note>
 
@@ -508,9 +508,9 @@ Devido à introdução de funções de limpeza de ref, retornar qualquer outra c
 + <div ref={current => {instance = current}} />
 ```
 
-O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _supondo_ ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
+O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _suposto_ ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
 
-Você pode codemodificar este padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
+Você pode codemodificar esse padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
 
 ### `useDeferredValue` valor inicial {/*use-deferred-value-initial-value*/}
 
@@ -518,8 +518,8 @@ Adicionamos uma opção `initialValue` ao `useDeferredValue`:
 
 ```js [[1, 1, "deferredValue"], [1, 4, "deferredValue"], [2, 4, "''"]]
 function Search({deferredValue}) {
-  // Na renderização inicial, o valor é ''.
-  // Então uma re-renderização é agendada com o deferredValue.
+  // Na renderização inicial o valor é ''.
+  // Em seguida, uma re-renderização é agendada com o deferredValue.
   const value = useDeferredValue(deferredValue, '');
   
   return (
@@ -528,15 +528,15 @@ function Search({deferredValue}) {
 }
 ````
 
-Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` retornará isso como `value` para a renderização inicial do componente, e agendará uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
+Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` retornará como `value` na renderização inicial do componente, e agenda uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
 
-Para mais informações, veja [`useDeferredValue`](/reference/react/useDeferredValue).
+Para mais informações, consulte [`useDeferredValue`](/reference/react/useDeferredValue).
 
 ### Suporte para Metadados do Documento {/*support-for-metadata-tags*/}
 
-No HTML, tags de metadados do documento como `<title>`, `<link>` e `<meta>` são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do lugar onde você renderiza o `<head>` ou o React não renderiza o `<head>` de forma alguma. No passado, esses elementos precisavam ser inseridos manualmente em um efeito, ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor. 
+Em HTML, tags de metadados do documento como `<title>`, `<link>` e `<meta>` são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do lugar onde você renderiza o `<head>` ou o React não renderiza o `<head>` de forma alguma. No passado, esses elementos precisariam ser inseridos manualmente em um efeito, ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam manuseio cuidadoso ao renderizar uma aplicação React no servidor.
 
-No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes nativamente:
+No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes de forma nativa:
 
 ```js {5-8}
 function BlogPost({post}) {
@@ -555,13 +555,13 @@ function BlogPost({post}) {
 }
 ```
 
-Quando o React renderiza este componente, ele verá as tags `<title>`, `<link>` e `<meta>`, e automaticamente as elevará à seção `<head>` do documento. Ao suportar essas tags de metadados nativamente, conseguimos garantir que funcionem com aplicativos apenas do cliente, SSR em streaming e Componentes do Servidor.
+Quando o React renderiza este componente, ele verá as tags `<title>`, `<link>` e `<meta>`, e as elevará automaticamente para a seção `<head>` do documento. Ao suportar essas tags de metadados de forma nativa, conseguimos garantir que elas funcionem com aplicativos apenas do cliente, SSR em streaming e Componentes do Servidor.
 
 <Note>
 
 #### Você ainda pode querer uma biblioteca de Metadados {/*you-may-still-want-a-metadata-library*/}
 
-Para casos de uso simples, renderizar Metadados do Documento como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como substituir metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet) suportar tags de metadados, em vez de substituí-las.
+Para casos de uso simples, renderizar Metadados do Documento como tags pode ser adequado, mas bibliotecas podem oferecer funcionalidades mais poderosas, como substituição de metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet) suportarem tags de metadados, em vez de substituí-las.
 
 </Note>
 
@@ -569,9 +569,9 @@ Para mais informações, consulte a documentação para [`<title>`](/reference/r
 
 ### Suporte para folhas de estilo {/*support-for-stylesheets*/}
 
-Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto inline (`<style>...</style>`), exigem uma cuidadosa posicionamento no DOM devido às regras de precedência de estilo. Criar uma capacidade de folha de estilo que permita a composição dentro de componentes é difícil, então os usuários frequentemente acabam carregando todos os seus estilos longe dos componentes que podem depender deles, ou usam uma biblioteca de estilo que encapsula essa complexidade.
+Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto internas (`<style>...</style>`), requerem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permite composição dentro de componentes é difícil, então os usuários frequentemente acabam carregando todas as suas folhas de estilo longe dos componentes que podem depender delas, ou usam uma biblioteca de estilo que encapsula essa complexidade.
 
-No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e Renderização em Streaming no Servidor com suporte embutido para folhas de estilo. Se você informar ao React a `precedence` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar o conteúdo que depende dessas regras de estilo.
+No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e na Renderização em Streaming no Servidor com suporte interno para folhas de estilo. Se você informar ao React a `precedence` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar conteúdo que dependa dessas regras de estilo.
 
 ```js {4,5,17}
 function ComponentOne() {
@@ -596,38 +596,38 @@ function ComponentTwo() {
 }
 ```
 
-Durante a Renderização do Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não seja pintado até que ela tenha carregado. Se a folha de estilo for descoberta tarde após já termos começado a transmissão, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de uma boundary de Suspense que depende daquela folha de estilo.
+Durante a Renderização Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não pinte até que tenha carregado. Se a folha de estilo for descoberta tarde, após já termos iniciado o streaming, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de um limite de Suspense que dependa dessa folha de estilo.
 
-Durante a Renderização no Lado do Cliente, o React aguardará as folhas de estilo renderizadas recentemente carregarem antes de confirmar a renderização. Se você renderizar este componente de vários lugares dentro da sua aplicação, o React incluirá a folha de estilo apenas uma vez no documento:
+Durante a Renderização Lado do Cliente, o React aguardará que as folhas de estilo recém-renderizadas carreguem antes de confirmar a renderização. Se você renderizar este componente de vários lugares dentro de sua aplicação, o React incluirá a folha de estilo apenas uma vez no documento:
 
 ```js {5}
 function App() {
   return <>
     <ComponentOne />
     ...
-    <ComponentOne /> // não levará a um link de folha de estilo duplicado no DOM
+    <ComponentOne /> // não levará a uma duplicata da folha de estilo no DOM
   </>
 }
 ```
 
-Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade de localizar essas folhas de estilo ao lado dos componentes que dependem delas, permitindo um raciocínio local melhor e uma forma mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
+Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade para localizar essas folhas de estilo ao lado dos componentes que dependem delas, permitindo um melhor raciocínio local e uma maneira mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
 
-Bibliotecas de estilo e integrações de estilo com empacotadores também podem adotar essa nova capacidade, então mesmo se você não renderizar diretamente suas próprias folhas de estilo, ainda poderá se beneficiar à medida que suas ferramentas forem atualizadas para usar esse recurso.
+Bibliotecas de estilo e integrações de estilo com empacotadores também podem adotar essa nova capacidade, de modo que mesmo se você não renderizar diretamente suas próprias folhas de estilo, ainda poderá se beneficiar à medida que suas ferramentas forem atualizadas para usar esse recurso.
 
 Para mais detalhes, consulte a documentação para [`<link>`](/reference/react-dom/components/link) e [`<style>`](/reference/react-dom/components/style).
 
 ### Suporte para scripts assíncronos {/*support-for-async-scripts*/}
 
-No HTML, scripts normais (`<script src="...">`) e scripts adiados (`<script defer="" src="...">`) carregam na ordem do documento, o que torna desafiador renderizar esses tipos de scripts profundamente em sua árvore de componentes. No entanto, scripts assíncronos (`<script async="" src="...">`) carregarão em ordem arbitrária.
+Em HTML, scripts normais (`<script src="...">`) e scripts diferidos (`<script defer="" src="...">`) carregam em ordem de documento, o que torna desafiador renderizar esses tipos de scripts profundamente dentro da sua árvore de componentes. Scripts assíncronos (`<script async="" src="...">`), no entanto, serão carregados em qualquer ordem.
 
-No React 19, incluímos melhor suporte para scripts assíncronos, permitindo que você os renderize em qualquer lugar de sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem precisar gerenciar o realocamento e a deduplicação das instâncias de script.
+No React 19, incluímos melhor suporte para scripts assíncronos, permitindo que você os renderize em qualquer lugar da sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem ter que gerenciar o reposicionamento e a deduplicação das instâncias de script.
 
 ```js {4,15}
 function MyComponent() {
   return (
     <div>
       <script async={true} src="..." />
-      Hello World
+      Olá Mundo
     </div>
   )
 }
@@ -643,33 +643,33 @@ function App() {
 }
 ```
 
-Em todos os ambientes de renderização, scripts assíncronos serão deduplicados, de forma que o React carregará e executará o script apenas uma vez, mesmo que ele seja renderizado por diferentes componentes.
+Em todos os ambientes de renderização, scripts assíncronos serão deduplicados, de modo que o React carregará e executará o script apenas uma vez, mesmo que seja renderizado por diferentes componentes.
 
-Na Renderização do Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados atrás de recursos mais críticos que bloqueiam a pintura, como folhas de estilo, fontes e pré-carregamentos de imagem.
+Na Renderização Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados atrás de recursos mais críticos que bloqueiam o desenho, como folhas de estilo, fontes e pré-carregamentos de imagem.
 
-Para mais detalhes, consulte a documentação para [`<script>`](/reference/react-dom/components/script).
+Para mais detalhes, veja a documentação para [`<script>`](/reference/react-dom/components/script).
 
 ### Suporte para pré-carregamento de recursos {/*support-for-preloading-resources*/}
 
-Durante o carregamento inicial do documento e atualizações do lado do cliente, informar ao Navegador sobre recursos que provavelmente precisarão ser carregados o mais cedo possível pode ter um efeito dramático no desempenho da página.
+Durante o carregamento inicial do documento e em atualizações do lado do cliente, informar ao navegador sobre recursos que ele precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
 
-O React 19 inclui uma série de novas APIs para carregar e pré-carregar recursos do Navegador para tornar o mais fácil possível construir experiências incríveis que não são prejudicadas pelo carregamento ineficiente de recursos.
+O React 19 inclui uma série de novas APIs para carregar e pré-carregar recursos do navegador para facilitar a construção de experiências excelentes que não sejam prejudicadas por carregamentos de recursos ineficientes.
 
 ```js
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 function MyComponent() {
-  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script ansiosamente
+  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script de forma ansiosa
   preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega esta fonte
   preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega esta folha de estilo
-  prefetchDNS('https://...') // quando você pode não realmente solicitar nada desse host
-  preconnect('https://...') // quando você solicitará algo, mas não tem certeza do que
+  prefetchDNS('https://...') // quando você pode não solicitar nada deste host
+  preconnect('https://...') // quando você solicitar algo, mas não tiver certeza do que
 }
 ```
 ```html
 <!-- o acima resultaria no seguinte DOM/HTML -->
 <html>
   <head>
-    <!-- links/scripts são priorizados por sua utilidade para carregamento inicial, não ordem de chamada -->
+    <!-- links/scripts são priorizados por sua utilidade para carregamento inicial, não pela ordem de chamada -->
     <link rel="prefetch-dns" href="https://...">
     <link rel="preconnect" href="https://...">
     <link rel="preload" as="font" href="https://.../path/to/font.woff">
@@ -682,21 +682,21 @@ function MyComponent() {
 </html>
 ```
 
-Essas APIs podem ser usadas para otimizar carregamentos de página iniciais, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento de folhas de estilo. Elas também podem tornar atualizações do cliente mais rápidas, ao pré-carregar uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregar esses recursos de forma ansiosa ao clicar ou até mesmo ao passar o mouse.
+Essas APIs podem ser usadas para otimizar carregamentos iniciais de página, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento de folhas de estilo. Elas também podem tornar atualizações do lado do cliente mais rápidas, pré-carregando uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregando esses recursos ansiosamente ao clicar ou até mesmo ao passar o mouse.
 
-Para mais informações, consulte [APIs de Pré-carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
+Para mais detalhes, consulte [APIs de Pré-carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
 
 ### Compatibilidade com scripts e extensões de terceiros {/*compatibility-with-third-party-scripts-and-extensions*/}
 
-Melhoramos a hidratação para levar em conta scripts de terceiros e extensões do navegador.
+Melhoramos a hidratação para considerar scripts de terceiros e extensões do navegador.
 
-Ao hidratar, se um elemento que é renderizado no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização no cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões do navegador, isso acorreria um erro de discrepância e renderização no cliente.
+Ao hidratar, se um elemento que é renderizado no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma re-renderização do cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões do navegador, isso acionaria um erro de discrepância e renderização do cliente.
 
-No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando os erros de discrepância. Se o React precisar re-renderizar o documento inteiro devido a uma discrepância de hidratação não relacionada, ele manterá estilos inseridos por scripts e extensões de terceiros.
+No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando os erros de discrepância. Se o React precisar re-renderizar todo o documento devido a um erro de hidratação não relacionado, ele deixará no lugar folhas de estilo inseridas por scripts de terceiros e extensões do navegador.
 
-### Melhor manipulação de erros {/*error-handling*/}
+### Melhor relatória de erros {/*error-handling*/}
 
-Melhoramos a manipulação de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização capturado por um Boundary de Erro, anteriormente o React jogava o erro duas vezes (uma vez pelo erro original, em seguida, novamente após falhar ao recuperar automaticamente), e chamava `console.error` com informações sobre onde o erro ocorreu. 
+Melhoramos o tratamento de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização capturado por um Limite de Erro, anteriormente o React lançaria o erro duas vezes (uma vez para o erro original, depois novamente após falhar ao se recuperar automaticamente) e, em seguida, chamaria `console.error` com informações sobre onde o erro ocorreu. 
 
 Isso resultou em três erros para cada erro capturado:
 
@@ -704,7 +704,7 @@ Isso resultou em três erros para cada erro capturado:
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: atingido
+Erro não capturado: hit
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...
@@ -713,7 +713,7 @@ Erro não capturado: atingido
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: atingido<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
+Erro não capturado: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...
@@ -726,19 +726,19 @@ O erro acima ocorreu no componente Throws:
 {'  '}em Throws
 {'  '}em ErrorBoundary
 {'  '}em App{'\n'}
-O React tentará recriar esta árvore de componentes do zero usando o boundary de erro que você forneceu, ErrorBoundary.
+O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-No React 19, registramos um único erro com todas as informações de erro incluídas:
+No React 19, registramos um único erro com todas as informações do erro incluídas:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Erro: atingido
+Erro: hit
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...{'\n'}
@@ -746,7 +746,7 @@ O erro acima ocorreu no componente Throws:
 {'  '}em Throws
 {'  '}em ErrorBoundary
 {'  '}em App{'\n'}
-O React tentará recriar esta árvore de componentes do zero usando o boundary de erro que você forneceu, ErrorBoundary.
+O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
 {'  '}em ErrorBoundary
 {'  '}em App
 
@@ -756,22 +756,23 @@ O React tentará recriar esta árvore de componentes do zero usando o boundary d
 
 Além disso, adicionamos duas novas opções de raiz para complementar `onRecoverableError`:
 
-- `onCaughtError`: chamada quando o React captura um erro em um Boundary de Erro.
-- `onUncaughtError`: chamada quando um erro é lançado e não capturado por um Boundary de Erro.
-- `onRecoverableError`: chamada quando um erro é lançado e automaticamente recuperado.
+- `onCaughtError`: chamado quando o React captura um erro em um Limite de Erro.
+- `onUncaughtError`: chamado quando um erro é lançado e não é capturado por um Limite de Erro.
+- `onRecoverableError`: chamado quando um erro é lançado e recuperado automaticamente.
 
 Para mais informações e exemplos, consulte a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
 
 ### Suporte para Elementos Personalizados {/*support-for-custom-elements*/}
 
-O React 19 adiciona suporte total para elementos personalizados e passa todos os testes no [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
+O React 19 adiciona suporte total para elementos personalizados e passa em todos os testes em [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
 
-Em versões anteriores, usar Elementos Personalizados no React era difícil porque o React tratava props não reconhecidas como atributos, em vez de propriedades. No React 19, adicionamos suporte para propriedades que funcionam no cliente e durante SSR com a seguinte estratégia:
+Nas versões anteriores, usar Elementos Personalizados no React era difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte para propriedades que funcionam no cliente e durante o SSR com a seguinte estratégia:
 
-- **Renderização do Lado do Servidor**: props passadas para um elemento personalizado serão renderizadas como atributos se seu tipo for um valor primitivo como `string`, `number` ou o valor for `true`. Props com tipos não primitivos como `object`, `symbol`, `function` ou valor `false` serão omitidos.
-- **Renderização do Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Personalizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
+- **Renderização Lado do Servidor**: props passadas para um elemento personalizado renderizarão como atributos se seu tipo for um valor primitivo como `string`, `number` ou o valor for `true`. Props com tipos não primitivos como `object`, `symbol`, `function` ou valor `false` serão omitidas.
+- **Renderização Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Personalizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
 
-Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por liderar o design e a implementação do suporte a Elementos Personalizados no React.
+Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por conduzir o design e a implementação do suporte a Elementos Personalizados no React.
+
 
 #### Como atualizar {/*how-to-upgrade*/}
-Consulte o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para obter instruções passo a passo e uma lista completa de mudanças notáveis e que quebram a compatibilidade.
+Consulte o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para instruções passo a passo e uma lista completa de mudanças quebradoras e notáveis.

--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -2,7 +2,7 @@
 title: "React 19 Beta"
 author: The React Team
 date: 2024/04/25
-description: React 19 Beta agora está disponível no npm! Neste post, faremos uma visão geral das novas funcionalidades no React 19 e como você pode adotá-las.
+description: React 19 Beta já está disponível no npm! Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
 ---
 
 25 de abril de 2024 por [The React Team](/community/team)
@@ -11,23 +11,23 @@ description: React 19 Beta agora está disponível no npm! Neste post, faremos u
 
 <Note>
 
-Esta versão beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar o React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
+Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e esperar pelo React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
 <Intro>
 
-React 19 Beta agora está disponível no npm!
+React 19 Beta já está disponível no npm!
 
 </Intro>
 
-No nosso [Guia de Atualização do React 19 Beta](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19 Beta. Neste post, faremos uma visão geral das novas funcionalidades no React 19 e como você pode adotá-las.
+Em nosso [Guia de Atualização do React 19 Beta](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19 Beta. Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
 
 - [O que há de novo no React 19](#whats-new-in-react-19)
 - [Melhorias no React 19](#improvements-in-react-19)
 - [Como atualizar](#how-to-upgrade)
 
-Para uma lista de mudanças significativas, veja o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
+Para uma lista de mudanças que quebram a compatibilidade, consulte o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
 
 ---
 
@@ -35,9 +35,9 @@ Para uma lista de mudanças significativas, veja o [Guia de Atualização](/blog
 
 ### Ações {/*actions*/}
 
-Um caso de uso comum em aplicativos React é executar uma mutação de dados e, em seguida, atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para alterar seu nome, você fará uma solicitação de API e, em seguida, lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
+Um caso de uso comum em aplicativos React é realizar uma mutação de dados e depois atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para alterar seu nome, você fará uma solicitação à API e, em seguida, lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
 
-Por exemplo, você poderia lidar com o estado pendente e o erro em `useState`:
+Por exemplo, você poderia lidar com o estado pendente e de erro em `useState`:
 
 ```js
 // Antes das Ações
@@ -69,9 +69,9 @@ function UpdateName({}) {
 }
 ```
 
-No React 19, estamos adicionando suporte ao uso de funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
+No React 19, estamos adicionando suporte para usar funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
 
-Por exemplo, você pode usar `useTransition` para lidar com o estado pendente para você:
+Por exemplo, você pode usar `useTransition` para tratar o estado pendente para você:
 
 ```js
 // Usando estado pendente das Ações
@@ -103,22 +103,22 @@ function UpdateName({}) {
 }
 ```
 
-A transição assíncrona definirá imediatamente o estado `isPending` como verdadeiro, fará a(s) solicitação(ões) assíncrona(s) e mudará `isPending` para falso após qualquer transição. Isso permite que você mantenha a UI atual responsiva e interativa enquanto os dados estão mudando.
+A transição assíncrona imediatamente definirá o estado `isPending` como verdadeiro, fará a(s) solicitação(ões) assíncrona(s) e mudará `isPending` para falso após qualquer transição. Isso permite que você mantenha a UI atual responsiva e interativa enquanto os dados estão mudando.
 
 <Note>
 
 #### Por convenção, funções que usam transições assíncronas são chamadas de "Ações". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
 
-Ações gerenciam automaticamente o envio de dados para você:
+As Ações gerenciam automaticamente o envio de dados para você:
 
-- **Estado pendente**: Ações fornecem um estado pendente que começa no início de uma solicitação e reinicia automaticamente quando a atualização final do estado é comprometida.
-- **Atualizações otimistas**: Ações suportam o novo hook [`useOptimistic`](#new-hook-optimistic-updates) para que você possa mostrar aos usuários um feedback instantâneo enquanto as solicitações estão sendo enviadas.
-- **Tratamento de erros**: Ações fornecem tratamento de erros para que você possa exibir Limites de Erro quando uma solicitação falha e reverter automaticamente atualizações otimistas para seus valores originais.
-- **Formulários**: Elementos `<form>` agora suportam a passagem de funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e reinicia o formulário automaticamente após a submissão.
+- **Estado pendente**: As Ações fornecem um estado pendente que começa no início de uma solicitação e é redefinido automaticamente quando a atualização final do estado é confirmada.
+- **Atualizações otimistas**: As Ações suportam o novo hook [`useOptimistic`](#new-hook-optimistic-updates) para que você possa mostrar feedback instantâneo aos usuários enquanto as solicitações estão sendo enviadas.
+- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir Boundaries de Erro quando uma solicitação falha e reverter atualizações otimistas ao seu valor original automaticamente.
+- **Formulários**: Elementos `<form>` agora suportam passar funções para as props `action` e `formAction`. Passar funções para as props `action` usa Ações por padrão e redefinirá automaticamente o formulário após o envio.
 
 </Note>
 
-Construindo em cima das Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns para Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar os casos comuns de Ações em formulários.
+Com base nas Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns para Ações. No `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar os casos comuns para Ações em formulários.
 
 No React 19, o exemplo acima pode ser simplificado para:
 
@@ -147,7 +147,7 @@ function ChangeName({ name, setName }) {
 }
 ```
 
-Na próxima seção, vamos detalhar cada uma das novas funcionalidades das Ações no React 19.
+Na próxima seção, detalharemos cada um dos novos recursos de Ação no React 19.
 
 ### Novo hook: `useActionState` {/*new-hook-useactionstate*/}
 
@@ -163,40 +163,40 @@ const [error, submitAction, isPending] = useActionState(
       return error;
     }
 
-    // lidar com sucesso
+    // tratar sucesso
     return null;
   },
   null,
 );
 ```
 
-`useActionState` aceita uma função (a "Ação") e retorna uma Ação encapsulada a ser chamada. Isso funciona porque as Ações se compõem. Quando a Ação encapsulada é chamada, `useActionState` retornará o último resultado da Ação como `data` e o estado pendente da Ação como `pending`. 
+`useActionState` aceita uma função (a "Ação") e retorna uma Ação envolvida para chamar. Isso funciona porque as Ações se compõem. Quando a Ação envolvida é chamada, `useActionState` retornará o último resultado da Ação como `data`, e o estado pendente da Ação como `pending`. 
 
 <Note>
 
-`React.useActionState` foi anteriormente chamado de `ReactDOM.useFormState` nas versões Canary, mas o renomeamos e depreciamos `useFormState`.
+`React.useActionState` foi anteriormente chamado `ReactDOM.useFormState` nas versões Canary, mas renomeamos e desaprovamos `useFormState`.
 
-Veja [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
+Consulte [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
 
 </Note>
 
-Para mais informações, veja a documentação para [`useActionState`](/reference/react/useActionState).
+Para mais informações, consulte a documentação para [`useActionState`](/reference/react/useActionState).
 
 ### React DOM: `<form>` Ações {/*form-actions*/}
 
-As Ações também estão integradas com as novas funcionalidades de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como as props `action` e `formAction` de `<form>`, `<input>` e `<button>` para enviar automaticamente formulários com Ações:
+As Ações também estão integradas com os novos recursos de `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como props `action` e `formAction` de `<form>`, `<input>` e `<button>` para enviar automaticamente formulários com Ações:
 
 ```js [[1,1,"actionFunction"]]
 <form action={actionFunction}>
 ```
 
-Quando uma Ação de `<form>` tem sucesso, o React automaticamente reinicia o formulário para componentes não controlados. Se você precisar reiniciar o `<form>` manualmente, pode chamar a nova API React DOM `requestFormReset`.
+Quando uma Ação `<form>` é bem-sucedida, o React redefinirá automaticamente o formulário para componentes não controlados. Se você precisar redefinir o `<form>` manualmente, pode chamar a nova API `requestFormReset` do React DOM.
 
-Para mais informações, veja a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input) e `<button>`.
+Para mais informações, consulte a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input) e `<button>`.
 
 ### React DOM: Novo hook: `useFormStatus` {/*new-hook-useformstatus*/}
 
-Em sistemas de design, é comum escrever componentes de design que precisam de acesso a informações sobre o `<form>` em que estão, sem passar props adiante para o componente. Isso pode ser feito via Contexto, mas para facilitar o caso comum, adicionamos um novo hook `useFormStatus`:
+Em sistemas de design, é comum escrever componentes de design que precisam acessar informações sobre o `<form>` em que estão, sem precisar passar props para baixo até o componente. Isso pode ser feito via Contexto, mas para facilitar o caso comum, adicionamos um novo hook `useFormStatus`:
 
 ```js [[1, 4, "pending"], [1, 5, "pending"]]
 import {useFormStatus} from 'react-dom';
@@ -209,11 +209,11 @@ function DesignButton() {
 
 `useFormStatus` lê o status do `<form>` pai como se o formulário fosse um provedor de Contexto.
 
-Para mais informações, veja a documentação do `react-dom` para [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+Para mais informações, consulte a documentação do `react-dom` para [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
 
 ### Novo hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
 
-Outro padrão de UI comum ao realizar uma mutação de dados é mostrar o estado final de maneira otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
+Outro padrão de UI comum ao realizar uma mutação de dados é mostrar o estado final de forma otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
 
 ```js {2,6,13,19}
 function ChangeName({currentName, onUpdateName}) {
@@ -230,7 +230,7 @@ function ChangeName({currentName, onUpdateName}) {
     <form action={submitAction}>
       <p>Seu nome é: {optimisticName}</p>
       <p>
-        <label>Alterar Nome:</label>
+        <label>Mudar Nome:</label>
         <input
           type="text"
           name="name"
@@ -242,28 +242,28 @@ function ChangeName({currentName, onUpdateName}) {
 }
 ```
 
-O hook `useOptimistic` renderizará imediatamente o `optimisticName` enquanto a solicitação `updateName` estiver em andamento. Quando a atualização termina ou falha, o React mudará automaticamente de volta para o valor `currentName`.
+O hook `useOptimistic` renderizará imediatamente o `optimisticName` enquanto a solicitação `updateName` está em andamento. Quando a atualização terminar ou falhar, o React mudará automaticamente de volta para o valor `currentName`.
 
-Para mais informações, veja a documentação para [`useOptimistic`](/reference/react/useOptimistic).
+Para mais informações, consulte a documentação para [`useOptimistic`](/reference/react/useOptimistic).
 
 ### Nova API: `use` {/*new-feature-use*/}
 
 No React 19, estamos introduzindo uma nova API para ler recursos durante a renderização: `use`.
 
-Por exemplo, você pode ler uma promessa com `use`, e o React fará Suspense até que a promessa se resolva:
+Por exemplo, você pode ler uma promessa com `use`, e o React suspenderá até que a promessa seja resolvida:
 
 ```js {1,5}
 import {use} from 'react';
 
 function Comments({commentsPromise}) {
-  // `use` suspenderá até que a promessa se resolva.
+  // `use` suspenderá até que a promessa seja resolvida.
   const comments = use(commentsPromise);
   return comments.map(comment => <p key={comment.id}>{comment}</p>);
 }
 
 function Page({commentsPromise}) {
-  // Quando `use` suspender em Comentários,
-  // este limite de Suspense será mostrado.
+  // Quando `use` suspende em Comments,
+  // esta boundary de Suspense será mostrada.
   return (
     <Suspense fallback={<div>Carregando...</div>}>
       <Comments commentsPromise={commentsPromise} />
@@ -276,23 +276,23 @@ function Page({commentsPromise}) {
 
 #### `use` não suporta promessas criadas na renderização. {/*use-does-not-support-promises-created-in-render*/}
 
-Se você tentar passar uma promessa criada na renderização para `use`, o React avisará:
+Se você tentar passar uma promessa criada na renderização para `use`, o React alertará:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Um componente foi suspenso por uma promessa não cacheada. Criar promessas dentro de um Componente Cliente ou hook ainda não é suportado, exceto via uma biblioteca ou framework compatível com Suspense.
+Um componente foi suspenso por uma promessa não armazenada em cache. Criar promessas dentro de um Componente Cliente ou hook ainda não é suportado, exceto via uma biblioteca ou framework compatível com Suspense.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Para corrigir, você precisa passar uma promessa de uma biblioteca ou framework alimentado por suspense que suporte cache para promessas. No futuro, planejamos lançar funcionalidades para facilitar o cache de promessas na renderização.
+Para corrigir isso, você precisa passar uma promessa de uma biblioteca ou framework que suporta cache para promessas. No futuro, planejamos lançar recursos para facilitar o cache de promessas na renderização.
 
 </Note>
 
-Você também pode ler o contexto com `use`, permitindo que você leia o Contexto condicionalmente, como após retornos antecipados:
+Você também pode ler contexto com `use`, permitindo que você leia o Contexto condicionalmente, como após retornos antecipados:
 
 ```js {1,11}
 import {use} from 'react';
@@ -314,56 +314,58 @@ function Heading({children}) {
 }
 ```
 
-A API `use` só pode ser chamada na renderização, semelhante aos hooks. Ao contrário dos hooks, `use` pode ser chamado condicionalmente. No futuro, planejamos suportar mais maneiras de consumir recursos durante a renderização com `use`.
+A API `use` só pode ser chamada na renderização, semelhante aos hooks. Ao contrário dos hooks, `use` pode ser chamado condicionalmente. No futuro, planejamos suportar mais formas de consumir recursos na renderização com `use`.
 
-Para mais informações, veja a documentação para [`use`](/reference/react/use).
+Para mais informações, consulte a documentação para [`use`](/reference/react/use).
 
 
 ## Componentes do Servidor React {/*react-server-components*/}
 
 ### Componentes do Servidor {/*server-components*/}
 
-Os Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes de realizar o bundling, em um ambiente separado do seu aplicativo cliente ou servidor SSR. Este ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção no seu servidor CI, ou podem ser executados para cada solicitação usando um servidor web.
+Os Componentes do Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes do empacotamento, em um ambiente separado do seu aplicativo cliente ou servidor SSR. Esse ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no tempo de construção no seu servidor CI ou podem ser executados a cada solicitação usando um servidor web.
 
-O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos no canal Canary. Isso significa que bibliotecas que são enviadas com Componentes do Servidor agora podem direcionar o React 19 como uma dependência peer com uma condição de exportação `react-server` [condicional](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura React Full-stack](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
+O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos do canal Canary. Isso significa que bibliotecas que enviam com Componentes do Servidor podem agora direcionar o React 19 como uma dependência peer com uma condição de exportação `react-server` [conhecida](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) para uso em frameworks que suportam a [Arquitetura Full-stack do React](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
+
 
 <Note>
 
 #### Como posso construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
 
-Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um bundler ou framework de Componentes do Servidor React não seguem semver e podem quebrar entre versões menores no React 19.x. 
+Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um empacotador ou framework de Componentes do Servidor React não seguem semver e podem quebrar entre versões menores no React 19.x. 
 
-Para suportar os Componentes do Servidor React como um bundler ou framework, recomendamos que você fixo a uma versão específica do React ou use a versão Canary. Continuaremos trabalhando com bundlers e frameworks para estabilizar as APIs utilizadas para implementar os Componentes do Servidor React no futuro.
+Para suportar Componentes do Servidor React como um empacotador ou framework, recomendamos que você bloqueie uma versão específica do React ou use a versão Canary. Continuaremos trabalhando com empacotadores e frameworks para estabilizar as APIs usadas para implementar Componentes do Servidor React no futuro.
 
 </Note>
 
-Para mais, veja a documentação para [Componentes do Servidor React](/reference/rsc/server-components).
+
+Para mais informações, consulte a documentação para [Componentes do Servidor React](/reference/rsc/server-components).
 
 ### Ações do Servidor {/*server-actions*/}
 
 As Ações do Servidor permitem que Componentes Cliente chamem funções assíncronas executadas no servidor.
 
-Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência à função do servidor e passará essa referência para o Componente Cliente. Quando essa função for chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
+Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Componente Cliente. Quando essa função é chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
 
 <Note>
 
 #### Não há diretiva para Componentes do Servidor. {/*there-is-no-directive-for-server-components*/}
 
-Uma compreensão comum é que os Componentes do Servidor são denotados por `"use server"`, mas não há diretiva para os Componentes do Servidor. A diretiva `"use server"` é usada para Ações do Servidor.
+Um mal-entendido comum é que os Componentes do Servidor são denotados por `"use server"`, mas não há diretiva para Componentes do Servidor. A diretiva `"use server"` é usada para Ações do Servidor.
 
-Para mais informações, veja a documentação para [Diretivas](/reference/rsc/directives).
+Para mais informações, consulte a documentação para [Diretivas](/reference/rsc/directives).
 
 </Note>
 
 As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes Cliente, ou podem ser importadas e usadas em Componentes Cliente.
 
-Para mais, veja a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
+Para mais informações, consulte a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
 
 ## Melhorias no React 19 {/*improvements-in-react-19*/}
 
 ### `ref` como uma prop {/*ref-as-a-prop*/}
 
-Começando no React 19, você agora pode acessar `ref` como uma prop para componentes de função:
+A partir do React 19, você pode acessar `ref` como uma prop para componentes de função:
 
 ```js [[1, 1, "ref"], [1, 2, "ref", 45], [1, 6, "ref", 14]]
 function MyInput({placeholder, ref}) {
@@ -374,23 +376,23 @@ function MyInput({placeholder, ref}) {
 <MyInput ref={ref} />
 ```
 
-Novos componentes de função não precisarão mais de `forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova prop `ref`. Nas versões futuras, iremos depreciar e remover `forwardRef`.
+Novos componentes de função não precisarão mais de `forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova prop `ref`. Em versões futuras, desaprovaremos e removeremos `forwardRef`.
 
 <Note>
 
-`refs` passados para classes não são passados como props, pois fazem referência à instância do componente.
+`refs` passadas para classes não são passadas como props, pois fazem referência à instância do componente.
 
 </Note>
 
-### Diferenças para erros de hidratação {/*diffs-for-hydration-errors*/}
+### Diferenças para erros de hidratação {*} 
 
-Também melhoramos a reportagem de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar múltiplos erros em DEV sem nenhuma informação sobre a discrepância:
+Melhoramos a coleta de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar vários erros em DEV sem nenhuma informação sobre a discrepância:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Aviso: O conteúdo de texto não correspondia. Servidor: "Servidor" Cliente: "Cliente"
+Aviso: O conteúdo do texto não correspondeu. Servidor: "Servidor" Cliente: "Cliente"
 {'  '}em span
 {'  '}em App
 
@@ -404,7 +406,7 @@ Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituí
 
 <ConsoleLogLine level="error">
 
-Aviso: O conteúdo de texto não correspondia. Servidor: "Servidor" Cliente: "Cliente"
+Aviso: O conteúdo do texto não correspondeu. Servidor: "Servidor" Cliente: "Cliente"
 {'  '}em span
 {'  '}em App
 
@@ -418,7 +420,7 @@ Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituí
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado no servidor.
+Erro não capturado: O conteúdo do texto não corresponde ao HTML renderizado no servidor.
 {'  '}em checkForUnmatchedText
 {'  '}...
 
@@ -428,17 +430,18 @@ Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado n
 
 Agora registramos uma única mensagem com uma diferença da discrepância:
 
+
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: A hidratação falhou porque o HTML renderizado pelo servidor não correspondesse ao cliente. Como resultado, esta árvore será regenerada no cliente. Isso pode acontecer se um Componente Cliente SSR-ed usou:{'\n'}
-\- Um branch servidor/clente `if (typeof window !== 'undefined')`.
-\- Entrada variável como `Date.now()` ou `Math.random()` que muda a cada chamada.
+Erro: A hidratação falhou porque o HTML renderizado no servidor não corresponde ao cliente. Como resultado, esta árvore será regenerada no cliente. Isso pode acontecer se um Componente Cliente SSR-ed usou:{'\n'}
+\- Um ramo servidor/clientes `if (typeof window !== 'undefined')`.
+\- Entrada variável como `Date.now()` ou `Math.random()` que muda a cada vez que é chamada.
 \- Formatação de data na localidade de um usuário que não corresponde ao servidor.
-\- Dados externos que mudam sem enviar um instantâneo junto com o HTML.
-\- Aninhamento inválido de tags HTML.{'\n'}
-Isso também pode acontecer se o cliente tiver uma extensão do navegador instalada que baguncem o HTML antes do React carregar.{'\n'}
+\- Dados externos mutáveis sem enviar um instantâneo deles juntamente com o HTML.
+\- Aninhamento de tags HTML inválido.{'\n'}
+Isso também pode acontecer se o cliente tiver uma extensão do navegador instalada que bagunce o HTML antes que o React carregue.{'\n'}
 https://react.dev/link/hydration-mismatch {'\n'}
 {'  '}\<App\>
 {'    '}\<span\>
@@ -468,11 +471,11 @@ function App({children}) {
 }
 ```
 
-Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod para converter provedores existentes. Nas versões futuras, iremos depreciar `<Context.Provider>`.
+Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod para converter provedores existentes. Em versões futuras, desaprovaremos `<Context.Provider>`.
 
 ### Funções de limpeza para refs {/*cleanup-functions-for-refs*/}
 
-Agora suportamos retornar uma função de limpeza dos callbacks de `ref`:
+Agora suportamos retornar uma função de limpeza de callbacks `ref`:
 
 ```js {7-9}
 <input
@@ -488,35 +491,35 @@ Agora suportamos retornar uma função de limpeza dos callbacks de `ref`:
 />
 ```
 
-Quando o componente é desmontado, o React chamará a função de limpeza retornada do callback de `ref`. Isso funciona para refs de DOM, refs para componentes de classe e `useImperativeHandle`. 
+Quando o componente é desmontado, o React chamará a função de limpeza retornada do callback `ref`. Isso funciona para refs do DOM, refs para componentes de classe e `useImperativeHandle`. 
 
 <Note>
 
-Anteriormente, o React chamaria funções de `ref` com `null` ao desmontar o componente. Se sua `ref` retornar uma função de limpeza, o React agora ignorará essa etapa.
+Anteriormente, o React chamava funções `ref` com `null` quando desmontava o componente. Se sua `ref` retornar uma função de limpeza, o React agora pulará essa etapa.
 
-Nas versões futuras, iremos depreciar a chamada de refs com `null` ao desmontar componentes.
+Em versões futuras, desaprovaremos chamar refs com `null` ao desmontar componentes.
 
 </Note>
 
-Devido à introdução de funções de limpeza de refs, retornar qualquer outra coisa de um callback de `ref` será agora rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos, por exemplo:
+Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de um callback `ref` agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos, por exemplo:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-O código original retornou a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _suposto_ ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
+O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _supondo_ ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
 
-Você pode codemodificar esse padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
+Você pode codemodificar este padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
 
 ### `useDeferredValue` valor inicial {/*use-deferred-value-initial-value*/}
 
-Adicionamos uma opção `initialValue` a `useDeferredValue`:
+Adicionamos uma opção `initialValue` ao `useDeferredValue`:
 
 ```js [[1, 1, "deferredValue"], [1, 4, "deferredValue"], [2, 4, "''"]]
 function Search({deferredValue}) {
   // Na renderização inicial, o valor é ''.
-  // Em seguida, uma nova renderização é agendada com o deferredValue.
+  // Então uma re-renderização é agendada com o deferredValue.
   const value = useDeferredValue(deferredValue, '');
   
   return (
@@ -525,13 +528,13 @@ function Search({deferredValue}) {
 }
 ````
 
-Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` o retornará como `value` para a renderização inicial do componente, e agenda uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
+Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` retornará isso como `value` para a renderização inicial do componente, e agendará uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
 
-Para mais, veja [`useDeferredValue`](/reference/react/useDeferredValue).
+Para mais informações, veja [`useDeferredValue`](/reference/react/useDeferredValue).
 
-### Suporte para Metadados de Documento {/*support-for-metadata-tags*/}
+### Suporte para Metadados do Documento {/*support-for-metadata-tags*/}
 
-Em HTML, as tags de metadados de documento, como `<title>`, `<link>` e `<meta>`, são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do local onde você renderiza o `<head>` ou o React não renderiza o `<head>` de maneira alguma. No passado, esses elementos precisariam ser inseridos manualmente em um efeito ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor. 
+No HTML, tags de metadados do documento como `<title>`, `<link>` e `<meta>` são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do lugar onde você renderiza o `<head>` ou o React não renderiza o `<head>` de forma alguma. No passado, esses elementos precisavam ser inseridos manualmente em um efeito, ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor. 
 
 No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes nativamente:
 
@@ -545,30 +548,30 @@ function BlogPost({post}) {
       <link rel="author" href="https://twitter.com/joshcstory/" />
       <meta name="keywords" content={post.keywords} />
       <p>
-        Eee é igual a em-see-quadrado...
+        Eee equals em-see-squared...
       </p>
     </article>
   );
 }
 ```
 
-Quando o React renderiza este componente, verá as tags `<title>`, `<link>` e `<meta>`, e automaticamente as elevará para a seção `<head>` do documento. Ao suportar essas tags de metadados nativamente, conseguimos garantir que funcionem com aplicativos apenas de cliente, SSR com streaming e Componentes do Servidor.
+Quando o React renderiza este componente, ele verá as tags `<title>`, `<link>` e `<meta>`, e automaticamente as elevará à seção `<head>` do documento. Ao suportar essas tags de metadados nativamente, conseguimos garantir que funcionem com aplicativos apenas do cliente, SSR em streaming e Componentes do Servidor.
 
 <Note>
 
 #### Você ainda pode querer uma biblioteca de Metadados {/*you-may-still-want-a-metadata-library*/}
 
-Para casos de uso simples, renderizar Metadados de Documento como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como substituir metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam o suporte a tags de metadados para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), em vez de substituí-las.
+Para casos de uso simples, renderizar Metadados do Documento como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como substituir metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet) suportar tags de metadados, em vez de substituí-las.
 
 </Note>
 
-Para mais informações, veja a documentação para [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link) e [`<meta>`](/reference/react-dom/components/meta).
+Para mais informações, consulte a documentação para [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link) e [`<meta>`](/reference/react-dom/components/meta).
 
 ### Suporte para folhas de estilo {/*support-for-stylesheets*/}
 
-Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto inline (`<style>...</style>`), exigem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permita a composibilidade dentro de componentes é difícil, então os usuários geralmente acabam carregando todas as suas estilos longe dos componentes que podem depender deles ou usam uma biblioteca de estilo que encapsula essa complexidade.
+Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto inline (`<style>...</style>`), exigem uma cuidadosa posicionamento no DOM devido às regras de precedência de estilo. Criar uma capacidade de folha de estilo que permita a composição dentro de componentes é difícil, então os usuários frequentemente acabam carregando todos os seus estilos longe dos componentes que podem depender deles, ou usam uma biblioteca de estilo que encapsula essa complexidade.
 
-No React 19, estamos abordando essa complexidade e oferecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e na Renderização por Streaming no Servidor com suporte incorporado para folhas de estilo. Se você informar ao React a `precedência` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar o conteúdo que depende dessas regras de estilo.
+No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e Renderização em Streaming no Servidor com suporte embutido para folhas de estilo. Se você informar ao React a `precedence` da sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar o conteúdo que depende dessas regras de estilo.
 
 ```js {4,5,17}
 function ComponentOne() {
@@ -593,38 +596,38 @@ function ComponentTwo() {
 }
 ```
 
-Durante a Renderização do Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não pintará até que tenha carregado. Se a folha de estilo for descoberta tarde, após já termos começado a fazer streaming, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de um limite de Suspense que depende daquela folha de estilo.
+Durante a Renderização do Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não seja pintado até que ela tenha carregado. Se a folha de estilo for descoberta tarde após já termos começado a transmissão, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de uma boundary de Suspense que depende daquela folha de estilo.
 
-Durante a Renderização do Lado do Cliente, o React aguardará que as novas folhas de estilo renderizadas carreguem antes de comprometer a renderização. Se você renderizar este componente de múltiplos locais dentro da sua aplicação, o React incluirá a folha de estilo apenas uma vez no documento:
+Durante a Renderização no Lado do Cliente, o React aguardará as folhas de estilo renderizadas recentemente carregarem antes de confirmar a renderização. Se você renderizar este componente de vários lugares dentro da sua aplicação, o React incluirá a folha de estilo apenas uma vez no documento:
 
 ```js {5}
 function App() {
   return <>
     <ComponentOne />
     ...
-    <ComponentOne /> // não levará a uma duplicata da folha de estilo no DOM
+    <ComponentOne /> // não levará a um link de folha de estilo duplicado no DOM
   </>
 }
 ```
 
-Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade de localizar essas folhas de estilo ao lado dos componentes dos quais dependem, permitindo um melhor raciocínio local e uma maneira mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
+Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade de localizar essas folhas de estilo ao lado dos componentes que dependem delas, permitindo um raciocínio local melhor e uma forma mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
 
-Bibliotecas de estilo e integrações de estilo com bundlers também podem adotar essa nova capacidade, para que mesmo que você não renderize suas próprias folhas de estilo diretamente, ainda possa se beneficiar à medida que suas ferramentas forem atualizadas para usar essa funcionalidade.
+Bibliotecas de estilo e integrações de estilo com empacotadores também podem adotar essa nova capacidade, então mesmo se você não renderizar diretamente suas próprias folhas de estilo, ainda poderá se beneficiar à medida que suas ferramentas forem atualizadas para usar esse recurso.
 
 Para mais detalhes, consulte a documentação para [`<link>`](/reference/react-dom/components/link) e [`<style>`](/reference/react-dom/components/style).
 
 ### Suporte para scripts assíncronos {/*support-for-async-scripts*/}
 
-Em HTML, scripts normais (`<script src="...">`) e scripts diferidos (`<script defer="" src="...">`) carregam na ordem do documento, o que torna desafiador renderizar esses tipos de scripts dentro de sua árvore de componentes. No entanto, scripts assíncronos (`<script async="" src="...">`) podem ser carregados em ordem arbitrária.
+No HTML, scripts normais (`<script src="...">`) e scripts adiados (`<script defer="" src="...">`) carregam na ordem do documento, o que torna desafiador renderizar esses tipos de scripts profundamente em sua árvore de componentes. No entanto, scripts assíncronos (`<script async="" src="...">`) carregarão em ordem arbitrária.
 
-No React 19, incluímos um suporte melhor para scripts assíncronos, permitindo que você os renderize em qualquer lugar de sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem precisar gerenciar o realocamento e deduplicação de instâncias de script.
+No React 19, incluímos melhor suporte para scripts assíncronos, permitindo que você os renderize em qualquer lugar de sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem precisar gerenciar o realocamento e a deduplicação das instâncias de script.
 
 ```js {4,15}
 function MyComponent() {
   return (
     <div>
       <script async={true} src="..." />
-      Olá Mundo
+      Hello World
     </div>
   )
 }
@@ -640,33 +643,33 @@ function App() {
 }
 ```
 
-Em todos os ambientes de renderização, os scripts assíncronos serão deduplicados, de modo que o React carregue e execute o script apenas uma vez, mesmo que seja renderizado por múltiplos componentes diferentes.
+Em todos os ambientes de renderização, scripts assíncronos serão deduplicados, de forma que o React carregará e executará o script apenas uma vez, mesmo que ele seja renderizado por diferentes componentes.
 
-Na Renderização do Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados após recursos mais críticos que bloqueiam a pintura, como folhas de estilo, fontes e pré-carregamentos de imagens.
+Na Renderização do Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados atrás de recursos mais críticos que bloqueiam a pintura, como folhas de estilo, fontes e pré-carregamentos de imagem.
 
 Para mais detalhes, consulte a documentação para [`<script>`](/reference/react-dom/components/script).
 
 ### Suporte para pré-carregamento de recursos {/*support-for-preloading-resources*/}
 
-Durante o carregamento inicial do documento e em atualizações do lado do cliente, informar ao navegador sobre os recursos que provavelmente precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
+Durante o carregamento inicial do documento e atualizações do lado do cliente, informar ao Navegador sobre recursos que provavelmente precisarão ser carregados o mais cedo possível pode ter um efeito dramático no desempenho da página.
 
-O React 19 inclui várias novas APIs para carregar e pré-carregar recursos do navegador para facilitar a construção de experiências excelentes que não sejam bloqueadas por um carregamento de recursos ineficiente.
+O React 19 inclui uma série de novas APIs para carregar e pré-carregar recursos do Navegador para tornar o mais fácil possível construir experiências incríveis que não são prejudicadas pelo carregamento ineficiente de recursos.
 
 ```js
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 function MyComponent() {
   preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script ansiosamente
-  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega essa fonte
-  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega essa folha de estilo
-  prefetchDNS('https://...') // quando você pode não realmente requerer nada desse host
-  preconnect('https://...') // quando você requisitará algo mas não tem certeza do que
+  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega esta fonte
+  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega esta folha de estilo
+  prefetchDNS('https://...') // quando você pode não realmente solicitar nada desse host
+  preconnect('https://...') // quando você solicitará algo, mas não tem certeza do que
 }
 ```
 ```html
 <!-- o acima resultaria no seguinte DOM/HTML -->
 <html>
   <head>
-    <!-- links/scripts são priorizados pela sua utilidade para o carregamento inicial, e não pela ordem de chamada -->
+    <!-- links/scripts são priorizados por sua utilidade para carregamento inicial, não ordem de chamada -->
     <link rel="prefetch-dns" href="https://...">
     <link rel="preconnect" href="https://...">
     <link rel="preload" as="font" href="https://.../path/to/font.woff">
@@ -679,29 +682,29 @@ function MyComponent() {
 </html>
 ```
 
-Essas APIs podem ser usadas para otimizar os carregamentos iniciais da página, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento da folha de estilo. Elas também podem tornar atualizações do cliente mais rápidas pré-carregando uma lista de recursos usados em uma navegação antecipada e, em seguida, pré-carregando esses recursos ansiosamente ao clicar ou até mesmo ao passar o mouse.
+Essas APIs podem ser usadas para otimizar carregamentos de página iniciais, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento de folhas de estilo. Elas também podem tornar atualizações do cliente mais rápidas, ao pré-carregar uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregar esses recursos de forma ansiosa ao clicar ou até mesmo ao passar o mouse.
 
-Para mais detalhes, veja [APIs de Pré-Carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
+Para mais informações, consulte [APIs de Pré-carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
 
 ### Compatibilidade com scripts e extensões de terceiros {/*compatibility-with-third-party-scripts-and-extensions*/}
 
 Melhoramos a hidratação para levar em conta scripts de terceiros e extensões do navegador.
 
-Ao hidratar, se um elemento que renderiza no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização do cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões do navegador, isso acionaria um erro de discrepância e uma renderização no cliente.
+Ao hidratar, se um elemento que é renderizado no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização no cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões do navegador, isso acorreria um erro de discrepância e renderização no cliente.
 
-No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando erros de discrepância. Se o React precisar re-renderizar todo o documento devido a uma discrepância de hidratação não relacionada, ele deixará no lugar folhas de estilos inseridas por scripts de terceiros e extensões do navegador.
+No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando os erros de discrepância. Se o React precisar re-renderizar o documento inteiro devido a uma discrepância de hidratação não relacionada, ele manterá estilos inseridos por scripts e extensões de terceiros.
 
-### Melhorias na reportagem de erros {/*error-handling*/}
+### Melhor manipulação de erros {/*error-handling*/}
 
-Melhoramos o manuseio de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização que é capturado por um Limite de Erro, anteriormente o React lançava o erro duas vezes (uma vez para o erro original, depois novamente após falhar em se recuperar automaticamente) e em seguida chamava `console.error` com informações sobre onde o erro ocorreu. 
+Melhoramos a manipulação de erros no React 19 para remover duplicações e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização capturado por um Boundary de Erro, anteriormente o React jogava o erro duas vezes (uma vez pelo erro original, em seguida, novamente após falhar ao recuperar automaticamente), e chamava `console.error` com informações sobre onde o erro ocorreu. 
 
-Isso resultava em três erros para cada erro capturado:
+Isso resultou em três erros para cada erro capturado:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: hit
+Erro não capturado: atingido
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...
@@ -710,7 +713,7 @@ Erro não capturado: hit
 
 <ConsoleLogLine level="error">
 
-Erro não capturado: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
+Erro não capturado: atingido<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...
@@ -723,19 +726,19 @@ O erro acima ocorreu no componente Throws:
 {'  '}em Throws
 {'  '}em ErrorBoundary
 {'  '}em App{'\n'}
-O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
+O React tentará recriar esta árvore de componentes do zero usando o boundary de erro que você forneceu, ErrorBoundary.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-No React 19, registramos um único erro com todas as informações do erro incluídas:
+No React 19, registramos um único erro com todas as informações de erro incluídas:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Erro: hit
+Erro: atingido
 {'  '}em Throws
 {'  '}em renderWithHooks
 {'  '}...{'\n'}
@@ -743,7 +746,7 @@ O erro acima ocorreu no componente Throws:
 {'  '}em Throws
 {'  '}em ErrorBoundary
 {'  '}em App{'\n'}
-O React tentará recriar esta árvore de componentes do zero usando o limite de erro que você forneceu, ErrorBoundary.
+O React tentará recriar esta árvore de componentes do zero usando o boundary de erro que você forneceu, ErrorBoundary.
 {'  '}em ErrorBoundary
 {'  '}em App
 
@@ -753,23 +756,22 @@ O React tentará recriar esta árvore de componentes do zero usando o limite de 
 
 Além disso, adicionamos duas novas opções de raiz para complementar `onRecoverableError`:
 
-- `onCaughtError`: chamado quando o React captura um erro em um Limite de Erro.
-- `onUncaughtError`: chamado quando um erro é lançado e não capturado por um Limite de Erro.
-- `onRecoverableError`: chamado quando um erro é lançado e recuperado automaticamente.
+- `onCaughtError`: chamada quando o React captura um erro em um Boundary de Erro.
+- `onUncaughtError`: chamada quando um erro é lançado e não capturado por um Boundary de Erro.
+- `onRecoverableError`: chamada quando um erro é lançado e automaticamente recuperado.
 
-Para mais informações e exemplos, veja a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
+Para mais informações e exemplos, consulte a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
 
-### Suporte para Elementos Customizados {/*support-for-custom-elements*/}
+### Suporte para Elementos Personalizados {/*support-for-custom-elements*/}
 
-O React 19 adiciona suporte completo para elementos customizados e passa em todos os testes em [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
+O React 19 adiciona suporte total para elementos personalizados e passa todos os testes no [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
 
-Em versões anteriores, usar Elementos Customizados no React tem sido difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte a propriedades que funcionam no cliente e durante SSR com a seguinte estratégia:
+Em versões anteriores, usar Elementos Personalizados no React era difícil porque o React tratava props não reconhecidas como atributos, em vez de propriedades. No React 19, adicionamos suporte para propriedades que funcionam no cliente e durante SSR com a seguinte estratégia:
 
-- **Renderização do Lado do Servidor**: props passadas para um elemento customizado serão renderizadas como atributos se seu tipo for um valor primitivo, como `string`, `number` ou o valor for `true`. Props com tipos não primitivos, como `object`, `symbol`, `function` ou valor `false` serão omitidas.
-- **Renderização do Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Customizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
+- **Renderização do Lado do Servidor**: props passadas para um elemento personalizado serão renderizadas como atributos se seu tipo for um valor primitivo como `string`, `number` ou o valor for `true`. Props com tipos não primitivos como `object`, `symbol`, `function` ou valor `false` serão omitidos.
+- **Renderização do Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Personalizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
 
-Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por liderar o projeto e a implementação do suporte a Elementos Customizados no React.
-
+Agradecimentos a [Joey Arhar](https://github.com/josepharhar) por liderar o design e a implementação do suporte a Elementos Personalizados no React.
 
 #### Como atualizar {/*how-to-upgrade*/}
-Veja o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para instruções passo a passo e uma lista completa de mudanças significativas e notáveis.
+Consulte o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para obter instruções passo a passo e uma lista completa de mudanças notáveis e que quebram a compatibilidade.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.