### PR TITLE
Translate `passing-data-deeply-with-context.md` to Portuguese

### DIFF
--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -160,7 +160,7 @@ export default function Heading({ level, children }) {
     case 4:
       return <h4>{children}</h4>;
     case 5:
-      return <h5>{children}</h1>;
+      return <h5>{children}</h5>;
     case 6:
       return <h6>{children}</h6>;
     default:
@@ -410,11 +410,11 @@ export default function Heading({ children }) {
     case 1:
       return <h1>{children}</h1>;
     case 2:
-      return <h2>{children}</h1>;
+      return <h2>{children}</h2>;
     case 3:
-      return <h3>{children}</h1>;
+      return <h3>{children}</h3>;
     case 4:
-      return <h4>{children}</h1>;
+      return <h4>{children}</h4>;
     case 5:
       return <h5>{children}</h5>;
     case 6:
@@ -532,13 +532,13 @@ export default function Heading({ children }) {
     case 1:
       return <h1>{children}</h1>;
     case 2:
-      return <h2>{children}</h1>;
+      return <h2>{children}</h2>;
     case 3:
-      return <h3>{children}</h1>;
+      return <h3>{children}</h3>;
     case 4:
-      return <h4>{children}</h1>;
+      return <h4>{children}</h4>;
     case 5:
-      return <h5>{children}</h1>;
+      return <h5>{children}</h5>;
     case 6:
       return <h6>{children}</h6>;
     default:
@@ -601,7 +601,9 @@ export default function Section({ children }) {
     </section>
   );
 }
-```Com essa mudança, você não precisa passar a prop `level` *nem* para o `<Section>` nem para o `<Heading>`:
+```
+
+Com essa mudança, você não precisa passar a prop `level` *nem* para o `<Section>` nem para o `<Heading>`:
 
 <Sandpack>
 


### PR DESCRIPTION
This pull request contains a translation of the referenced page to Portuguese. The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.