### PR TITLE
Translate `useDebugValue.md` to pt-br

### DIFF
--- a/src/content/reference/react/useDebugValue.md
+++ b/src/content/reference/react/useDebugValue.md
@@ -4,7 +4,7 @@ title: useDebugValue
 
 <Intro>
 
-`useDebugValue` is a React Hook that lets you add a label to a custom Hook in [React DevTools.](/learn/react-developer-tools)
+`useDebugValue` é um Hook do React que permite adicionar um rótulo a um Hook personalizado no [React DevTools.](/learn/react-developer-tools)
 
 ```js
 useDebugValue(value, format?)
@@ -16,11 +16,11 @@ useDebugValue(value, format?)
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `useDebugValue(value, format?)` {/*usedebugvalue*/}
 
-Call `useDebugValue` at the top level of your [custom Hook](/learn/reusing-logic-with-custom-hooks) to display a readable debug value:
+Chame `useDebugValue` na raiz do seu [Hook personalizado](/learn/reusing-logic-with-custom-hooks) para exibir um valor de depuração legível:
 
 ```js
 import { useDebugValue } from 'react';
@@ -32,22 +32,22 @@ function useOnlineStatus() {
 }
 ```
 
-[See more examples below.](#usage)
+[Veja mais exemplos abaixo.](#usage)
 
-#### Parameters {/*parameters*/}
+#### Parâmetros {/*parameters*/}
 
-* `value`: The value you want to display in React DevTools. It can have any type.
-* **optional** `format`: A formatting function. When the component is inspected, React DevTools will call the formatting function with the `value` as the argument, and then display the returned formatted value (which may have any type). If you don't specify the formatting function, the original `value` itself will be displayed.
+* `value`: O valor que você deseja exibir no React DevTools. Pode ter qualquer tipo.
+* **opcional** `format`: Uma função de formatação. Quando o componente é inspecionado, o React DevTools chamará a função de formatação com o `value` como argumento e, em seguida, exibirá o valor formatado retornado (que pode ter qualquer tipo). Se você não especificar a função de formatação, o valor original `value` será exibido.
 
-#### Returns {/*returns*/}
+#### Retornos {/*returns*/}
 
-`useDebugValue` does not return anything.
+`useDebugValue` não retorna nada.
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Adding a label to a custom Hook {/*adding-a-label-to-a-custom-hook*/}
+### Adicionando um rótulo a um Hook personalizado {/*adding-a-label-to-a-custom-hook*/}
 
-Call `useDebugValue` at the top level of your [custom Hook](/learn/reusing-logic-with-custom-hooks) to display a readable <CodeStep step={1}>debug value</CodeStep> for [React DevTools.](/learn/react-developer-tools)
+Chame `useDebugValue` na raiz do seu [Hook personalizado](/learn/reusing-logic-with-custom-hooks) para exibir um <CodeStep step={1}>valor de depuração</CodeStep> legível para [React DevTools.](/learn/react-developer-tools)
 
 ```js [[1, 5, "isOnline ? 'Online' : 'Offline'"]]
 import { useDebugValue } from 'react';
@@ -59,11 +59,11 @@ function useOnlineStatus() {
 }
 ```
 
-This gives components calling `useOnlineStatus` a label like `OnlineStatus: "Online"` when you inspect them:
+Isso fornece aos componentes que chamam `useOnlineStatus` um rótulo como `OnlineStatus: "Online"` quando você os inspeciona:
 
-![A screenshot of React DevTools showing the debug value](/images/docs/react-devtools-usedebugvalue.png)
+![Uma captura de tela do React DevTools mostrando o valor de depuração](/images/docs/react-devtools-usedebugvalue.png)
 
-Without the `useDebugValue` call, only the underlying data (in this example, `true`) would be displayed.
+Sem a chamada `useDebugValue`, apenas os dados subjacentes (neste exemplo, `true`) seriam exibidos.
 
 <Sandpack>
 
@@ -103,20 +103,20 @@ function subscribe(callback) {
 
 <Note>
 
-Don't add debug values to every custom Hook. It's most valuable for custom Hooks that are part of shared libraries and that have a complex internal data structure that's difficult to inspect.
+Não adicione valores de depuração a todos os Hooks personalizados. É mais valioso para Hooks personalizados que fazem parte de bibliotecas compartilhadas e que têm uma estrutura de dados interna complexa que é difícil de inspecionar.
 
 </Note>
 
 ---
 
-### Deferring formatting of a debug value {/*deferring-formatting-of-a-debug-value*/}
+### Adiando a formatação de um valor de depuração {/*deferring-formatting-of-a-debug-value*/}
 
-You can also pass a formatting function as the second argument to `useDebugValue`:
+Você também pode passar uma função de formatação como o segundo argumento para `useDebugValue`:
 
 ```js [[1, 1, "date", 18], [2, 1, "date.toDateString()"]]
 useDebugValue(date, date => date.toDateString());
 ```
 
-Your formatting function will receive the <CodeStep step={1}>debug value</CodeStep> as a parameter and should return a <CodeStep step={2}>formatted display value</CodeStep>. When your component is inspected, React DevTools will call this function and display its result.
+Sua função de formatação receberá o <CodeStep step={1}>valor de depuração</CodeStep> como parâmetro e deve retornar um <CodeStep step={2}>valor de exibição formatado</CodeStep>. Quando seu componente é inspecionado, o React DevTools chamará essa função e exibirá seu resultado.
 
-This lets you avoid running potentially expensive formatting logic unless the component is actually inspected. For example, if `date` is a Date value, this avoids calling `toDateString()` on it for every render.
+Isso permite evitar executar lógica de formatação potencialmente cara, a menos que o componente seja realmente inspecionado. Por exemplo, se `date` for um valor Date, isso evita chamar `toDateString()` nele para cada renderização.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.