### PR TITLE
Translate React Compiler notes in useCallback and useMemo

### DIFF
--- a/src/content/reference/react/useCallback.md
+++ b/src/content/reference/react/useCallback.md
@@ -14,7 +14,7 @@ const cachedFn = useCallback(fn, dependencies)
 
 <Note>
 
-[React Compiler](/learn/react-compiler) automatically memoizes values and functions, reducing the need for manual `useCallback` calls. You can use the compiler to handle memoization automatically.
+[React Compiler](/learn/react-compiler) memoiza automaticamente valores e funções, reduzindo a necessidade de chamadas manuais de `useCallback`. Você pode usar o React Compiler para memoizar automaticamente.
 
 </Note>
 

--- a/src/content/reference/react/useMemo.md
+++ b/src/content/reference/react/useMemo.md
@@ -14,7 +14,7 @@ const cachedValue = useMemo(calculateValue, dependencies)
 
 <Note>
 
-[React Compiler](/learn/react-compiler) automatically memoizes values and functions, reducing the need for manual `useMemo` calls. You can use the compiler to handle memoization automatically.
+[React Compiler](/learn/react-compiler) memoiza automaticamente valores e funções, reduzindo a necessidade de chamadas manuais de `useMemo`. Você pode usar o React Compiler para memoizar automaticamente.
 
 </Note>
 


### PR DESCRIPTION
## What?

This PR translates the React Compiler notes in the following files:
- `src/content/reference/react/useCallback.md`
- `src/content/reference/react/useMemo.md`

## Why?

These sections were missing Portuguese (Brazil) translation. This completes the translation for the React Compiler documentation notes in both hooks.

## How?

Translated the `<Note>` blocks about React Compiler while keeping:
- Technical terms in English (React Compiler, useCallback, useMemo)
- Code examples unchanged
- Markdown formatting intact