### PR TITLE
Translate `the-plan-for-react-18.md` to Portuguese

### DIFF
--- a/src/content/blog/2021/06/08/the-plan-for-react-18.md
+++ b/src/content/blog/2021/06/08/the-plan-for-react-18.md
@@ -1,71 +1,72 @@
 ---
-title: "The Plan for React 18"
+title: "O Plano para React 18"
 author: Andrew Clark, Brian Vaughn, Christine Abernathy, Dan Abramov, Rachel Nabors, Rick Hanlon, Sebastian Markbage, and Seth Webster
 date: 2021/06/08
-description: The React team is excited to share a few updates. We’ve started work on the React 18 release, which will be our next major version. We’ve created a Working Group to prepare the community for gradual adoption of new features in React 18. We’ve published a React 18 Alpha so that library authors can try it and provide feedback...
+description: A equipe do React está animada para compartilhar algumas atualizações. Começamos a trabalhar na versão React 18, que será nossa próxima versão principal. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18. Publicamos uma versão Alpha do React 18 para que os autores de bibliotecas possam experimentá-la e fornecer feedback...
 ---
 
-June 8, 2021 by [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://bsky.app/profile/danabra.mov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), and [Seth Webster](https://twitter.com/sethwebster)
+8 de junho de 2021 por [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://github.com/bvaughn), [Christine Abernathy](https://twitter.com/abernathyca), [Dan Abramov](https://bsky.app/profile/danabra.mov), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Sebastian Markbåge](https://twitter.com/sebmarkbage), e [Seth Webster](https://twitter.com/sethwebster)
 
 ---
 
 <Intro>
 
-The React team is excited to share a few updates:
+A equipe do React está animada para compartilhar algumas atualizações:
 
-1. We’ve started work on the React 18 release, which will be our next major version.
-2. We’ve created a Working Group to prepare the community for gradual adoption of new features in React 18.
-3. We’ve published a React 18 Alpha so that library authors can try it and provide feedback.
+1. Começamos a trabalhar na versão React 18, que será nossa próxima versão principal.
+2. Criamos um Grupo de Trabalho para preparar a comunidade para a adoção gradual de novos recursos no React 18.
+3. Publicamos uma versão Alpha do React 18 para que os autores de bibliotecas possam experimentá-la e fornecer *feedback*.
 
-These updates are primarily aimed at maintainers of third-party libraries. If you’re learning, teaching, or using React to build user-facing applications, you can safely ignore this post. But you are welcome to follow the discussions in the React 18 Working Group if you're curious!
+Essas atualizações são direcionadas principalmente aos *maintainers* de bibliotecas de terceiros. Se você está aprendendo, ensinando ou usando o React para construir aplicações voltadas para o usuário, você pode ignorar esta publicação com segurança. Mas você está convidado a acompanhar as discussões no Grupo de Trabalho do React 18 se estiver curioso!
 
 ---
 
 </Intro>
 
-## What’s coming in React 18 {/*whats-coming-in-react-18*/}
+## O que vem no React 18 {/*whats-coming-in-react-18*/}
 
-When it’s released, React 18 will include out-of-the-box improvements (like [automatic batching](https://github.com/reactwg/react-18/discussions/21)), new APIs (like [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), and a [new streaming server renderer](https://github.com/reactwg/react-18/discussions/37) with built-in support for `React.lazy`.
+Quando for lançado, o React 18 incluirá melhorias prontas para uso (como [ *automatic batching*](https://github.com/reactwg/react-18/discussions/21)), novas APIs (como [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), e um [novo *streaming server renderer*](https://github.com/reactwg/react-18/discussions/37) com suporte integrado para `React.lazy`.
 
-These features are possible thanks to a new opt-in mechanism we’re adding in React 18. It’s called “concurrent rendering” and it lets React prepare multiple versions of the UI at the same time. This change is mostly behind-the-scenes, but it unlocks new possibilities to improve both real and perceived performance of your app.
+Esses recursos são possíveis graças a um novo mecanismo de *opt-in* que estamos adicionando no React 18. Ele é chamado de "renderização concorrente" e permite que o React prepare várias versões da UI ao mesmo tempo. Essa mudança está principalmente nos bastidores, mas ela abre novas possibilidades para melhorar o desempenho real e percebido do seu *app*.
 
-If you've been following our research into the future of React (we don't expect you to!), you might have heard of something called “concurrent mode” or that it might break your app. In response to this feedback from the community, we’ve redesigned the upgrade strategy for gradual adoption. Instead of an all-or-nothing “mode”, concurrent rendering will only be enabled for updates triggered by one of the new features. In practice, this means **you will be able to adopt React 18 without rewrites and try the new features at your own pace.**
+Se você está acompanhando nossas pesquisas sobre o futuro do React (não esperamos que você acompanhe!), talvez já tenha ouvido falar em algo chamado "modo concorrente" ou que isso possa quebrar seu *app*. Em resposta a esse *feedback* da comunidade, redesenhamos a estratégia de *upgrade* para adoção gradual. Em vez de um “modo” de tudo ou nada, a renderização concorrente será habilitada apenas para atualizações acionadas por um dos novos recursos. Na prática, isso significa que **você poderá adotar o React 18 sem reescritas e experimentar os novos recursos no seu próprio ritmo.**
 
-## A gradual adoption strategy {/*a-gradual-adoption-strategy*/}
+## Uma estratégia de adoção gradual {/*a-gradual-adoption-strategy*/}
 
-Since concurrency in React 18 is opt-in, there are no significant out-of-the-box breaking changes to component behavior. **You can upgrade to React 18 with minimal or no changes to your application code, with a level of effort comparable to a typical major React release**. Based on our experience converting several apps to React 18, we expect that many users will be able to upgrade within a single afternoon.
+Como a concorrência no React 18 é *opt-in*, não há mudanças significativas e imediatas que quebrem o comportamento do componente. **Você pode atualizar para o React 18 com o mínimo ou nenhuma mudança no código da sua aplicação, com um esforço comparável ao de um lançamento principal típico do React**. Com base em nossa experiência na conversão de vários *apps* para React 18, esperamos que muitos usuários possam atualizar em uma única tarde.
 
-We successfully shipped concurrent features to tens of thousands of components at Facebook, and in our experience, we've found that most React components “just work” without additional changes. We're committed to making sure this is a smooth upgrade for the entire community, so today we're announcing the React 18 Working Group.
+Nós enviamos com sucesso recursos de concorrência para dezenas de milhares de componentes no Facebook e, em nossa experiência, descobrimos que a maioria dos componentes do React "simplesmente funciona" sem alterações adicionais. Estamos comprometidos em garantir que essa seja uma atualização tranquila para toda a comunidade, por isso estamos anunciando hoje o React 18 Working Group.
 
-## Working with the community {/*working-with-the-community*/}
+## Trabalhando com a comunidade {/*working-with-the-community*/}
 
-We’re trying something new for this release: We've invited a panel of experts, developers, library authors, and educators from across the React community to participate in our [React 18 Working Group](https://github.com/reactwg/react-18) to provide feedback, ask questions, and collaborate on the release. We couldn't invite everyone we wanted to this initial, small group, but if this experiment works out, we hope there will be more in the future!
+Estamos tentando algo novo para este lançamento: Convidamos um painel de especialistas, desenvolvedores, autores de bibliotecas e educadores de toda a comunidade React para participar do nosso [React 18 Working Group](https://github.com/reactwg/react-18) para fornecer *feedback*, fazer perguntas e colaborar no lançamento. Não pudemos convidar todos que queríamos para este grupo inicial e pequeno, mas se este experimento funcionar, esperamos que haja mais no futuro!
 
-**The goal of the React 18 Working Group is to prepare the ecosystem for a smooth, gradual adoption of React 18 by existing applications and libraries.** The Working Group is hosted on [GitHub Discussions](https://github.com/reactwg/react-18/discussions) and is available for the public to read. Members of the working group can leave feedback, ask questions, and share ideas. The core team will also use the discussions repo to share our research findings. As the stable release gets closer, any important information will also be posted on this blog.
+**O objetivo do React 18 Working Group é preparar o ecossistema para uma adoção suave e gradual do React 18 pelas aplicações e bibliotecas existentes.**  O Working Group é hospedado no [GitHub Discussions](https://github.com/reactwg/react-18/discussions) e está disponível para leitura pública. Membros do grupo de trabalho podem deixar *feedback*, fazer perguntas e compartilhar ideias. A equipe principal também usará o repositório de discussões para compartilhar nossas descobertas de pesquisa. À medida que o lançamento estável se aproxima, qualquer informação importante também será postada neste *blog*.
 
-For more information on upgrading to React 18, or additional resources about the release, see the [React 18 announcement post](https://github.com/reactwg/react-18/discussions/4).
+Para obter mais informações sobre como atualizar para o React 18 ou recursos adicionais sobre o lançamento, consulte a [publicação de anúncio do React 18](https://github.com/reactwg/react-18/discussions/4).
 
-## Accessing the React 18 Working Group {/*accessing-the-react-18-working-group*/}
+## Acessando o React 18 Working Group {/*accessing-the-react-18-working-group*/}
 
-Everyone can read the discussions in the [React 18 Working Group repo](https://github.com/reactwg/react-18).
+Todos podem ler as discussões no [repositório do React 18 Working Group](https://github.com/reactwg/react-18).
 
-Because we expect an initial surge of interest in the Working Group, only invited members will be allowed to create or comment on threads. However, the threads are fully visible to the public, so everyone has access to the same information. We believe this is a good compromise between creating a productive environment for working group members, while maintaining transparency with the wider community.
+Como esperamos um aumento inicial de interesse no Working Group, apenas membros convidados poderão criar ou comentar *threads*. No entanto, os *threads* são totalmente visíveis ao público, para que todos tenham acesso às mesmas informações. Acreditamos que este é um bom compromisso entre a criação de um ambiente produtivo para os membros do grupo de trabalho, mantendo a transparência com a comunidade em geral.
 
-As always, you can submit bug reports, questions, and general feedback to our [issue tracker](https://github.com/facebook/react/issues).
+Como sempre, você pode enviar relatórios de *bug*, perguntas e *feedback* geral para nossa [ferramenta de *issue*](https://github.com/facebook/react/issues).
 
-## How to try React 18 Alpha today {/*how-to-try-react-18-alpha-today*/}
+## Como experimentar o React 18 Alpha hoje {/*how-to-try-react-18-alpha-today*/}
 
-New alphas are [regularly published to npm using the `@alpha` tag](https://github.com/reactwg/react-18/discussions/9). These releases are built using the most recent commit to our main repo. When a feature or bugfix is merged, it will appear in an alpha the following weekday.
+Novas versões *alpha* são [publicadas regularmente no npm usando a tag `@alpha`](https://github.com/reactwg/react-18/discussions/9). Esses *releases* são construídos usando a *commit* mais recente em nosso repositório principal. Quando um recurso ou correção de *bug* é mesclado, ele aparecerá em uma versão *alpha* no dia da semana seguinte.
 
-There may be significant behavioral or API changes between alpha releases. Please remember that **alpha releases are not recommended for user-facing, production applications**.
+Pode haver mudanças significativas de comportamento ou API entre as versões *alpha*. Por favor, lembre-se que **as versões *alpha* não são recomendadas para aplicações de produção, voltadas para o usuário**.
 
-## Projected React 18 release timeline {/*projected-react-18-release-timeline*/}
+## Cronograma de lançamento projetado do React 18 {/*projected-react-18-release-timeline*/}
 
-We don't have a specific release date scheduled, but we expect it will take several months of feedback and iteration before React 18 is ready for most production applications.
+Não temos uma data de lançamento específica agendada, mas esperamos que leve vários meses de *feedback* e iteração até que o React 18 esteja pronto para a maioria das aplicações de produção.
 
-* Library Alpha: Available today
-* Public Beta: At least several months
-* Release Candidate (RC): At least several weeks after Beta
-* General Availability: At least several weeks after RC
+*   Library Alpha: Disponível hoje
+*   Public Beta: Pelo menos vários meses
+*   Release Candidate (RC): Pelo menos várias semanas após a Beta
+*   General Availability: Pelo menos várias semanas após a RC
 
-More details about our projected release timeline are [available in the Working Group](https://github.com/reactwg/react-18/discussions/9). We'll post updates on this blog when we're closer to a public release.
+Mais detalhes sobre nosso cronograma de lançamento projetado estão [disponíveis no Working Group](https://github.com/reactwg/react-18/discussions/9). Publicaremos atualizações neste *blog* quando estivermos mais próximos de um lançamento público.
+``


### PR DESCRIPTION
This pull request contains a translation of the referenced page to Portuguese. The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.