### PR TITLE
fix(pt-br): corrige erro de digitação em 'normalmente'

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -407,7 +407,7 @@ O primeiro `MyButton` atualiza seu `count` para `1`.
 
 </DiagramGroup>
 
-No entanto, normalment você vai precisar que componentes *compartilhem dados e sempre sejam atualizados juntos*.
+No entanto, normalmente você vai precisar que componentes *compartilhem dados e sempre sejam atualizados juntos*.
 
 Para fazer com que ambos os componentes `MyButton` exibam o mesmo `count` e sejam atualizados juntos, você precisa mover o estado dos botões individuais "para cima", para o componente mais próximo que contenha todos eles.
 


### PR DESCRIPTION
Adicionar apenas um único caractere para a correção ortográfica da palavra

Erro ortográfico encontrado em: src/content/learn/index.md
