### PR TITLE
Translate `prefetchDNS.md` to pt-br

### DIFF
--- a/src/content/reference/react-dom/prefetchDNS.md
+++ b/src/content/reference/react-dom/prefetchDNS.md
@@ -5,13 +5,13 @@ canary: true
 
 <Canary>
 
-The `prefetchDNS` function is currently only available in React's Canary and experimental channels. Learn more about [React's release channels here](/community/versioning-policy#all-release-channels).
+A função `prefetchDNS` está atualmente disponível apenas nos canais Canary e experimentais do React. Saiba mais sobre [os canais de lançamento do React aqui](/community/versioning-policy#all-release-channels).
 
 </Canary>
 
 <Intro>
 
-`prefetchDNS` lets you eagerly look up the IP of a server that you expect to load resources from.
+`prefetchDNS` permite que você busque de forma antecipada o IP de um servidor do qual você espera carregar recursos.
 
 ```js
 prefetchDNS("https://example.com");
@@ -23,11 +23,11 @@ prefetchDNS("https://example.com");
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `prefetchDNS(href)` {/*prefetchdns*/}
 
-To look up a host, call the `prefetchDNS` function from `react-dom`.
+Para buscar um host, chame a função `prefetchDNS` do `react-dom`.
 
 ```js
 import { prefetchDNS } from 'react-dom';
@@ -39,34 +39,34 @@ function AppRoot() {
 
 ```
 
-[See more examples below.](#usage)
+[Veja mais exemplos abaixo.](#usage)
 
-The prefetchDNS function provides the browser with a hint that it should look up the IP address of a given server. If the browser chooses to do so, this can speed up the loading of resources from that server. 
+A função prefetchDNS fornece ao navegador uma dica de que ele deve buscar o endereço IP de um servidor específico. Se o navegador optar por fazê-lo, isso pode acelerar o carregamento de recursos desse servidor. 
 
-#### Parameters {/*parameters*/}
+#### Parâmetros {/*parameters*/}
 
-* `href`: a string. The URL of the server you want to connect to.
+* `href`: uma string. A URL do servidor ao qual você deseja se conectar.
 
-#### Returns {/*returns*/}
+#### Retornos {/*returns*/}
 
-`prefetchDNS` returns nothing.
+`prefetchDNS` não retorna nada.
 
-#### Caveats {/*caveats*/}
+#### Ressalvas {/*caveats*/}
 
-* Multiple calls to `prefetchDNS` with the same server have the same effect as a single call.
-* In the browser, you can call `prefetchDNS` in any situation: while rendering a component, in an Effect, in an event handler, and so on.
-* In server-side rendering or when rendering Server Components, `prefetchDNS` only has an effect if you call it while rendering a component or in an async context originating from rendering a component. Any other calls will be ignored.
-* If you know the specific resources you'll need, you can call [other functions](/reference/react-dom/#resource-preloading-apis) instead that will start loading the resources right away.
-* There is no benefit to prefetching the same server the webpage itself is hosted from because it's already been looked up by the time the hint would be given.
-* Compared with [`preconnect`](/reference/react-dom/preconnect), `prefetchDNS` may be better if you are speculatively connecting to a large number of domains, in which case the overhead of preconnections might outweigh the benefit.
+* Chamadas múltiplas para `prefetchDNS` com o mesmo servidor têm o mesmo efeito que uma única chamada.
+* No navegador, você pode chamar `prefetchDNS` em qualquer situação: durante a renderização de um componente, em um Effect, em um manipulador de eventos, e assim por diante.
+* Na renderização do lado do servidor ou ao renderizar Componentes do Servidor, `prefetchDNS` tem efeito apenas se você chamá-lo enquanto renderiza um componente ou em um contexto assíncrono originado da renderização de um componente. Quaisquer outras chamadas serão ignoradas.
+* Se você conhece os recursos específicos que precisará, pode chamar [outras funções](/reference/react-dom/#resource-preloading-apis) que começarão a carregar os recursos imediatamente.
+* Não há benefício em buscar antecipadamente o mesmo servidor de onde a página da web está hospedada, pois ele já foi buscado no momento em que a dica seria dada.
+* Comparado com [`preconnect`](/reference/react-dom/preconnect), `prefetchDNS` pode ser melhor se você estiver conectando de forma especulativa a um grande número de domínios, caso em que o overhead das pré-conexões pode superar o benefício.
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Prefetching DNS when rendering {/*prefetching-dns-when-rendering*/}
+### Busca antecipada de DNS ao renderizar {/*prefetching-dns-when-rendering*/}
 
-Call `prefetchDNS` when rendering a component if you know that its children will load external resources from that host.
+Chame `prefetchDNS` ao renderizar um componente se você souber que seus filhos carregarão recursos externos desse host.
 
 ```js
 import { prefetchDNS } from 'react-dom';
@@ -77,9 +77,9 @@ function AppRoot() {
 }
 ```
 
-### Prefetching DNS in an event handler {/*prefetching-dns-in-an-event-handler*/}
+### Busca antecipada de DNS em um manipulador de eventos {/*prefetching-dns-in-an-event-handler*/}
 
-Call `prefetchDNS` in an event handler before transitioning to a page or state where external resources will be needed. This gets the process started earlier than if you call it during the rendering of the new page or state.
+Chame `prefetchDNS` em um manipulador de eventos antes de fazer a transição para uma página ou estado onde recursos externos serão necessários. Isso inicia o processo mais cedo do que se você chamá-lo durante a renderização da nova página ou estado.
 
 ```js
 import { prefetchDNS } from 'react-dom';
@@ -90,7 +90,7 @@ function CallToAction() {
     startWizard();
   }
   return (
-    <button onClick={onClick}>Start Wizard</button>
+    <button onClick={onClick}>Iniciar Assistente</button>
   );
 }
 ```


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.