### PR TITLE
fix: adjusted useEffect page translate

### DIFF
--- a/src/content/reference/react/useEffect.md
+++ b/src/content/reference/react/useEffect.md
@@ -216,7 +216,7 @@ button { margin-left: 10px; }
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Ouvindo um evento global do navegador {/*listening-to-a-global-browser-event*/}
 
@@ -265,7 +265,7 @@ body {
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Iniciando uma animação {/*triggering-an-animation*/}
 
@@ -364,7 +364,7 @@ html, body { min-height: 300px; }
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Controlando um diálogo modal {/*controlling-a-modal-dialog*/}
 
@@ -424,7 +424,7 @@ body {
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Rastreando a visibilidade de um elemento {/*tracking-element-visibility*/}
 
@@ -496,7 +496,7 @@ export default function Box() {
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 </Recipes>
 
@@ -635,7 +635,7 @@ button { margin-left: 10px; }
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Hook personalizado `useWindowListener` {/*custom-usewindowlistener-hook*/}
 
@@ -692,7 +692,7 @@ body {
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Hook personalizado `useIntersectionObserver` {/*custom-useintersectionobserver-hook*/}
 
@@ -780,7 +780,7 @@ export function useIntersectionObserver(ref) {
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 </Recipes>
 
@@ -1237,7 +1237,7 @@ button { margin-left: 5px; }
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 #### Passando um array de dependências vazio {/*passing-an-empty-dependency-array*/}
 
@@ -1313,7 +1313,7 @@ export function createConnection(serverUrl, roomId) {
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 
 #### Não passando nenhuma array de dependências {/*passing-no-dependency-array-at-all*/}
@@ -1411,7 +1411,7 @@ button { margin-left: 5px; }
 
 </Sandpack>
 
-<Solução />
+<Solution />
 
 </Recipes>
 


### PR DESCRIPTION
This pull request includes changes to the `src/content/reference/react/useEffect.md` file to correct a translation error by replacing the Portuguese word "Solução" with the English word "Solution" in multiple sections.

Translation corrections:

* Replaced `<Solução />` with `<Solution />` in various sections, including "listening-to-a-global-browser-event", "triggering-an-animation", "controlling-a-modal-dialog", "tracking-element-visibility", "custom-usewindowlistener-hook", "custom-useintersectionobserver-hook", "passing-an-empty-dependency-array", and "passing-no-dependency-array-at-all". [[1]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L219-R219) [[2]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L268-R268) [[3]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L367-R367) [[4]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L427-R427) [[5]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L499-R499) [[6]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L638-R638) [[7]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L695-R695) [[8]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L783-R783) [[9]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L1240-R1240) [[10]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L1316-R1316) [[11]](diffhunk://#diff-061a92673aa4024ae20f85c87778101b5059de2bb6515a3f5100b365d44cad26L1414-R1414)<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
