### PR TITLE
Translate `useRef.md` to pt-br

### DIFF
--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -4,10 +4,10 @@ title: useRef
 
 <Intro>
 
-`useRef` is a React Hook that lets you reference a value that's not needed for rendering.
+`useRef` é um Hook do React que permite referenciar um valor que não é necessário para renderização.
 
 ```js
-const ref = useRef(initialValue)
+const ref = useRef(valorInicial)
 ```
 
 </Intro>
@@ -16,112 +16,112 @@ const ref = useRef(initialValue)
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
-### `useRef(initialValue)` {/*useref*/}
+### `useRef(valorInicial)` {/*useref*/}
 
-Call `useRef` at the top level of your component to declare a [ref.](/learn/referencing-values-with-refs)
+Chame `useRef` na raiz do seu componente para declarar um [ref.](/learn/referencing-values-with-refs)
 
 ```js
 import { useRef } from 'react';
 
-function MyComponent() {
-  const intervalRef = useRef(0);
-  const inputRef = useRef(null);
+function MeuComponente() {
+  const intervaloRef = useRef(0);
+  const entradaRef = useRef(null);
   // ...
 ```
 
-[See more examples below.](#usage)
+[Veja mais exemplos abaixo.](#usage)
 
-#### Parameters {/*parameters*/}
+#### Parâmetros {/*parameters*/}
 
-* `initialValue`: The value you want the ref object's `current` property to be initially. It can be a value of any type. This argument is ignored after the initial render.
+* `valorInicial`: O valor que você deseja que a propriedade `current` do objeto ref seja inicialmente. Pode ser um valor de qualquer tipo. Este argumento é ignorado após a renderização inicial.
 
-#### Returns {/*returns*/}
+#### Retornos {/*returns*/}
 
-`useRef` returns an object with a single property:
+`useRef` retorna um objeto com uma única propriedade:
 
-* `current`: Initially, it's set to the `initialValue` you have passed. You can later set it to something else. If you pass the ref object to React as a `ref` attribute to a JSX node, React will set its `current` property.
+* `current`: Inicialmente, é definido como o `valorInicial` que você passou. Você pode defini-lo posteriormente para algo diferente. Se você passar o objeto ref para o React como um atributo `ref` para um nó JSX, o React definirá sua propriedade `current`.
 
-On the next renders, `useRef` will return the same object.
+Nas próximas renderizações, `useRef` retornará o mesmo objeto.
 
-#### Caveats {/*caveats*/}
+#### Ressalvas {/*caveats*/}
 
-* You can mutate the `ref.current` property. Unlike state, it is mutable. However, if it holds an object that is used for rendering (for example, a piece of your state), then you shouldn't mutate that object.
-* When you change the `ref.current` property, React does not re-render your component. React is not aware of when you change it because a ref is a plain JavaScript object.
-* Do not write _or read_ `ref.current` during rendering, except for [initialization.](#avoiding-recreating-the-ref-contents) This makes your component's behavior unpredictable.
-* In Strict Mode, React will **call your component function twice** in order to [help you find accidental impurities.](/reference/react/useState#my-initializer-or-updater-function-runs-twice) This is development-only behavior and does not affect production. Each ref object will be created twice, but one of the versions will be discarded. If your component function is pure (as it should be), this should not affect the behavior.
+* Você pode modificar a propriedade `ref.current`. Ao contrário do estado, é mutável. No entanto, se ele contiver um objeto que é usado para renderização (por exemplo, uma parte do seu estado), você não deve modificar esse objeto.
+* Quando você muda a propriedade `ref.current`, o React não re-renderiza seu componente. O React não está ciente de quando você a altera, pois um ref é um objeto JavaScript simples.
+* Não escreva _ou leia_ `ref.current` durante a renderização, exceto para [inicialização.](#avoiding-recreating-the-ref-contents) Isso torna o comportamento do seu componente imprevisível.
+* No Modo Estrito, o React **chamará a função do seu componente duas vezes** a fim de [ajudá-lo a encontrar impurezas acidentais.](/reference/react/useState#my-initializer-or-updater-function-runs-twice) Este é um comportamento exclusivo de desenvolvimento e não afeta a produção. Cada objeto ref será criado duas vezes, mas uma das versões será descartada. Se a função do seu componente for pura (como deveria ser), isso não deve afetar o comportamento.
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Referencing a value with a ref {/*referencing-a-value-with-a-ref*/}
+### Referenciando um valor com um ref {/*referencing-a-value-with-a-ref*/}
 
-Call `useRef` at the top level of your component to declare one or more [refs.](/learn/referencing-values-with-refs)
+Chame `useRef` na raiz do seu componente para declarar um ou mais [refs.](/learn/referencing-values-with-refs)
 
 ```js [[1, 4, "intervalRef"], [3, 4, "0"]]
 import { useRef } from 'react';
 
-function Stopwatch() {
-  const intervalRef = useRef(0);
+function Cronômetro() {
+  const intervaloRef = useRef(0);
   // ...
 ```
 
-`useRef` returns a <CodeStep step={1}>ref object</CodeStep> with a single <CodeStep step={2}>`current` property</CodeStep> initially set to the <CodeStep step={3}>initial value</CodeStep> you provided.
+`useRef` retorna um <CodeStep step={1}>objeto ref</CodeStep> com uma única <CodeStep step={2}>propriedade `current`</CodeStep> inicialmente definida como o <CodeStep step={3}>valor inicial</CodeStep> que você forneceu.
 
-On the next renders, `useRef` will return the same object. You can change its `current` property to store information and read it later. This might remind you of [state](/reference/react/useState), but there is an important difference.
+Nas próximas renderizações, `useRef` retornará o mesmo objeto. Você pode alterar sua propriedade `current` para armazenar informações e lê-las depois. Isso pode lembrá-lo do [estado](/reference/react/useState), mas há uma diferença importante.
 
-**Changing a ref does not trigger a re-render.** This means refs are perfect for storing information that doesn't affect the visual output of your component. For example, if you need to store an [interval ID](https://developer.mozilla.org/en-US/docs/Web/API/setInterval) and retrieve it later, you can put it in a ref. To update the value inside the ref, you need to manually change its <CodeStep step={2}>`current` property</CodeStep>:
+**Mudar um ref não dispara uma re-renderização.** Isso significa que os refs são perfeitos para armazenar informações que não afetam a saída visual do seu componente. Por exemplo, se você precisar armazenar um [ID de intervalo](https://developer.mozilla.org/en-US/docs/Web/API/setInterval) e recuperá-lo mais tarde, você pode colocá-lo em um ref. Para atualizar o valor dentro do ref, você precisa mudar manualmente sua <CodeStep step={2}>propriedade `current`</CodeStep>:
 
 ```js [[2, 5, "intervalRef.current"]]
 function handleStartClick() {
   const intervalId = setInterval(() => {
     // ...
   }, 1000);
-  intervalRef.current = intervalId;
+  intervaloRef.current = intervalId;
 }
 ```
 
-Later, you can read that interval ID from the ref so that you can call [clear that interval](https://developer.mozilla.org/en-US/docs/Web/API/clearInterval):
+Mais tarde, você pode ler esse ID de intervalo do ref para que possa [limpar esse intervalo](https://developer.mozilla.org/en-US/docs/Web/API/clearInterval):
 
 ```js [[2, 2, "intervalRef.current"]]
 function handleStopClick() {
-  const intervalId = intervalRef.current;
+  const intervalId = intervaloRef.current;
   clearInterval(intervalId);
 }
 ```
 
-By using a ref, you ensure that:
+Ao usar um ref, você garante que:
 
-- You can **store information** between re-renders (unlike regular variables, which reset on every render).
-- Changing it **does not trigger a re-render** (unlike state variables, which trigger a re-render).
-- The **information is local** to each copy of your component (unlike the variables outside, which are shared).
+- Você pode **armazenar informações** entre as re-renderizações (diferente de variáveis regulares, que se resetam em cada render).
+- Mudá-lo **não dispara uma re-renderização** (diferente de variáveis de estado, que disparam uma re-renderização).
+- A **informação é local** para cada cópia do seu componente (diferente de variáveis fora, que são compartilhadas).
 
-Changing a ref does not trigger a re-render, so refs are not appropriate for storing information you want to display on the screen. Use state for that instead. Read more about [choosing between `useRef` and `useState`.](/learn/referencing-values-with-refs#differences-between-refs-and-state)
+Mudar um ref não dispara uma re-renderização, então refs não são apropriados para armazenar informações que você deseja exibir na tela. Use estado para isso em vez disso. Leia mais sobre [escolher entre `useRef` e `useState`.](/learn/referencing-values-with-refs#differences-between-refs-and-state)
 
-<Recipes titleText="Examples of referencing a value with useRef" titleId="examples-value">
+<Receitas titleText="Exemplos de referência de um valor com useRef" titleId="examples-value">
 
-#### Click counter {/*click-counter*/}
+#### Contador de cliques {/*click-counter*/}
 
-This component uses a ref to keep track of how many times the button was clicked. Note that it's okay to use a ref instead of state here because the click count is only read and written in an event handler.
+Esse componente usa um ref para acompanhar quantas vezes o botão foi clicado. Note que é aceitável usar um ref em vez de estado aqui porque a contagem de cliques é apenas lida e escrita em um manipulador de eventos.
 
 <Sandpack>
 
 ```js
 import { useRef } from 'react';
 
-export default function Counter() {
+export default function Contador() {
   let ref = useRef(0);
 
   function handleClick() {
     ref.current = ref.current + 1;
-    alert('You clicked ' + ref.current + ' times!');
+    alert('Você clicou ' + ref.current + ' vezes!');
   }
 
   return (
     <button onClick={handleClick}>
-      Click me!
+      Clique em mim!
     </button>
   );
 }
@@ -129,51 +129,51 @@ export default function Counter() {
 
 </Sandpack>
 
-If you show `{ref.current}` in the JSX, the number won't update on click. This is because setting `ref.current` does not trigger a re-render. Information that's used for rendering should be state instead.
+Se você mostrar `{ref.current}` no JSX, o número não será atualizado ao clicar. Isso ocorre porque definir `ref.current` não dispara uma re-renderização. Informações que são usadas para renderização devem ser estado em vez disso.
 
-<Solution />
+<Solução />
 
-#### A stopwatch {/*a-stopwatch*/}
+#### Um cronômetro {/*a-stopwatch*/}
 
-This example uses a combination of state and refs. Both `startTime` and `now` are state variables because they are used for rendering. But we also need to hold an [interval ID](https://developer.mozilla.org/en-US/docs/Web/API/setInterval) so that we can stop the interval on button press. Since the interval ID is not used for rendering, it's appropriate to keep it in a ref, and manually update it.
+Este exemplo usa uma combinação de estado e refs. Tanto `startTime` quanto `now` são variáveis de estado porque são usadas para renderização. Mas também precisamos armazenar um [ID de intervalo](https://developer.mozilla.org/en-US/docs/Web/API/setInterval) para que possamos parar o intervalo ao pressionar o botão. Como o ID de intervalo não é usado para renderização, é apropriado mantê-lo em um ref e atualizá-lo manualmente.
 
 <Sandpack>
 
 ```js
 import { useState, useRef } from 'react';
 
-export default function Stopwatch() {
-  const [startTime, setStartTime] = useState(null);
-  const [now, setNow] = useState(null);
-  const intervalRef = useRef(null);
+export default function Cronômetro() {
+  const [inicioTempo, setInicioTempo] = useState(null);
+  const [agora, setAgora] = useState(null);
+  const intervaloRef = useRef(null);
 
   function handleStart() {
-    setStartTime(Date.now());
-    setNow(Date.now());
+    setInicioTempo(Date.now());
+    setAgora(Date.now());
 
-    clearInterval(intervalRef.current);
-    intervalRef.current = setInterval(() => {
-      setNow(Date.now());
+    clearInterval(intervaloRef.current);
+    intervaloRef.current = setInterval(() => {
+      setAgora(Date.now());
     }, 10);
   }
 
   function handleStop() {
-    clearInterval(intervalRef.current);
+    clearInterval(intervaloRef.current);
   }
 
-  let secondsPassed = 0;
-  if (startTime != null && now != null) {
-    secondsPassed = (now - startTime) / 1000;
+  let segundosPassados = 0;
+  if (inicioTempo != null && agora != null) {
+    segundosPassados = (agora - inicioTempo) / 1000;
   }
 
   return (
     <>
-      <h1>Time passed: {secondsPassed.toFixed(3)}</h1>
+      <h1>Tempo decorrido: {segundosPassados.toFixed(3)}</h1>
       <button onClick={handleStart}>
-        Start
+        Iniciar
       </button>
       <button onClick={handleStop}>
-        Stop
+        Parar
       </button>
     </>
   );
@@ -182,96 +182,96 @@ export default function Stopwatch() {
 
 </Sandpack>
 
-<Solution />
+<Solução />
 
-</Recipes>
+</Receitas>
 
-<Pitfall>
+<Cuidado>
 
-**Do not write _or read_ `ref.current` during rendering.**
+**Não escreva _ou leia_ `ref.current` durante a renderização.**
 
-React expects that the body of your component [behaves like a pure function](/learn/keeping-components-pure):
+O React espera que o corpo do seu componente [comporte-se como uma função pura](/learn/keeping-components-pure):
 
-- If the inputs ([props](/learn/passing-props-to-a-component), [state](/learn/state-a-components-memory), and [context](/learn/passing-data-deeply-with-context)) are the same, it should return exactly the same JSX.
-- Calling it in a different order or with different arguments should not affect the results of other calls.
+- Se as entradas ([props](/learn/passing-props-to-a-component), [estado](/learn/state-a-components-memory), e [contexto](/learn/passing-data-deeply-with-context)) forem as mesmas, deve retornar exatamente o mesmo JSX.
+- Chamá-lo em uma ordem diferente ou com argumentos diferentes não deve afetar os resultados de outras chamadas.
 
-Reading or writing a ref **during rendering** breaks these expectations.
+Ler ou escrever um ref **durante a renderização** quebra essas expectativas.
 
 ```js {3-4,6-7}
-function MyComponent() {
+function MeuComponente() {
   // ...
-  // 🚩 Don't write a ref during rendering
-  myRef.current = 123;
+  // 🚩 Não escreva um ref durante a renderização
+  meuRef.current = 123;
   // ...
-  // 🚩 Don't read a ref during rendering
-  return <h1>{myOtherRef.current}</h1>;
+  // 🚩 Não leia um ref durante a renderização
+  return <h1>{meuOutroRef.current}</h1>;
 }
 ```
 
-You can read or write refs **from event handlers or effects instead**.
+Você pode ler ou escrever refs **a partir de manipuladores de eventos ou efeitos**.
 
 ```js {4-5,9-10}
-function MyComponent() {
+function MeuComponente() {
   // ...
   useEffect(() => {
-    // ✅ You can read or write refs in effects
-    myRef.current = 123;
+    // ✅ Você pode ler ou escrever refs em efeitos
+    meuRef.current = 123;
   });
   // ...
   function handleClick() {
-    // ✅ You can read or write refs in event handlers
-    doSomething(myOtherRef.current);
+    // ✅ Você pode ler ou escrever refs em manipuladores de eventos
+    fazerAlgo(meuOutroRef.current);
   }
   // ...
 }
 ```
 
-If you *have to* read [or write](/reference/react/useState#storing-information-from-previous-renders) something during rendering, [use state](/reference/react/useState) instead.
+Se você *precisar* ler [ou escrever](/reference/react/useState#storing-information-from-previous-renders) algo durante a renderização, use [estado](/reference/react/useState) em vez disso.
 
-When you break these rules, your component might still work, but most of the newer features we're adding to React will rely on these expectations. Read more about [keeping your components pure.](/learn/keeping-components-pure#where-you-_can_-cause-side-effects)
+Quando você quebra essas regras, seu componente ainda pode funcionar, mas a maioria dos novos recursos que estamos adicionando ao React dependerão dessas expectativas. Leia mais sobre [manter seus componentes puros.](/learn/keeping-components-pure#where-you-_can_-cause-side-effects)
 
-</Pitfall>
+</Cuidado>
 
 ---
 
-### Manipulating the DOM with a ref {/*manipulating-the-dom-with-a-ref*/}
+### Manipulando o DOM com um ref {/*manipulating-the-dom-with-a-ref*/}
 
-It's particularly common to use a ref to manipulate the [DOM.](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API) React has built-in support for this.
+É particularmente comum usar um ref para manipular o [DOM.](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API) O React tem suporte embutido para isso.
 
-First, declare a <CodeStep step={1}>ref object</CodeStep> with an <CodeStep step={3}>initial value</CodeStep> of `null`:
+Primeiro, declare um <CodeStep step={1}>objeto ref</CodeStep> com um <CodeStep step={3}>valor inicial</CodeStep> de `null`:
 
 ```js [[1, 4, "inputRef"], [3, 4, "null"]]
 import { useRef } from 'react';
 
-function MyComponent() {
-  const inputRef = useRef(null);
+function MeuComponente() {
+  const entradaRef = useRef(null);
   // ...
 ```
 
-Then pass your ref object as the `ref` attribute to the JSX of the DOM node you want to manipulate:
+Em seguida, passe seu objeto ref como o atributo `ref` para o JSX do nó DOM que você deseja manipular:
 
 ```js [[1, 2, "inputRef"]]
   // ...
-  return <input ref={inputRef} />;
+  return <input ref={entradaRef} />;
 ```
 
-After React creates the DOM node and puts it on the screen, React will set the <CodeStep step={2}>`current` property</CodeStep> of your ref object to that DOM node. Now you can access the `<input>`'s DOM node and call methods like [`focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus):
+Depois que o React cria o nó DOM e o coloca na tela, o React definirá a <CodeStep step={2}>propriedade `current`</CodeStep> do seu objeto ref para aquele nó DOM. Agora você pode acessar o nó DOM do `<input>` e chamar métodos como [`focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus):
 
 ```js [[2, 2, "inputRef.current"]]
   function handleClick() {
-    inputRef.current.focus();
+    entradaRef.current.focus();
   }
 ```
 
-React will set the `current` property back to `null` when the node is removed from the screen.
+O React definirá a propriedade `current` de volta para `null` quando o nó for removido da tela.
 
-Read more about [manipulating the DOM with refs.](/learn/manipulating-the-dom-with-refs)
+Leia mais sobre [manipulando o DOM com refs.](/learn/manipulating-the-dom-with-refs)
 
-<Recipes titleText="Examples of manipulating the DOM with useRef" titleId="examples-dom">
+<Receitas titleText="Exemplos de manipulação do DOM com useRef" titleId="examples-dom">
 
-#### Focusing a text input {/*focusing-a-text-input*/}
+#### Focando em um campo de texto {/*focusing-a-text-input*/}
 
-In this example, clicking the button will focus the input:
+Neste exemplo, clicar no botão irá focar o campo de entrada:
 
 <Sandpack>
 
@@ -279,17 +279,17 @@ In this example, clicking the button will focus the input:
 import { useRef } from 'react';
 
 export default function Form() {
-  const inputRef = useRef(null);
+  const entradaRef = useRef(null);
 
   function handleClick() {
-    inputRef.current.focus();
+    entradaRef.current.focus();
   }
 
   return (
     <>
-      <input ref={inputRef} />
+      <input ref={entradaRef} />
       <button onClick={handleClick}>
-        Focus the input
+        Focar no campo
       </button>
     </>
   );
@@ -298,25 +298,25 @@ export default function Form() {
 
 </Sandpack>
 
-<Solution />
+<Solução />
 
-#### Scrolling an image into view {/*scrolling-an-image-into-view*/}
+#### Rolando uma imagem para visualizar {/*scrolling-an-image-into-view*/}
 
-In this example, clicking the button will scroll an image into view. It uses a ref to the list DOM node, and then calls DOM [`querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll) API to find the image we want to scroll to.
+Neste exemplo, clicar no botão rolará uma imagem para visualizar. Ele usa um ref para o nó DOM da lista e, em seguida, chama a API DOM [`querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll) para encontrar a imagem que desejamos rolar.
 
 <Sandpack>
 
 ```js
 import { useRef } from 'react';
 
-export default function CatFriends() {
-  const listRef = useRef(null);
+export default function AmigosGato() {
+  const listaRef = useRef(null);
 
-  function scrollToIndex(index) {
-    const listNode = listRef.current;
-    // This line assumes a particular DOM structure:
-    const imgNode = listNode.querySelectorAll('li > img')[index];
-    imgNode.scrollIntoView({
+  function rolarParaIndice(indice) {
+    const nóLista = listaRef.current;
+    // Esta linha assume uma estrutura DOM particular:
+    const nóImg = nóLista.querySelectorAll('li > img')[indice];
+    nóImg.scrollIntoView({
       behavior: 'smooth',
       block: 'nearest',
       inline: 'center'
@@ -326,18 +326,18 @@ export default function CatFriends() {
   return (
     <>
       <nav>
-        <button onClick={() => scrollToIndex(0)}>
+        <button onClick={() => rolarParaIndice(0)}>
           Tom
         </button>
-        <button onClick={() => scrollToIndex(1)}>
+        <button onClick={() => rolarParaIndice(1)}>
           Maru
         </button>
-        <button onClick={() => scrollToIndex(2)}>
+        <button onClick={() => rolarParaIndice(2)}>
           Jellylorum
         </button>
       </nav>
       <div>
-        <ul ref={listRef}>
+        <ul ref={listaRef}>
           <li>
             <img
               src="https://placekitten.com/g/200/200"
@@ -391,26 +391,26 @@ li {
 
 </Sandpack>
 
-<Solution />
+<Solução />
 
-#### Playing and pausing a video {/*playing-and-pausing-a-video*/}
+#### Reproduzindo e pausando um vídeo {/*playing-and-pausing-a-video*/}
 
-This example uses a ref to call [`play()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [`pause()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause) on a `<video>` DOM node.
+Este exemplo usa um ref para chamar [`play()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) e [`pause()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause) em um nó DOM `<video>`.
 
 <Sandpack>
 
 ```js
 import { useState, useRef } from 'react';
 
-export default function VideoPlayer() {
-  const [isPlaying, setIsPlaying] = useState(false);
+export default function ReprodutorVideo() {
+  const [estáReproduzindo, setEstáReproduzindo] = useState(false);
   const ref = useRef(null);
 
   function handleClick() {
-    const nextIsPlaying = !isPlaying;
-    setIsPlaying(nextIsPlaying);
+    const próximoEstáReproduzindo = !estáReproduzindo;
+    setEstáReproduzindo(próximoEstáReproduzindo);
 
-    if (nextIsPlaying) {
+    if (próximoEstáReproduzindo) {
       ref.current.play();
     } else {
       ref.current.pause();
@@ -420,13 +420,13 @@ export default function VideoPlayer() {
   return (
     <>
       <button onClick={handleClick}>
-        {isPlaying ? 'Pause' : 'Play'}
+        {estáReproduzindo ? 'Pausar' : 'Reproduzir'}
       </button>
       <video
         width="250"
         ref={ref}
-        onPlay={() => setIsPlaying(true)}
-        onPause={() => setIsPlaying(false)}
+        onPlay={() => setEstáReproduzindo(true)}
+        onPause={() => setEstáReproduzindo(false)}
       >
         <source
           src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
@@ -444,33 +444,33 @@ button { display: block; margin-bottom: 20px; }
 
 </Sandpack>
 
-<Solution />
+<Solução />
 
-#### Exposing a ref to your own component {/*exposing-a-ref-to-your-own-component*/}
+#### Expondo um ref para seu próprio componente {/*exposing-a-ref-to-your-own-component*/}
 
-Sometimes, you may want to let the parent component manipulate the DOM inside of your component. For example, maybe you're writing a `MyInput` component, but you want the parent to be able to focus the input (which the parent has no access to). You can use a combination of `useRef` to hold the input and [`forwardRef`](/reference/react/forwardRef) to expose it to the parent component. Read a [detailed walkthrough](/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes) here.
+Às vezes, você pode querer permitir que o componente pai manipule o DOM dentro do seu componente. Por exemplo, talvez você esteja escrevendo um componente `MeuInput`, mas deseja que o pai possa focar a entrada (à qual o pai não tem acesso). Você pode usar uma combinação de `useRef` para manter a entrada e [`forwardRef`](/reference/react/forwardRef) para expô-la ao componente pai. Leia um [passo a passo detalhado](/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes) aqui.
 
 <Sandpack>
 
 ```js
 import { forwardRef, useRef } from 'react';
 
-const MyInput = forwardRef((props, ref) => {
+const MeuInput = forwardRef((props, ref) => {
   return <input {...props} ref={ref} />;
 });
 
 export default function Form() {
-  const inputRef = useRef(null);
+  const entradaRef = useRef(null);
 
   function handleClick() {
-    inputRef.current.focus();
+    entradaRef.current.focus();
   }
 
   return (
     <>
-      <MyInput ref={inputRef} />
+      <MeuInput ref={entradaRef} />
       <button onClick={handleClick}>
-        Focus the input
+        Focar no campo
       </button>
     </>
   );
@@ -479,15 +479,15 @@ export default function Form() {
 
 </Sandpack>
 
-<Solution />
+<Solução />
 
-</Recipes>
+</Receitas>
 
 ---
 
-### Avoiding recreating the ref contents {/*avoiding-recreating-the-ref-contents*/}
+### Evitando a recriação do conteúdo do ref {/*avoiding-recreating-the-ref-contents*/}
 
-React saves the initial ref value once and ignores it on the next renders.
+O React salva o valor inicial do ref uma vez e ignora-o nas próximas renderizações.
 
 ```js
 function Video() {
@@ -495,9 +495,9 @@ function Video() {
   // ...
 ```
 
-Although the result of `new VideoPlayer()` is only used for the initial render, you're still calling this function on every render. This can be wasteful if it's creating expensive objects.
+Embora o resultado de `new VideoPlayer()` seja usado apenas para a renderização inicial, você ainda está chamando essa função em cada renderização. Isso pode ser dispendioso se estiver criando objetos caros.
 
-To solve it, you may initialize the ref like this instead:
+Para resolver isso, você pode inicializar o ref assim em vez disso:
 
 ```js
 function Video() {
@@ -508,19 +508,19 @@ function Video() {
   // ...
 ```
 
-Normally, writing or reading `ref.current` during render is not allowed. However, it's fine in this case because the result is always the same, and the condition only executes during initialization so it's fully predictable.
+Normalmente, escrever ou ler `ref.current` durante a renderização não é permitido. No entanto, é aceitável neste caso porque o resultado é sempre o mesmo, e a condição só é executada durante a inicialização, portanto, é totalmente previsível.
 
-<DeepDive>
+<Mergulho>
 
-#### How to avoid null checks when initializing useRef later {/*how-to-avoid-null-checks-when-initializing-use-ref-later*/}
+#### Como evitar verificações nulas ao inicializar useRef mais tarde {/*how-to-avoid-null-checks-when-initializing-use-ref-later*/}
 
-If you use a type checker and don't want to always check for `null`, you can try a pattern like this instead:
+Se você usar um verificador de tipo e não quiser verificar sempre se é `null`, pode tentar um padrão assim:
 
 ```js
 function Video() {
   const playerRef = useRef(null);
 
-  function getPlayer() {
+  function obterPlayer() {
     if (playerRef.current !== null) {
       return playerRef.current;
     }
@@ -532,38 +532,38 @@ function Video() {
   // ...
 ```
 
-Here, the `playerRef` itself is nullable. However, you should be able to convince your type checker that there is no case in which `getPlayer()` returns `null`. Then use `getPlayer()` in your event handlers.
+Aqui, o `playerRef` em si é anulável. No entanto, você deve ser capaz de convencer seu verificador de tipo que não há caso em que `obterPlayer()` retorne `null`. Então use `obterPlayer()` em seus manipuladores de eventos.
 
-</DeepDive>
+</Mergulho>
 
 ---
 
-## Troubleshooting {/*troubleshooting*/}
+## Solução de Problemas {/*troubleshooting*/}
 
-### I can't get a ref to a custom component {/*i-cant-get-a-ref-to-a-custom-component*/}
+### Não consigo obter um ref para um componente personalizado {/*i-cant-get-a-ref-to-a-custom-component*/}
 
-If you try to pass a `ref` to your own component like this:
+Se você tentar passar um `ref` para seu próprio componente assim:
 
 ```js
-const inputRef = useRef(null);
+const entradaRef = useRef(null);
 
-return <MyInput ref={inputRef} />;
+return <MeuInput ref={entradaRef} />;
 ```
 
-You might get an error in the console:
+Você pode receber um erro no console:
 
 <ConsoleBlock level="error">
 
-Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
+Atenção: Componentes de função não podem receber refs. Tentativas de acessar este ref falharão. Você quis usar React.forwardRef()?
 
 </ConsoleBlock>
 
-By default, your own components don't expose refs to the DOM nodes inside them.
+Por padrão, seus próprios componentes não expõem refs para os nós DOM dentro deles.
 
-To fix this, find the component that you want to get a ref to:
+Para corrigir isso, encontre o componente que você deseja obter um ref:
 
 ```js
-export default function MyInput({ value, onChange }) {
+export default function MeuInput({ value, onChange }) {
   return (
     <input
       value={value}
@@ -573,12 +573,12 @@ export default function MyInput({ value, onChange }) {
 }
 ```
 
-And then wrap it in [`forwardRef`](/reference/react/forwardRef) like this:
+E então envolva-o em [`forwardRef`](/reference/react/forwardRef) assim:
 
 ```js {3,8}
 import { forwardRef } from 'react';
 
-const MyInput = forwardRef(({ value, onChange }, ref) => {
+const MeuInput = forwardRef(({ value, onChange }, ref) => {
   return (
     <input
       value={value}
@@ -588,9 +588,9 @@ const MyInput = forwardRef(({ value, onChange }, ref) => {
   );
 });
 
-export default MyInput;
+export default MeuInput;
 ```
 
-Then the parent component can get a ref to it.
+Então o componente pai pode obter um ref para ele.
 
-Read more about [accessing another component's DOM nodes.](/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes)
+Leia mais sobre [acessando os nós DOM de outro componente.](/learn/manipulating-the-dom-with-refs#accessing-another-components-dom-nodes)


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.