### PR TITLE
Translate `react-19.md` to pt-br

### DIFF
--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -2,45 +2,45 @@
 title: "React 19 Beta"
 author: The React Team
 date: 2024/04/25
-description: React 19 Beta is now available on npm! In this post, we'll give an overview of the new features in React 19, and how you can adopt them.
+description: React 19 Beta agora está disponível no npm! Neste post, daremos uma visão geral dos novos recursos no React 19 e como você pode adotá-los.
 ---
 
-April 25, 2024 by [The React Team](/community/team)
+25 de abril de 2024 por [The React Team](/community/team)
 
 ---
 
 <Note>
 
-This beta release is for libraries to prepare for React 19. App developers should upgrade to 18.3.0 and wait for React 19 stable as we work with libraries and make changes based on feedback.
+Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar o React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
 <Intro>
 
-React 19 Beta is now available on npm!
+React 19 Beta agora está disponível no npm!
 
 </Intro>
 
-In our [React 19 Beta Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide), we shared step-by-step instructions for upgrading your app to React 19 Beta. In this post, we'll give an overview of the new features in React 19, and how you can adopt them.
+Em nosso [Guia de Atualização para o React 19 Beta](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19 Beta. Neste post, daremos uma visão geral dos novos recursos no React 19 e como você pode adotá-los.
 
-- [What's new in React 19](#whats-new-in-react-19)
-- [Improvements in React 19](#improvements-in-react-19)
-- [How to upgrade](#how-to-upgrade)
+- [Novidades no React 19](#whats-new-in-react-19)
+- [Melhorias no React 19](#improvements-in-react-19)
+- [Como atualizar](#how-to-upgrade)
 
-For a list of breaking changes, see the [Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide).
+Para uma lista de mudanças impactantes, veja o [Guia de Atualização](/blog/2024/04/25/react-19-upgrade-guide).
 
 ---
 
-## What's new in React 19 {/*whats-new-in-react-19*/}
+## Novidades no React 19 {/*whats-new-in-react-19*/}
 
-### Actions {/*actions*/}
+### Ações {/*actions*/}
 
-A common use case in React apps is to perform a data mutation and then update state in response. For example, when a user submits a form to change their name, you will make an API request, and then handle the response. In the past, you would need to handle pending states, errors, optimistic updates, and sequential requests manually.
+Um caso comum nos aplicativos React é realizar uma mutação de dados e, em seguida, atualizar o estado como resposta. Por exemplo, quando um usuário envia um formulário para mudar seu nome, você fará uma solicitação de API e, em seguida, lidará com a resposta. No passado, você precisaria gerenciar estados pendentes, erros, atualizações otimistas e solicitações sequenciais manualmente.
 
-For example, you could handle the pending and error state in `useState`:
+Por exemplo, você poderia lidar com o estado pendente e o estado de erro em `useState`:
 
 ```js
-// Before Actions
+// Antes das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -61,7 +61,7 @@ function UpdateName({}) {
     <div>
       <input value={name} onChange={(event) => setName(event.target.value)} />
       <button onClick={handleSubmit} disabled={isPending}>
-        Update
+        Atualizar
       </button>
       {error && <p>{error}</p>}
     </div>
@@ -69,12 +69,12 @@ function UpdateName({}) {
 }
 ```
 
-In React 19, we're adding support for using async functions in transitions to handle pending states, errors, forms, and optimistic updates automatically.
+No React 19, estamos adicionando suporte para usar funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
 
-For example, you can use `useTransition` to handle the pending state for you:
+Por exemplo, você pode usar `useTransition` para lidar com o estado pendente para você:
 
 ```js
-// Using pending state from Actions
+// Usando estado pendente das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -95,7 +95,7 @@ function UpdateName({}) {
     <div>
       <input value={name} onChange={(event) => setName(event.target.value)} />
       <button onClick={handleSubmit} disabled={isPending}>
-        Update
+        Atualizar
       </button>
       {error && <p>{error}</p>}
     </div>
@@ -103,27 +103,27 @@ function UpdateName({}) {
 }
 ```
 
-The async transition will immediately set the `isPending` state to true, make the async request(s), and switch `isPending` to false after any transitions. This allows you to keep the current UI responsive and interactive while the data is changing.
+A transição assíncrona imediatamente definirá o estado `isPending` como verdadeiro, fará a(s) solicitação(ões) assíncrona(s) e mudará `isPending` para falso após qualquer transição. Isso permite que você mantenha a UI atual responsiva e interativa enquanto os dados estão mudando.
 
 <Note>
 
-#### By convention, functions that use async transitions are called "Actions". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
+#### Por convenção, funções que usam transições assíncronas são chamadas de "Ações". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
 
-Actions automatically manage submitting data for you:
+As Ações gerenciam automaticamente o envio de dados para você:
 
-- **Pending state**: Actions provide a pending state that starts at the beginning of a request and automatically resets when the final state update is committed.
-- **Optimistic updates**: Actions support the new [`useOptimistic`](#new-hook-optimistic-updates) hook so you can show users instant feedback while the requests are submitting.
-- **Error handling**: Actions provide error handling so you can display Error Boundaries when a request fails, and revert optimistic updates to their original value automatically.
-- **Forms**: `<form>` elements now support passing functions to the `action` and `formAction` props. Passing functions to the `action` props use Actions by default and reset the form automatically after submission.
+- **Estado pendente**: As Ações fornecem um estado pendente que começa no início de uma solicitação e é automaticamente redefinido quando a atualização do estado final é confirmada.
+- **Atualizações otimistas**: As Ações suportam o novo [`useOptimistic`](#new-hook-optimistic-updates) hook para que você possa mostrar feedback instantâneo aos usuários enquanto as solicitações estão sendo enviadas.
+- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir Boundaries de Erro quando uma solicitação falhar e reverter atualizações otimistas para seus valores originais automaticamente.
+- **Formulários**: Os elementos `<form>` agora suportam passar funções para as propriedades `action` e `formAction`. Passar funções para as propriedades `action` usa Ações por padrão e redefine o formulário automaticamente após a submissão.
 
 </Note>
 
-Building on top of Actions, React 19 introduces [`useOptimistic`](#new-hook-optimistic-updates) to manage optimistic updates, and a new hook [`React.useActionState`](#new-hook-useactionstate) to handle common cases for Actions. In `react-dom` we're adding [`<form>` Actions](#form-actions) to manage forms automatically and [`useFormStatus`](#new-hook-useformstatus) to support the common cases for Actions in forms.
+Construindo sobre as Ações, o React 19 introduz [`useOptimistic`](#new-hook-optimistic-updates) para gerenciar atualizações otimistas, e um novo hook [`React.useActionState`](#new-hook-useactionstate) para lidar com casos comuns de Ações. Em `react-dom`, estamos adicionando [`<form>` Ações](#form-actions) para gerenciar formulários automaticamente e [`useFormStatus`](#new-hook-useformstatus) para suportar os casos comuns de Ações em formulários.
 
-In React 19, the above example can be simplified to:
+No React 19, o exemplo acima pode ser simplificado para:
 
 ```js
-// Using <form> Actions and useActionState
+// Usando <form> Ações e useActionState
 function ChangeName({ name, setName }) {
   const [error, submitAction, isPending] = useActionState(
     async (previousState, formData) => {
@@ -140,63 +140,63 @@ function ChangeName({ name, setName }) {
   return (
     <form action={submitAction}>
       <input type="text" name="name" />
-      <button type="submit" disabled={isPending}>Update</button>
+      <button type="submit" disabled={isPending}>Atualizar</button>
       {error && <p>{error}</p>}
     </form>
   );
 }
 ```
 
-In the next section, we'll break down each of the new Action features in React 19.
+Na próxima seção, vamos detalhar cada um dos novos recursos de Ação no React 19.
 
-### New hook: `useActionState` {/*new-hook-useactionstate*/}
+### Novo hook: `useActionState` {/*new-hook-useactionstate*/}
 
-To make the common cases easier for Actions, we've added a new hook called `useActionState`:
+Para facilitar os casos comuns de Ações, adicionamos um novo hook chamado `useActionState`:
 
 ```js
 const [error, submitAction, isPending] = useActionState(
   async (previousState, newName) => {
     const error = await updateName(newName);
     if (error) {
-      // You can return any result of the action.
-      // Here, we return only the error.
+      // Você pode retornar qualquer resultado da ação.
+      // Aqui, retornamos apenas o erro.
       return error;
     }
 
-    // handle success
+    // lidar com sucesso
     return null;
   },
   null,
 );
 ```
 
-`useActionState` accepts a function (the "Action"), and returns a wrapped Action to call. This works because Actions compose. When the wrapped Action is called, `useActionState` will return the last result of the Action as `data`, and the pending state of the Action as `pending`. 
+`useActionState` aceita uma função (a "Ação") e retorna uma Ação encapsulada para chamar. Isso funciona porque as Ações se combinam. Quando a Ação encapsulada é chamada, `useActionState` retornará o último resultado da Ação como `data` e o estado pendente da Ação como `pending`. 
 
 <Note>
 
-`React.useActionState` was previously called `ReactDOM.useFormState` in the Canary releases, but we've renamed it and deprecated `useFormState`.
+`React.useActionState` era anteriormente chamado `ReactDOM.useFormState` nas versões Canary, mas o renomeamos e depreciamos `useFormState`.
 
-See [#28491](https://github.com/facebook/react/pull/28491) for more info.
+Veja [#28491](https://github.com/facebook/react/pull/28491) para mais informações.
 
 </Note>
 
-For more information, see the docs for [`useActionState`](/reference/react/useActionState).
+Para mais informações, veja a documentação para [`useActionState`](/reference/react/useActionState).
 
-### React DOM: `<form>` Actions {/*form-actions*/}
+### React DOM: `<form>` Ações {/*form-actions*/}
 
-Actions are also integrated with React 19's new `<form>` features for `react-dom`. We've added support for passing functions as the `action` and `formAction` props of `<form>`, `<input>`, and `<button>` elements to automatically submit forms with Actions:
+As Ações também estão integradas com os novos recursos `<form>` do React 19 para `react-dom`. Adicionamos suporte para passar funções como as propriedades `action` e `formAction` de `<form>`, `<input>`, e `<button>` para enviar formulários automaticamente com Ações:
 
 ```js [[1,1,"actionFunction"]]
 <form action={actionFunction}>
 ```
 
-When a `<form>` Action succeeds, React will automatically reset the form for uncontrolled components. If you need to reset the `<form>` manually, you can call the new `requestFormReset` React DOM API.
+Quando uma Ação `<form>` é bem-sucedida, o React reiniciará automaticamente o formulário para componentes não controlados. Se você precisar reiniciar o `<form>` manualmente, pode chamar a nova API React DOM `requestFormReset`.
 
-For more information, see the `react-dom` docs for [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input), and `<button>`.
+Para mais informações, consulte a documentação do `react-dom` para [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input), e `<button>`.
 
-### React DOM: New hook: `useFormStatus` {/*new-hook-useformstatus*/}
+### React DOM: Novo hook: `useFormStatus` {/*new-hook-useformstatus*/}
 
-In design systems, it's common to write design components that need access to information about the `<form>` they're in, without drilling props down to the component. This can be done via Context, but to make the common case easier, we've added a new hook `useFormStatus`:
+Em sistemas de design, é comum escrever componentes de design que precisam de acesso a informações sobre o `<form>` em que estão, sem passar props para baixo no componente. Isso pode ser feito via Context, mas para tornar o caso comum mais fácil, adicionamos um novo hook `useFormStatus`:
 
 ```js [[1, 4, "pending"], [1, 5, "pending"]]
 import {useFormStatus} from 'react-dom';
@@ -207,13 +207,13 @@ function DesignButton() {
 }
 ```
 
-`useFormStatus` reads the status of the parent `<form>` as if the form was a Context provider.
+`useFormStatus` lê o status do `<form>` pai como se o formulário fosse um provedor de Context.
 
-For more information, see the `react-dom` docs for [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+Para mais informações, veja a documentação do `react-dom` para [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
 
-### New hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
+### Novo hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
 
-Another common UI pattern when performing a data mutation is to show the final state optimistically while the async request is underway. In React 19, we're adding a new hook called `useOptimistic` to make this easier:
+Outro padrão comum de UI ao realizar uma mutação de dados é mostrar o estado final otimista enquanto a solicitação assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado `useOptimistic` para facilitar isso:
 
 ```js {2,6,13,19}
 function ChangeName({currentName, onUpdateName}) {
@@ -228,9 +228,9 @@ function ChangeName({currentName, onUpdateName}) {
 
   return (
     <form action={submitAction}>
-      <p>Your name is: {optimisticName}</p>
+      <p>Seu nome é: {optimisticName}</p>
       <p>
-        <label>Change Name:</label>
+        <label>Mudar Nome:</label>
         <input
           type="text"
           name="name"
@@ -242,30 +242,30 @@ function ChangeName({currentName, onUpdateName}) {
 }
 ```
 
-The `useOptimistic` hook will immediately render the `optimisticName` while the `updateName` request is in progress. When the update finishes or errors, React will automatically switch back to the `currentName` value.
+O hook `useOptimistic` renderizará imediatamente o `optimisticName` enquanto a solicitação `updateName` estiver em andamento. Quando a atualização terminar ou ocorrer um erro, o React mudará automaticamente de volta para o valor `currentName`.
 
-For more information, see the docs for [`useOptimistic`](/reference/react/useOptimistic).
+Para mais informações, veja a documentação para [`useOptimistic`](/reference/react/useOptimistic).
 
-### New API: `use` {/*new-feature-use*/}
+### Nova API: `use` {/*new-feature-use*/}
 
-In React 19 we're introducing a new API to read resources in render: `use`.
+No React 19, estamos introduzindo uma nova API para ler recursos na renderização: `use`.
 
-For example, you can read a promise with `use`, and React will Suspend until the promise resolves:
+Por exemplo, você pode ler uma promessa com `use`, e o React irá Suspender até que a promessa seja resolvida:
 
 ```js {1,5}
 import {use} from 'react';
 
 function Comments({commentsPromise}) {
-  // `use` will suspend until the promise resolves.
+  // `use` suspenderá até que a promessa seja resolvida.
   const comments = use(commentsPromise);
   return comments.map(comment => <p key={comment.id}>{comment}</p>);
 }
 
 function Page({commentsPromise}) {
-  // When `use` suspends in Comments,
-  // this Suspense boundary will be shown.
+  // Quando `use` suspender em Comments,
+  // essa boundary de Suspense será exibida.
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<div>Carregando...</div>}>
       <Comments commentsPromise={commentsPromise} />
     </Suspense>
   )
@@ -274,25 +274,25 @@ function Page({commentsPromise}) {
 
 <Note>
 
-#### `use` does not support promises created in render. {/*use-does-not-support-promises-created-in-render*/}
+#### `use` não suporta promessas criadas na renderização. {/*use-does-not-support-promises-created-in-render*/}
 
-If you try to pass a promise created in render to `use`, React will warn:
+Se você tentar passar uma promessa criada na renderização para `use`, o React irá avisar:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.
+Um componente foi suspenso por uma promessa não cacheada. Criar promessas dentro de um Componente Cliente ou hook ainda não é suportado, exceto via uma biblioteca ou framework compatível com Suspense.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-To fix, you need to pass a promise from a suspense powered library or framework that supports caching for promises. In the future we plan to ship features to make it easier to cache promises in render.
+Para corrigir, você precisa passar uma promessa de uma biblioteca ou framework compatível com suspense que suporte cache para promessas. No futuro, planejamos lançar recursos para facilitar o cache de promessas na renderização.
 
 </Note>
 
-You can also read context with `use`, allowing you to read Context conditionally such as after early returns:
+Você também pode ler o contexto com `use`, permitindo que você leia o Context condicionalmente, como após retornos antecipados:
 
 ```js {1,11}
 import {use} from 'react';
@@ -303,8 +303,8 @@ function Heading({children}) {
     return null;
   }
   
-  // This would not work with useContext
-  // because of the early return.
+  // Isso não funcionaria com useContext
+  // por causa do retorno antecipado.
   const theme = use(ThemeContext);
   return (
     <h1 style={{color: theme.color}}>
@@ -314,58 +314,57 @@ function Heading({children}) {
 }
 ```
 
-The `use` API can only be called in render, similar to hooks. Unlike hooks, `use` can be called conditionally. In the future we plan to support more ways to consume resources in render with `use`.
+A API `use` só pode ser chamada na renderização, semelhante aos hooks. Diferente dos hooks, `use` pode ser chamado condicionalmente. No futuro, planejamos suportar mais maneiras de consumir recursos na renderização com `use`.
 
-For more information, see the docs for [`use`](/reference/react/use).
+Para mais informações, veja a documentação para [`use`](/reference/react/use).
 
 
-## React Server Components {/*react-server-components*/}
+## Componentes do Servidor React {/*react-server-components*/}
 
-### Server Components {/*server-components*/}
+### Componentes do Servidor {/*server-components*/}
 
-Server Components are a new option that allows rendering components ahead of time, before bundling, in an environment separate from your client application or SSR server. This separate environment is the "server" in React Server Components. Server Components can run once at build time on your CI server, or they can be run for each request using a web server.
+Componentes do Servidor são uma nova opção que permite renderizar componentes com antecedência, antes da criação do pacote, em um ambiente separado do seu aplicativo cliente ou servidor SSR. Este ambiente separado é o "servidor" nos Componentes do Servidor React. Os Componentes do Servidor podem ser executados uma vez no momento da construção em seu servidor CI, ou podem ser executados para cada solicitação usando um servidor web.
 
-React 19 includes all of the React Server Components features included from the Canary channel. This means libraries that ship with Server Components can now target React 19 as a peer dependency with a `react-server` [export condition](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) for use in frameworks that support the [Full-stack React Architecture](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
+O React 19 inclui todos os recursos dos Componentes do Servidor React incluídos do canal Canary. Isso significa que bibliotecas que enviam Componentes do Servidor agora podem direcionar o React 19 como uma dependência compatível com uma condição de exportação `react-server` [para uso em frameworks que suportam a [Arquitetura Full-stack React](/learn/start-a-new-react-project#which-features-make-up-the-react-teams-full-stack-architecture-vision). 
 
 
 <Note>
 
-#### How do I build support for Server Components? {/*how-do-i-build-support-for-server-components*/}
+#### Como posso construir suporte para Componentes do Servidor? {/*how-do-i-build-support-for-server-components*/}
 
-While React Server Components in React 19 are stable and will not break between major versions, the underlying APIs used to implement a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x. 
+Embora os Componentes do Servidor no React 19 sejam estáveis e não quebrarão entre versões principais, as APIs subjacentes usadas para implementar um empacotador ou framework de Componentes do Servidor React não seguem semver e podem quebrar entre versões menores no React 19.x. 
 
-To support React Server Components as a bundler or framework, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize the APIs used to implement React Server Components in the future.
+Para suportar Componentes do Servidor React como um empacotador ou framework, recomendamos fixar uma versão específica do React, ou usar a versão Canary. Continuaremos trabalhando com empacotadores e frameworks para estabilizar as APIs usadas para implementar Componentes do Servidor React no futuro.
 
 </Note>
 
+Para mais detalhes, veja a documentação para [Componentes do Servidor React](/reference/rsc/server-components).
 
-For more, see the docs for [React Server Components](/reference/rsc/server-components).
+### Ações do Servidor {/*server-actions*/}
 
-### Server Actions {/*server-actions*/}
+Ações do Servidor permitem que Componentes Cliente chamem funções assíncronas executadas no servidor.
 
-Server Actions allow Client Components to call async functions executed on the server.
-
-When a Server Action is defined with the `"use server"` directive, your framework will automatically create a reference to the server function, and pass that reference to the Client Component. When that function is called on the client, React will send a request to the server to execute the function, and return the result.
+Quando uma Ação do Servidor é definida com a diretiva `"use server"`, seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Componente Cliente. Quando essa função for chamada no cliente, o React enviará uma solicitação ao servidor para executar a função e retornará o resultado.
 
 <Note>
 
-#### There is no directive for Server Components. {/*there-is-no-directive-for-server-components*/}
+#### Não há diretiva para Componentes do Servidor. {/*there-is-no-directive-for-server-components*/}
 
-A common misunderstanding is that Server Components are denoted by `"use server"`, but there is no directive for Server Components. The `"use server"` directive is used for Server Actions.
+Um mal-entendido comum é que os Componentes do Servidor são denotados por `"use server"`, mas não há diretiva para Componentes do Servidor. A diretiva `"use server"` é usada para Ações do Servidor.
 
-For more info, see the docs for [Directives](/reference/rsc/directives).
+Para mais informações, veja a documentação para [Diretivas](/reference/rsc/directives).
 
 </Note>
 
-Server Actions can be created in Server Components and passed as props to Client Components, or they can be imported and used in Client Components.
+As Ações do Servidor podem ser criadas em Componentes do Servidor e passadas como props para Componentes Cliente, ou podem ser importadas e usadas em Componentes Cliente.
 
-For more, see the docs for [React Server Actions](/reference/rsc/server-actions).
+Para mais detalhes, veja a documentação para [Ações do Servidor React](/reference/rsc/server-actions).
 
-## Improvements in React 19 {/*improvements-in-react-19*/}
+## Melhorias no React 19 {/*improvements-in-react-19*/}
 
-### `ref` as a prop {/*ref-as-a-prop*/}
+### `ref` como uma prop {/*ref-as-a-prop*/}
 
-Starting in React 19, you can now access `ref` as a prop for function components:
+A partir do React 19, você pode acessar `ref` como uma prop para componentes de função:
 
 ```js [[1, 1, "ref"], [1, 2, "ref", 45], [1, 6, "ref", 14]]
 function MyInput({placeholder, ref}) {
@@ -376,87 +375,86 @@ function MyInput({placeholder, ref}) {
 <MyInput ref={ref} />
 ```
 
-New function components will no longer need `forwardRef`, and we will be publishing a codemod to automatically update your components to use the new `ref` prop. In future versions we will deprecate and remove `forwardRef`.
+Novos componentes de função não precisarão mais de `forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova prop `ref`. Em versões futuras, vamos depreciar e remover `forwardRef`.
 
 <Note>
 
-`refs` passed to classes are not passed as props since they reference the component instance.
+`refs` passadas para classes não são passadas como props, pois referenciam a instância do componente.
 
 </Note>
 
-### Diffs for hydration errors {/*diffs-for-hydration-errors*/}
+### Diferenças para erros de hidratação {/*diffs-for-hydration-errors*/}
 
-We also improved error reporting for hydration errors in `react-dom`. For example, instead of logging multiple errors in DEV without any information about the mismatch:
+Também melhoramos o relatório de erros para erros de hidratação em `react-dom`. Por exemplo, em vez de registrar múltiplos erros em DEV sem qualquer informação sobre a discrepância:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Warning: Text content did not match. Server: "Server" Client: "Client"
-{'  '}at span
-{'  '}at App
+Aviso: O conteúdo de texto não correspondia. Servidor: "Servidor" Cliente: "Cliente"
+{'  '}em span
+{'  '}em App
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Warning: An error occurred during hydration. The server HTML was replaced with client content in \<div\>.
+Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Warning: Text content did not match. Server: "Server" Client: "Client"
-{'  '}at span
-{'  '}at App
+Aviso: O conteúdo de texto não correspondia. Servidor: "Servidor" Cliente: "Cliente"
+{'  '}em span
+{'  '}em App
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Warning: An error occurred during hydration. The server HTML was replaced with client content in \<div\>.
+Aviso: Ocorreu um erro durante a hidratação. O HTML do servidor foi substituído pelo conteúdo do cliente em \<div\>.
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: Text content does not match server-rendered HTML.
-{'  '}at checkForUnmatchedText
+Erro não capturado: O conteúdo de texto não corresponde ao HTML renderizado pelo servidor.
+{'  '}em checkForUnmatchedText
 {'  '}...
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-We now log a single message with a diff of the mismatch:
-
+Agora registramos uma única mensagem com uma diferença da discrepância:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if an SSR-ed Client Component used:{'\n'}
-\- A server/client branch `if (typeof window !== 'undefined')`.
-\- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
-\- Date formatting in a user's locale which doesn't match the server.
-\- External changing data without sending a snapshot of it along with the HTML.
-\- Invalid HTML tag nesting.{'\n'}
-It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.{'\n'}
+Erro: A hidratação falhou porque o HTML renderizado pelo servidor não correspondeu ao cliente. Como resultado, esta árvore será regenerada no cliente. Isso pode acontecer se um Componente Cliente SSR-ed usou:{'\n'}
+\- Uma ramificação de servidor/cliente `if (typeof window !== 'undefined')`.
+\- Entrada variável como `Date.now()` ou `Math.random()` que muda a cada vez que é chamada.
+\- Formatação de data na localidade de um usuário que não corresponde ao servidor.
+\- Dados externos que mudam sem enviar um instantâneo deles junto com o HTML.
+\- Aninhamento de tags HTML inválido.{'\n'}
+Isso também pode acontecer se o cliente tiver uma extensão de navegador instalada que bagunça o HTML antes do React carregar.{'\n'}
 https://react.dev/link/hydration-mismatch {'\n'}
 {'  '}\<App\>
 {'    '}\<span\>
-{'+    '}Client
-{'-    '}Server{'\n'}
-{'  '}at throwOnHydrationMismatch
+{'+    '}Cliente
+{'-    '}Servidor{'\n'}
+{'  '}em throwOnHydrationMismatch
 {'  '}...
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### `<Context>` as a provider {/*context-as-a-provider*/}
+### `<Context>` como um provedor {/*context-as-a-provider*/}
 
-In React 19, you can render `<Context>` as a provider instead of `<Context.Provider>`:
+No React 19, você pode renderizar `<Context>` como um provedor em vez de `<Context.Provider>`:
 
 
 ```js {5,7}
@@ -471,56 +469,55 @@ function App({children}) {
 }
 ```
 
-New Context providers can use `<Context>` and we will be publishing a codemod to convert existing providers. In future versions we will deprecate `<Context.Provider>`.
+Novos provedores de Contexto podem usar `<Context>` e publicaremos um codemod para converter provedores existentes. Em versões futuras, vamos depreciar `<Context.Provider>`.
 
-### Cleanup functions for refs {/*cleanup-functions-for-refs*/}
+### Funções de cleanup para refs {/*cleanup-functions-for-refs*/}
 
-We now support returning a cleanup function from `ref` callbacks:
+Agora suportamos retornar uma função de cleanup das callbacks de `ref`:
 
 ```js {7-9}
 <input
   ref={(ref) => {
-    // ref created
+    // ref criada
 
-    // NEW: return a cleanup function to reset
-    // the ref when element is removed from DOM.
+    // NOVO: retornar uma função de cleanup para redefinir
+    // a ref quando o elemento for removido do DOM.
     return () => {
-      // ref cleanup
+      // cleanup da ref
     };
   }}
 />
 ```
 
-When the component unmounts, React will call the cleanup function returned from the `ref` callback. This works for DOM refs, refs to class components, and `useImperativeHandle`. 
+Quando o componente for desmontado, o React chamará a função de cleanup retornada da callback da `ref`. Isso funciona para refs DOM, refs para componentes de classe e `useImperativeHandle`. 
 
 <Note>
 
-Previously, React would call `ref` functions with `null` when unmounting the component. If your `ref` returns a cleanup function, React will now skip this step.
+Anteriormente, o React chamaria funções de `ref` com `null` ao desmontar o componente. Se sua `ref` retornar uma função de cleanup, o React agora pulará esta etapa.
 
-In future versions, we will deprecate calling refs with `null` when unmounting components.
+Em versões futuras, vamos depreciar a chamada de refs com `null` ao desmontar componentes.
 
 </Note>
 
-Due to the introduction of ref cleanup functions, returning anything else from a `ref` callback will now be rejected by TypeScript. The fix is usually to stop using implicit returns, for example:
+Devido à introdução das funções de cleanup de `ref`, retornar qualquer outra coisa de uma callback de `ref` agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos, por exemplo:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-The original code returned the instance of the `HTMLDivElement` and TypeScript wouldn't know if this was _supposed_ to be a cleanup function or if you didn't want to return a cleanup function.
+O código original retornava a instância do `HTMLDivElement` e o TypeScript não saberia se isso era _suposto_ ser uma função de cleanup ou se você não queria retornar uma função de cleanup.
 
-You can codemod this pattern with [`no-implicit-ref-callback-return
-`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
+Você pode codemodar esse padrão com [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
 
-### `useDeferredValue` initial value {/*use-deferred-value-initial-value*/}
+### `useDeferredValue` valor inicial {/*use-deferred-value-initial-value*/}
 
-We've added an `initialValue` option to `useDeferredValue`:
+Adicionamos uma opção `initialValue` a `useDeferredValue`:
 
 ```js [[1, 1, "deferredValue"], [1, 4, "deferredValue"], [2, 4, "''"]]
 function Search({deferredValue}) {
-  // On initial render the value is ''.
-  // Then a re-render is scheduled with the deferredValue.
+  // Na renderização inicial o valor é ''.
+  // Em seguida, uma re-renderização é agendada com o deferredValue.
   const value = useDeferredValue(deferredValue, '');
   
   return (
@@ -529,15 +526,15 @@ function Search({deferredValue}) {
 }
 ````
 
-When <CodeStep step={2}>initialValue</CodeStep> is provided, `useDeferredValue` will return it as `value` for the initial render of the component, and schedules a re-render in the background with the <CodeStep step={1}>deferredValue</CodeStep> returned.
+Quando <CodeStep step={2}>initialValue</CodeStep> é fornecido, `useDeferredValue` o retornará como `value` para a renderização inicial do componente, e agenda uma re-renderização em segundo plano com o <CodeStep step={1}>deferredValue</CodeStep> retornado.
 
-For more, see [`useDeferredValue`](/reference/react/useDeferredValue).
+Para mais informações, veja [`useDeferredValue`](/reference/react/useDeferredValue).
 
-### Support for Document Metadata {/*support-for-metadata-tags*/}
+### Suporte para Metadados do Documento {/*support-for-metadata-tags*/}
 
-In HTML, document metadata tags like `<title>`, `<link>`, and `<meta>` are reserved for placement in the `<head>` section of the document. In React, the component that decides what metadata is appropriate for the app may be very far from the place where you render the `<head>` or React does not render the `<head>` at all. In the past, these elements would need to be inserted manually in an effect, or by libraries like [`react-helmet`](https://github.com/nfl/react-helmet), and required careful handling when server rendering a React application. 
+Em HTML, tags de metadados do documento como `<title>`, `<link>` e `<meta>` são reservadas para colocação na seção `<head>` do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito longe do local onde você renderiza o `<head>` ou o React não renderiza o `<head>` de forma alguma. No passado, esses elementos precisavam ser inseridos manualmente em um efeito, ou por bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor. 
 
-In React 19, we're adding support for rendering document metadata tags in components natively:
+No React 19, estamos adicionando suporte para renderizar tags de metadados do documento em componentes nativamente:
 
 ```js {5-8}
 function BlogPost({post}) {
@@ -556,28 +553,28 @@ function BlogPost({post}) {
 }
 ```
 
-When React renders this component, it will see the `<title>` `<link>` and `<meta>` tags, and automatically hoist them to the `<head>` section of document. By supporting these metadata tags natively, we're able to ensure they work with client-only apps, streaming SSR, and Server Components.
+Quando o React renderiza este componente, ele verá as tags `<title>`, `<link>` e `<meta>`, e automaticamente as elevará para a seção `<head>` do documento. Ao suportar essas tags de metadados nativamente, conseguimos garantir que elas funcionem com aplicativos somente para cliente, SSR por streaming e Componentes do Servidor.
 
 <Note>
 
-#### You may still want a Metadata library {/*you-may-still-want-a-metadata-library*/}
+#### Você ainda pode querer uma biblioteca de Metadados {/*you-may-still-want-a-metadata-library*/}
 
-For simple use cases, rendering Document Metadata as tags may be suitable, but libraries can offer more powerful features like overriding generic metadata with specific metadata based on the current route. These features make it easier for frameworks and libraries like [`react-helmet`](https://github.com/nfl/react-helmet) to support metadata tags, rather than replace them.
+Para casos de uso simples, renderizar Metadados do Documento como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como substituir metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam o trabalho para frameworks e bibliotecas como [`react-helmet`](https://github.com/nfl/react-helmet) suportarem tags de metadados, em vez de substituí-las.
 
 </Note>
 
-For more info, see the docs for [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link), and [`<meta>`](/reference/react-dom/components/meta).
+Para mais informações, veja a documentação para [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link), e [`<meta>`](/reference/react-dom/components/meta).
 
-### Support for stylesheets {/*support-for-stylesheets*/}
+### Suporte para folhas de estilo {/*support-for-stylesheets*/}
 
-Stylesheets, both externally linked (`<link rel="stylesheet" href="...">`) and inline (`<style>...</style>`), require careful positioning in the DOM due to style precedence rules. Building a stylesheet capability that allows for composability within components is hard, so users often end up either loading all of their styles far from the components that may depend on them, or they use a style library which encapsulates this complexity.
+Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto internas (`<style>...</style>`), requerem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permita a composabilidade dentro de componentes é difícil, então os usuários frequentemente acabam carregando todos os seus estilos longe dos componentes que podem depender deles, ou usam uma biblioteca de estilo que encapsula essa complexidade.
 
-In React 19, we're addressing this complexity and providing even deeper integration into Concurrent Rendering on the Client and Streaming Rendering on the Server with built in support for stylesheets. If you tell React the `precedence` of your stylesheet it will manage the insertion order of the stylesheet in the DOM and ensure that the stylesheet (if external) is loaded before revealing content that depends on those style rules.
+No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda na Renderização Concorrente no Cliente e na Renderização por Streaming no Servidor com suporte embutido para folhas de estilo. Se você informar ao React a `precedence` de sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar o conteúdo que depende dessas regras de estilo.
 
 ```js {4,5,17}
 function ComponentOne() {
   return (
-    <Suspense fallback="loading...">
+    <Suspense fallback="carregando...">
       <link rel="stylesheet" href="foo" precedence="default" />
       <link rel="stylesheet" href="bar" precedence="high" />
       <article class="foo-class bar-class">
@@ -591,44 +588,44 @@ function ComponentTwo() {
   return (
     <div>
       <p>{...}</p>
-      <link rel="stylesheet" href="baz" precedence="default" />  <-- will be inserted between foo & bar
+      <link rel="stylesheet" href="baz" precedence="default" />  <-- será inserido entre foo & bar
     </div>
   )
 }
 ```
 
-During Server Side Rendering React will include the stylesheet in the `<head>`, which ensures that the browser will not paint until it has loaded. If the stylesheet is discovered late after we've already started streaming, React will ensure that the stylesheet is inserted into the `<head>` on the client before revealing the content of a Suspense boundary that depends on that stylesheet.
+Durante a Renderização no Lado do Servidor, o React incluirá a folha de estilo no `<head>`, o que garante que o navegador não pinte até que tenha sido carregada. Se a folha de estilo for descoberta tarde, após já termos começado o streaming, o React garantirá que a folha de estilo seja inserida no `<head>` no cliente antes de revelar o conteúdo de uma boundary de Suspense que depende dessa folha de estilo.
 
-During Client Side Rendering React will wait for newly rendered stylesheets to load before committing the render. If you render this component from multiple places within your application React will only include the stylesheet once in the document:
+Durante a Renderização no Lado do Cliente, o React aguardará que folhas de estilo recém-renderizadas sejam carregadas antes de confirmar a renderização. Se você renderizar este componente de múltiplos locais dentro de seu aplicativo, o React incluirá a folha de estilo uma única vez no documento:
 
 ```js {5}
 function App() {
   return <>
     <ComponentOne />
     ...
-    <ComponentOne /> // won't lead to a duplicate stylesheet link in the DOM
+    <ComponentOne /> // não levará a uma duplicata de <link> de folha de estilo no DOM
   </>
 }
 ```
 
-For users accustomed to loading stylesheets manually this is an opportunity to locate those stylesheets alongside the components that depend on them allowing for better local reasoning and an easier time ensuring you only load the stylesheets that you actually depend on.
+Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade para localizar essas folhas de estilo ao lado dos componentes dos quais dependem, permitindo uma melhor lógica local e facilitando garantir que você carregue apenas as folhas de estilo que realmente depende.
 
-Style libraries and style integrations with bundlers can also adopt this new capability so even if you don't directly render your own stylesheets, you can still benefit as your tools are upgraded to use this feature.
+Bibliotecas de estilo e integrações de estilo com empacotadores também podem adotar essa nova capacidade, então mesmo que você não renderize diretamente suas próprias folhas de estilo, ainda poderá se beneficiar conforme suas ferramentas forem atualizadas para usar esse recurso.
 
-For more details, read the docs for [`<link>`](/reference/react-dom/components/link) and [`<style>`](/reference/react-dom/components/style).
+Para mais detalhes, leia a documentação para [`<link>`](/reference/react-dom/components/link) e [`<style>`](/reference/react-dom/components/style).
 
-### Support for async scripts {/*support-for-async-scripts*/}
+### Suporte para scripts assíncronos {/*support-for-async-scripts*/}
 
-In HTML normal scripts (`<script src="...">`) and deferred scripts (`<script defer="" src="...">`) load in document order which makes rendering these kinds of scripts deep within your component tree challenging. Async scripts (`<script async="" src="...">`) however will load in arbitrary order.
+Em HTML, scripts normais (`<script src="...">`) e scripts deferred (`<script defer="" src="...">`) carregam em ordem de documento, o que torna a renderização desses tipos de scripts profundamente dentro de sua árvore de componentes desafiadora. Scripts assíncronos (`<script async="" src="...">`), no entanto, carregarão em ordem arbitrária.
 
-In React 19 we've included better support for async scripts by allowing you to render them anywhere in your component tree, inside the components that actually depend on the script, without having to manage relocating and deduplicating script instances.
+No React 19, incluímos melhor suporte para scripts assíncronos, permitindo que você os renderize em qualquer lugar de sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem precisar gerenciar o realocamento e a deduplicação das instâncias de scripts.
 
 ```js {4,15}
 function MyComponent() {
   return (
     <div>
       <script async={true} src="..." />
-      Hello World
+      Olá Mundo
     </div>
   )
 }
@@ -638,39 +635,39 @@ function App() {
     <body>
       <MyComponent>
       ...
-      <MyComponent> // won't lead to duplicate script in the DOM
+      <MyComponent> // não levará a um script duplicado no DOM
     </body>
   </html>
 }
 ```
 
-In all rendering environments, async scripts will be deduplicated so that React will only load and execute the script once even if it is rendered by multiple different components.
+Em todos os ambientes de renderização, scripts assíncronos serão deduplicados para que o React carregue e execute o script apenas uma vez, mesmo que seja renderizado por múltiplos componentes diferentes.
 
-In Server Side Rendering, async scripts will be included in the `<head>` and prioritized behind more critical resources that block paint such as stylesheets, fonts, and image preloads.
+Na Renderização no Lado do Servidor, scripts assíncronos serão incluídos no `<head>` e priorizados atrás de recursos mais críticos que bloqueiam a pintura, como folhas de estilo, fontes e pré-carregamentos de imagens.
 
-For more details, read the docs for [`<script>`](/reference/react-dom/components/script).
+Para mais detalhes, leia a documentação para [`<script>`](/reference/react-dom/components/script).
 
-### Support for preloading resources {/*support-for-preloading-resources*/}
+### Suporte para pré-carregamento de recursos {/*support-for-preloading-resources*/}
 
-During initial document load and on client side updates, telling the Browser about resources that it will likely need to load as early as possible can have a dramatic effect on page performance.
+Durante o carregamento inicial do documento e nas atualizações do lado do cliente, informar ao navegador sobre recursos que ele provavelmente precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
 
-React 19 includes a number of new APIs for loading and preloading Browser resources to make it as easy as possible to build great experiences that aren't held back by inefficient resource loading.
+O React 19 inclui uma série de novas APIs para carregar e pré-carregar recursos do navegador para facilitar a construção de excelentes experiências que não ficam presas a carregamentos ineficientes de recursos.
 
 ```js
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 function MyComponent() {
-  preinit('https://.../path/to/some/script.js', {as: 'script' }) // loads and executes this script eagerly
-  preload('https://.../path/to/font.woff', { as: 'font' }) // preloads this font
-  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // preloads this stylesheet
-  prefetchDNS('https://...') // when you may not actually request anything from this host
-  preconnect('https://...') // when you will request something but aren't sure what
+  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script ansiosamente
+  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega esta fonte
+  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega esta folha de estilo
+  prefetchDNS('https://...') // quando você pode não solicitar nada deste host
+  preconnect('https://...') // quando você solicitar algo, mas não tiver certeza do que
 }
 ```
 ```html
-<!-- the above would result in the following DOM/HTML -->
+<!-- o acima resultaria no seguinte DOM/HTML -->
 <html>
   <head>
-    <!-- links/scripts are prioritized by their utility to early loading, not call order -->
+    <!-- links/scripts são priorizados por sua utilidade para o carregamento inicial, não pela ordem de chamada -->
     <link rel="prefetch-dns" href="https://...">
     <link rel="preconnect" href="https://...">
     <link rel="preload" as="font" href="https://.../path/to/font.woff">
@@ -683,100 +680,97 @@ function MyComponent() {
 </html>
 ```
 
-These APIs can be used to optimize initial page loads by moving discovery of additional resources like fonts out of stylesheet loading. They can also make client updates faster by prefetching a list of resources used by an anticipated navigation and then eagerly preloading those resources on click or even on hover.
+Essas APIs podem ser usadas para otimizar os carregamentos da página inicial, movendo a descoberta de recursos adicionais como fontes para fora do carregamento de folhas de estilo. Elas também podem acelerar as atualizações do cliente ao pré-carregar uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregando ansiosamente esses recursos no clique ou até mesmo no hover.
 
-For more details see [Resource Preloading APIs](/reference/react-dom#resource-preloading-apis).
+Para mais detalhes, veja as [APIs de Pré-carregamento de Recursos](/reference/react-dom#resource-preloading-apis).
 
-### Compatibility with third-party scripts and extensions {/*compatibility-with-third-party-scripts-and-extensions*/}
+### Compatibilidade com scripts e extensões de terceiros {/*compatibility-with-third-party-scripts-and-extensions*/}
 
-We've improved hydration to account for third-party scripts and browser extensions.
+Melhoramos a hidratação para contabilizar scripts de terceiros e extensões de navegador.
 
-When hydrating, if an element that renders on the client doesn't match the element found in the HTML from the server, React will force a client re-render to fix up the content. Previously, if an element was inserted by third-party scripts or browser extensions, it would trigger a mismatch error and client render.
+Ao hidratar, se um elemento que renderiza no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização no cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões de navegador, isso acionaria um erro de discrepância e renderização no cliente.
 
-In React 19, unexpected tags in the `<head>` and `<body>` will be skipped over, avoiding the mismatch errors. If React needs to re-render the entire document due to an unrelated hydration mismatch, it will leave in place stylesheets inserted by third-party scripts and browser extensions.
+No React 19, tags inesperadas no `<head>` e `<body>` serão ignoradas, evitando erros de discrepância. Se o React precisar re-renderizar todo o documento devido a uma discrepância de hidratação não relacionada, ele deixará em seu lugar as folhas de estilo inseridas por scripts de terceiros e extensões de navegador.
 
-### Better error reporting {/*error-handling*/}
+### Melhor relatório de erros {/*error-handling*/}
 
-We improved error handling in React 19 to remove duplication and provide options for handling caught and uncaught errors. For example, when there's an error in render caught by an Error Boundary, previously React would throw the error twice (once for the original error, then again after failing to automatically recover), and then call `console.error` with info about where the error occurred. 
+Melhoramos o tratamento de erros no React 19 para remover duplicação e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização capturado por um Boundary de Erro, anteriormente o React lançaria o erro duas vezes (uma vez para o erro original, e novamente após falhar em se recuperar automaticamente), e então chamaria `console.error` com informações sobre onde o erro ocorreu. 
 
-This resulted in three errors for every caught error:
+Isso resultou em três erros para cada erro capturado:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: hit
-{'  '}at Throws
-{'  '}at renderWithHooks
+Erro não capturado: atingido
+{'  '}em Throws
+{'  '}em renderWithHooks
 {'  '}...
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicate</span>
-{'  '}at Throws
-{'  '}at renderWithHooks
+Erro não capturado: atingido<span className="ms-2 text-gray-30">{'    <--'} Duplicado</span>
+{'  '}em Throws
+{'  '}em renderWithHooks
 {'  '}...
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-The above error occurred in the Throws component:
-{'  '}at Throws
-{'  '}at ErrorBoundary
-{'  '}at App{'\n'}
-React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary.
+O erro acima ocorreu no componente Throws:
+{'  '}em Throws
+{'  '}em ErrorBoundary
+{'  '}em App{'\n'}
+O React tentará recriar esta árvore de componentes do zero usando o boundary de erro que você forneceu, ErrorBoundary.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-In React 19, we log a single error with all the error information included:
+No React 19, registramos um único erro com todas as informações de erro incluídas:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Error: hit
-{'  '}at Throws
-{'  '}at renderWithHooks
+Erro: atingido
+{'  '}em Throws
+{'  '}em renderWithHooks
 {'  '}...{'\n'}
-The above error occurred in the Throws component:
-{'  '}at Throws
-{'  '}at ErrorBoundary
-{'  '}at App{'\n'}
-React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary.
-{'  '}at ErrorBoundary
-{'  '}at App
+O erro acima ocorreu no componente Throws:
+{'  '}em Throws
+{'  '}em ErrorBoundary
+{'  '}em App{'\n'}
+O React tentará recriar esta árvore de componentes do zero usando o boundary de erro que você forneceu, ErrorBoundary.
+{'  '}em ErrorBoundary
+{'  '}em App
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Additionally, we've added two new root options to complement `onRecoverableError`:
+Além disso, adicionamos duas novas opções de raiz para complementar `onRecoverableError`:
 
-- `onCaughtError`: called when React catches an error in an Error Boundary.
-- `onUncaughtError`: called when an error is thrown and not caught by an Error Boundary.
-- `onRecoverableError`: called when an error is thrown and automatically recovered.
+- `onCaughtError`: chamada quando o React captura um erro em um Boundary de Erro.
+- `onUncaughtError`: chamada quando um erro é lançado e não capturado por um Boundary de Erro.
+- `onRecoverableError`: chamada quando um erro é lançado e recuperado automaticamente.
 
-For more info and examples, see the docs for [`createRoot`](/reference/react-dom/client/createRoot) and [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
+Para mais informações e exemplos, veja a documentação para [`createRoot`](/reference/react-dom/client/createRoot) e [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
 
-### Support for Custom Elements {/*support-for-custom-elements*/}
+### Suporte para Elementos Personalizados {/*support-for-custom-elements*/}
 
-React 19 adds full support for custom elements and passes all tests on [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
+O React 19 adiciona suporte total para elementos personalizados e passa em todos os testes em [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
 
-In past versions, using Custom Elements in React has been difficult because React treated unrecognized props as attributes rather than properties. In React 19, we've added support for properties that works on the client and during SSR with the following strategy:
+Em versões passadas, usar Elementos Personalizados no React tem sido difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte para propriedades que funciona no cliente e durante a SSR com a seguinte estratégia:
 
-- **Server Side Rendering**: props passed to a custom element will render as attributes if their type is a primitive value like `string`, `number`, or the value is `true`. Props with non-primitive types like `object`, `symbol`, `function`, or value `false` will be omitted.
-- **Client Side Rendering**: props that match a property on the Custom Element instance will be assigned as properties, otherwise they will be assigned as attributes.
+- **Renderização no Lado do Servidor**: props passadas para um elemento personalizado renderizarão como atributos se seu tipo for um valor primitivo como `string`, `number`, ou se o valor for `true`. Props com tipos não primitivos como `object`, `symbol`, `function`, ou valor `false` serão omitidas.
+- **Renderização no Lado do Cliente**: props que correspondem a uma propriedade na instância do Elemento Personalizado serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
 
-Thanks to [Joey Arhar](https://github.com/josepharhar) for driving the design and implementation of Custom Element support in React.
-
-
-#### How to upgrade {/*how-to-upgrade*/}
-See the [React 19 Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide) for step-by-step instructions and a full list of breaking and notable changes.
+Agradecemos a [Joey Arhar](https://github.com/josepharhar) por liderar o design e a implementação do suporte a Elementos Personalizados no React.
 
 
-
+#### Como atualizar {/*how-to-upgrade*/}
+Veja o [Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide) para instruções passo a passo e uma lista completa de mudanças impactantes e notáveis.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.