### PR TITLE
Tradução de `preserving-and-resetting-state.md` para Português (Brasil)

### DIFF
--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -739,9 +739,9 @@ Toda vez que você clica no botão, o estado do input desaparece! Isso ocorre po
 
 </Pitfall>
 
-## Resetando o estado na mesma posição {/*resetting-state-at-the-same-position*/}
+## Redefinindo o estado na mesma posição {/*resetting-state-at-the-same-position*/}
 
-Por padrão, o React preserva o estado de um componente enquanto ele permanece na mesma posição. Geralmente, é exatamente isso que você deseja, então faz sentido como comportamento padrão. Mas, às vezes, você pode querer resetar o estado de um componente. Considere este aplicativo que permite que dois jogadores acompanhem suas pontuações em cada turno:
+Por padrão, o React preserva o estado de um componente enquanto ele permanece na mesma posição. Geralmente, é exatamente isso que você deseja, então faz sentido como comportamento padrão. Mas, às vezes, você pode querer redefinir o estado de um componente. Considere este aplicativo que permite que dois jogadores acompanhem suas pontuações em cada turno:
 
 <Sandpack>
 
@@ -815,7 +815,7 @@ Atualmente, ao trocar de jogador, a pontuação é preservada. Os dois `Counter`
 
 Mas conceitualmente, neste aplicativo, eles deveriam ser dois contadores separados. Eles podem aparecer no mesmo lugar na UI, mas um é um contador para Taylor e outro é para Sarah.
 
-Existem duas maneiras de resetar o estado ao alternar entre eles:
+Existem duas maneiras de redefinir o estado ao alternar entre eles:
 
 1. Renderizar componentes em posições diferentes
 2. Dar a cada componente uma identidade explícita com `key`
@@ -923,9 +923,9 @@ O estado de cada `Counter` é destruído toda vez que ele é removido do DOM. É
 
 Esta solução é conveniente quando você tem apenas alguns componentes independentes renderizados no mesmo local. Neste exemplo, você tem apenas dois, então não é um incômodo renderizá-los separadamente no JSX.
 
-### Opção 2: Resetando o estado com uma chave {/*option-2-resetting-state-with-a-key*/}
+### Opção 2: Redefinindo o estado com uma chave {/*option-2-resetting-state-with-a-key*/}
 
-Há também outra maneira, mais genérica, de resetar o estado de um componente.
+Há também outra maneira, mais genérica, de redefinir o estado de um componente.
 
 Você pode ter visto `key`s ao [renderizar listas.](/learn/rendering-lists#keeping-list-items-in-order-with-key) As chaves não servem apenas para listas! Você pode usar chaves para fazer o React distinguir entre quaisquer componentes. Por padrão, o React usa a ordem dentro do pai ("primeiro contador", "segundo contador") para discernir entre componentes. Mas as chaves permitem que você diga ao React que este não é apenas um *primeiro* contador, ou um *segundo* contador, mas um contador específico - por exemplo, o contador *de Taylor*. Dessa forma, o React saberá o contador *de Taylor* onde quer que ele apareça na árvore!
 
@@ -1017,9 +1017,9 @@ Lembre-se que as chaves não são globalmente únicas. Elas apenas especificam a
 
 </Note>
 
-### Resetando um formulário com uma chave {/*resetting-a-form-with-a-key*/}
+### Redefinindo um formulário com uma chave {/*resetting-a-form-with-a-key*/}
 
-Resetar o estado com uma chave é particularmente útil ao lidar com formulários.
+Redefinir o estado com uma chave é particularmente útil ao lidar com formulários.
 
 Neste aplicativo de chat, o componente `<Chat>` contém o estado da entrada de texto:
 

--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -4,7 +4,7 @@ title: Preserving and Resetting State
 
 <Intro>
 
-O estado é isolado entre componentes. O React acompanha qual estado pertence a qual componente com base em sua posição na árvore de UI. Você pode controlar quando preservar o estado e quando redefini-lo entre as re-renderizações.
+O estado é isolado entre componentes. O React acompanha qual estado pertence a qual componente com base em sua posição na árvore de UI. Você pode controlar quando preservar o estado e quando redefini-lo entre as renderizações.
 
 </Intro>
 
@@ -86,7 +86,7 @@ label {
 
 </Sandpack>
 
-Veja como eles se parecem como uma árvore:
+Veja como isso se parece em uma árvore:
 
 <DiagramGroup>
 
@@ -248,7 +248,7 @@ label {
 
 </Sandpack>
 
-Note como no momento em que você para de renderizar o segundo contador, seu estado desaparece completamente. Isso ocorre porque, quando o React remove um componente, ele destrói seu estado.
+Note como no momento em que você para de renderizar o segundo contador, seu estado desaparece completamente. Isso ocorre porque quando o React remove um componente, ele destrói seu estado.
 
 <DiagramGroup>
 
@@ -272,7 +272,7 @@ Adicionando um componente
 
 </DiagramGroup>
 
-**O React preserva o estado de um componente enquanto ele estiver sendo renderizado em sua posição na árvore de UI.** Se ele for removido, ou um componente diferente for renderizado na mesma posição, o React descarta seu estado.
+**O React preserva o estado de um componente enquanto ele estiver sendo renderizado em sua posição na árvore de UI.** Se ele for removido, ou um componente diferente for renderizado na mesma posição, o React descartará seu estado.
 
 ## O mesmo componente na mesma posição preserva o estado {/*same-component-at-the-same-position-preserves-state*/}
 
@@ -365,7 +365,7 @@ Quando você marca ou desmarca a caixa de seleção, o estado do contador não �
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_same_component" height={461} width={600} alt="Diagrama com duas seções separadas por uma seta fazendo a transição entre elas. Cada seção contém um layout de componentes com um pai rotulado 'App' contendo uma bolha de estado rotulada isFancy. Este componente tem um filho rotulado 'div', que leva a uma bolha de props contendo isFancy (destacada em roxo) passada para o único filho. O último filho é rotulado 'Counter' e contém uma bolha de estado com o rótulo 'count' e valor 3 em ambos os diagramas. Na seção esquerda do diagrama, nada está destacado e o valor do estado pai isFancy é falso. Na seção direita do diagrama, o valor do estado pai isFancy mudou para true e ele está destacado em amarelo, assim como a bolha de props abaixo, que também mudou seu valor isFancy para true.">
+<Diagram name="preserving_state_same_component" height={461} width={600} alt="Diagrama com duas seções separadas por uma seta fazendo a transição entre elas. Cada seção contém um layout de componentes com um pai rotulado 'App' contendo uma bolha de estado rotulada isFancy. Este componente tem um filho rotulado 'div', que leva a uma bolha de props contendo isFancy (destacada em roxo) passada para o único filho. O último filho é rotulado 'Counter' e contém uma bolha de estado com rótulo 'count' e valor 3 em ambos os diagramas. Na seção esquerda do diagrama, nada está destacado e o valor do estado pai isFancy é falso. Na seção direita do diagrama, o valor do estado pai isFancy mudou para true e está destacado em amarelo, assim como a bolha de props abaixo, que também mudou seu valor isFancy para true.">
 
 Atualizar o estado do `App` não redefine o `Counter` porque o `Counter` permanece na mesma posição
 
@@ -378,7 +378,7 @@ Atualizar o estado do `App` não redefine o `Counter` porque o `Counter` permane
 
 <Pitfall>
 
-Lembre-se de que **é a posição na árvore de UI — não no markup JSX — que importa para o React!** Este componente tem duas cláusulas `return` com tags JSX `<Counter />` diferentes dentro e fora do `if`:
+Lembre-se de que **é a posição na árvore de UI — não no markup JSX — que importa para o React!** Este componente tem duas cláusulas `return` com diferentes tags JSX `<Counter />` dentro e fora do `if`:
 
 <Sandpack>
 
@@ -478,7 +478,7 @@ label {
 
 Você pode esperar que o estado seja redefinido ao marcar a caixa de seleção, mas não é! Isso ocorre porque **ambas essas tags `<Counter />` são renderizadas na mesma posição.** O React não sabe onde você coloca as condições em sua função. Tudo o que ele "vê" é a árvore que você retorna.
 
-Em ambos os casos, o componente `App` retorna um `<div>` com `<Counter />` como primeiro filho. Para o React, esses dois contadores têm o mesmo "endereço": o primeiro filho do primeiro filho da raiz. É assim que o React os associa entre a renderização anterior e a próxima, independentemente de como você estrutura sua lógica.
+Em ambos os casos, o componente `App` retorna um `<div>` com `<Counter />` como o primeiro filho. Para o React, esses dois contadores têm o mesmo "endereço": o primeiro filho do primeiro filho da raiz. É assim que o React os associa entre a renderização anterior e a próxima, independentemente de como você estrutura sua lógica.
 
 </Pitfall>
 
@@ -561,13 +561,13 @@ label {
 
 </Sandpack>
 
-Aqui, você alterna entre tipos de componentes _diferentes_ na mesma posição. Inicialmente, o primeiro filho do `<div>` continha um `Counter`. Mas quando você trocou por um `p`, o React removeu o `Counter` da árvore de UI e destruiu seu estado.
+Aqui, você alterna entre _diferentes_ tipos de componentes na mesma posição. Inicialmente, o primeiro filho do `<div>` continha um `Counter`. Mas quando você o substituiu por um `p`, o React removeu o `Counter` da árvore de UI e destruiu seu estado.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_pt1" height={290} width={753} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas o componente filho foi excluído, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'p', destacado em amarelo.">
+<Diagram name="preserving_state_diff_pt1" height={290} width={753} alt="Diagrama com três seções, com uma seta transicionando cada seção entre elas. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas o componente filho foi agora deletado, indicado por uma imagem amarela de 'prova'. A terceira seção tem novamente o mesmo pai 'div', agora com um novo filho rotulado 'p', destacado em amarelo.">
 
-Quando `Counter` muda para `p`, o `Counter` é excluído e o `p` é adicionado
+Quando `Counter` muda para `p`, o `Counter` é deletado e o `p` é adicionado
 
 </Diagram>
 
@@ -575,9 +575,9 @@ Quando `Counter` muda para `p`, o `Counter` é excluído e o `p` é adicionado
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_pt2" height={290} width={753} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'p'. A seção do meio tem o mesmo pai 'div', mas o componente filho foi excluído, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, destacado em amarelo.">
+<Diagram name="preserving_state_diff_pt2" height={290} width={753} alt="Diagrama com três seções, com uma seta transicionando cada seção entre elas. A primeira seção contém um componente React rotulado 'p'. A seção do meio tem o mesmo pai 'div', mas o componente filho foi agora deletado, indicado por uma imagem amarela de 'prova'. A terceira seção tem novamente o mesmo pai 'div', agora com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, destacado em amarelo.">
 
-Ao alternar de volta, o `p` é excluído e o `Counter` é adicionado
+Ao voltar, o `p` é deletado e o `Counter` é adicionado
 
 </Diagram>
 
@@ -672,13 +672,13 @@ label {
 
 </Sandpack>
 
-O estado do contador é redefinido quando você clica na caixa de seleção. Embora você renderize um `Counter`, o primeiro filho do `div` muda de uma `section` para um `div`. Quando o `section` filho foi removido do DOM, toda a árvore abaixo dele (incluindo o `Counter` e seu estado) também foi destruída.
+O estado do contador é redefinido quando você clica na caixa de seleção. Embora você renderize um `Counter`, o primeiro filho do `div` muda de uma `section` para um `div`. Quando a `section` filha foi removida do DOM, toda a árvore abaixo dela (incluindo o `Counter` e seu estado) também foi destruída.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_same_pt1" height={350} width={794} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'section', que tem um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram excluídos, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'div', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, todos destacados em amarelo.">
+<Diagram name="preserving_state_diff_same_pt1" height={350} width={794} alt="Diagrama com três seções, com uma seta transicionando cada seção entre elas. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'section', que tem um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram agora deletados, indicado por uma imagem amarela de 'prova'. A terceira seção tem novamente o mesmo pai 'div', agora com um novo filho rotulado 'div', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, tudo destacado em amarelo.">
 
-Quando `section` muda para `div`, o `section` é excluído e o novo `div` é adicionado
+Quando `section` muda para `div`, a `section` é deletada e o novo `div` é adicionado
 
 </Diagram>
 
@@ -686,9 +686,9 @@ Quando `section` muda para `div`, o `section` é excluído e o novo `div` é adi
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_same_pt2" height={350} width={794} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'div', que tem um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram excluídos, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'section', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, todos destacados em amarelo.">
+<Diagram name="preserving_state_diff_same_pt2" height={350} width={794} alt="Diagrama com três seções, com uma seta transicionando cada seção entre elas. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'div', que tem um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram agora deletados, indicado por uma imagem amarela de 'prova'. A terceira seção tem novamente o mesmo pai 'div', agora com um novo filho rotulado 'section', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, tudo destacado em amarelo.">
 
-Ao alternar de volta, o `div` é excluído e o novo `section` é adicionado
+Ao alternar de volta, o `div` é deletado e a nova `section` é adicionada
 
 </Diagram>
 
@@ -741,7 +741,7 @@ Toda vez que você clica no botão, o estado do input desaparece! Isso ocorre po
 
 ## Redefinindo o estado na mesma posição {/*resetting-state-at-the-same-position*/}
 
-Por padrão, o React preserva o estado de um componente enquanto ele permanece na mesma posição. Geralmente, é exatamente isso que você deseja, então faz sentido como comportamento padrão. Mas, às vezes, você pode querer redefinir o estado de um componente. Considere este aplicativo que permite que dois jogadores acompanhem suas pontuações em cada turno:
+Por padrão, o React preserva o estado de um componente enquanto ele permanece na mesma posição. Geralmente, é exatamente isso que você deseja, então faz sentido como comportamento padrão. Mas, às vezes, você pode querer redefinir o estado de um componente. Considere este aplicativo que permite que dois jogadores acompanhem suas pontuações a cada turno:
 
 <Sandpack>
 
@@ -811,9 +811,9 @@ h1 {
 
 </Sandpack>
 
-Atualmente, ao trocar de jogador, a pontuação é preservada. Os dois `Counter`s aparecem na mesma posição, então o React os considera o *mesmo* `Counter` cuja prop `person` foi alterada.
+Atualmente, quando você troca de jogador, a pontuação é preservada. Os dois `Counter`s aparecem na mesma posição, então o React os considera o *mesmo* `Counter` cuja prop `person` foi alterada.
 
-Mas conceitualmente, neste aplicativo, eles deveriam ser dois contadores separados. Eles podem aparecer no mesmo lugar na UI, mas um é um contador para Taylor e outro é para Sarah.
+Mas, conceitualmente, neste aplicativo, eles deveriam ser dois contadores separados. Eles podem aparecer no mesmo lugar na interface do usuário, mas um é um contador para Taylor e outro é um contador para Sarah.
 
 Existem duas maneiras de redefinir o estado ao alternar entre eles:
 
@@ -895,7 +895,7 @@ h1 {
 </Sandpack>
 
 * Inicialmente, `isPlayerA` é `true`. Portanto, a primeira posição contém o estado do `Counter`, e a segunda está vazia.
-* Ao clicar no botão "Próximo jogador", a primeira posição é limpa, mas a segunda agora contém um `Counter`.
+* Quando você clica no botão "Próximo jogador", a primeira posição é limpa, mas a segunda agora contém um `Counter`.
 
 <DiagramGroup>
 
@@ -905,13 +905,13 @@ Estado inicial
 
 </Diagram>
 
-<Diagram name="preserving_state_diff_position_p2" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'false'. A bolha de estado está destacada em amarelo, indicando que foi alterada. O filho esquerdo é substituído por uma imagem de 'poof' amarela indicando que foi excluído e há um novo filho à direita, destacado em amarelo indicando que foi adicionado. O novo filho é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0.">
+<Diagram name="preserving_state_diff_position_p2" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'false'. A bolha de estado está destacada em amarelo, indicando que foi alterada. O filho esquerdo é substituído por uma imagem de 'poof' amarela indicando que foi excluído e há um novo filho à direita, destacado em amarelo indicando que foi adicionado. O novo filho é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com o valor 0.">
 
 Clicando em "próximo"
 
 </Diagram>
 
-<Diagram name="preserving_state_diff_position_p3" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'true'. A bolha de estado está destacada em amarelo, indicando que foi alterada. Há um novo filho à esquerda, destacado em amarelo indicando que foi adicionado. O novo filho é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0. O filho direito é substituído por uma imagem de 'poof' amarela indicando que foi excluído.">
+<Diagram name="preserving_state_diff_position_p3" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'true'. A bolha de estado está destacada em amarelo, indicando que foi alterada. Há um novo filho à esquerda, destacado em amarelo indicando que foi adicionado. O novo filho é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com o valor 0. O filho direito é substituído por uma imagem de 'poof' amarela indicando que foi excluído.">
 
 Clicando em "próximo" novamente
 
@@ -919,15 +919,15 @@ Clicando em "próximo" novamente
 
 </DiagramGroup>
 
-O estado de cada `Counter` é destruído toda vez que ele é removido do DOM. É por isso que eles resetam toda vez que você clica no botão.
+O estado de cada `Counter` é destruído toda vez que ele é removido do DOM. É por isso que eles são redefinidos toda vez que você clica no botão.
 
-Esta solução é conveniente quando você tem apenas alguns componentes independentes renderizados no mesmo local. Neste exemplo, você tem apenas dois, então não é um incômodo renderizá-los separadamente no JSX.
+Esta solução é conveniente quando você tem apenas alguns componentes independentes renderizados no mesmo lugar. Neste exemplo, você tem apenas dois, então não é um incômodo renderizá-los separadamente no JSX.
 
 ### Opção 2: Redefinindo o estado com uma chave {/*option-2-resetting-state-with-a-key*/}
 
 Há também outra maneira, mais genérica, de redefinir o estado de um componente.
 
-Você pode ter visto `key`s ao [renderizar listas.](/learn/rendering-lists#keeping-list-items-in-order-with-key) As chaves não servem apenas para listas! Você pode usar chaves para fazer o React distinguir entre quaisquer componentes. Por padrão, o React usa a ordem dentro do pai ("primeiro contador", "segundo contador") para discernir entre componentes. Mas as chaves permitem que você diga ao React que este não é apenas um *primeiro* contador, ou um *segundo* contador, mas um contador específico - por exemplo, o contador *de Taylor*. Dessa forma, o React saberá o contador *de Taylor* onde quer que ele apareça na árvore!
+Você pode ter visto `key`s ao [renderizar listas.](/learn/rendering-lists#keeping-list-items-in-order-with-key) As chaves não servem apenas para listas! Você pode usar chaves para fazer o React distinguir entre quaisquer componentes. Por padrão, o React usa a ordem dentro do pai ("primeiro contador", "segundo contador") para discernir entre componentes. Mas as chaves permitem que você diga ao React que este não é apenas um *primeiro* contador ou um *segundo* contador, mas um contador específico - por exemplo, o contador *de Taylor*. Dessa forma, o React saberá o contador *de Taylor* onde quer que ele apareça na árvore!
 
 Neste exemplo, os dois `<Counter />`s não compartilham estado, mesmo que apareçam no mesmo lugar no JSX:
 
@@ -999,7 +999,7 @@ h1 {
 
 </Sandpack>
 
-Alternar entre Taylor e Sarah não preserva o estado. Isso ocorre porque **você deu a eles `key`s diferentes**:
+Alternar entre Taylor e Sarah não preserva o estado. Isso ocorre porque **você deu a eles `key`s diferentes:**
 
 ```js
 {isPlayerA ? (
@@ -1009,11 +1009,11 @@ Alternar entre Taylor e Sarah não preserva o estado. Isso ocorre porque **você
 )}
 ```
 
-Especificar uma `key` diz ao React para usar a própria `key` como parte da posição, em vez de sua ordem dentro do pai. É por isso que, mesmo que você os renderize no mesmo lugar no JSX, o React os vê como dois contadores diferentes, e assim eles nunca compartilharão estado. Toda vez que um contador aparece na tela, seu estado é criado. Toda vez que ele é removido, seu estado é destruído. Alternar entre eles reseta seus estados repetidamente.
+Especificar uma `key` diz ao React para usar a `key` em si como parte da posição, em vez de sua ordem dentro do pai. É por isso que, mesmo que você os renderize no mesmo lugar no JSX, o React os vê como dois contadores diferentes, e assim eles nunca compartilharão estado. Toda vez que um contador aparece na tela, seu estado é criado. Toda vez que ele é removido, seu estado é destruído. Alternar entre eles redefine seu estado repetidamente.
 
 <Note>
 
-Lembre-se que as chaves não são globalmente únicas. Elas apenas especificam a posição *dentro do pai*.
+Lembre-se de que as chaves não são globalmente exclusivas. Elas apenas especificam a posição *dentro do pai*.
 
 </Note>
 
@@ -1116,15 +1116,15 @@ textarea {
 
 </Sandpack>
 
-Tente digitar algo na entrada e, em seguida, pressione "Alice" ou "Bob" para escolher um destinatário diferente. Você notará que o estado da entrada é preservado porque o `<Chat>` é renderizado na mesma posição na árvore.
+Tente digitar algo na entrada e, em seguida, clique em "Alice" ou "Bob" para escolher um destinatário diferente. Você notará que o estado da entrada é preservado porque o `<Chat>` é renderizado na mesma posição na árvore.
 
-**Em muitos aplicativos, este pode ser o comportamento desejado, mas não em um aplicativo de chat!** Você não quer permitir que o usuário envie uma mensagem que já digitou para a pessoa errada devido a um clique acidental. Para corrigir isso, adicione uma `key`:
+**Em muitos aplicativos, este pode ser o comportamento desejado, mas não em um aplicativo de chat!** Você não quer que o usuário envie uma mensagem que já digitou para a pessoa errada devido a um clique acidental. Para corrigir isso, adicione uma `key`:
 
 ```js
 <Chat key={to.id} contact={to} />
 ```
 
-Isso garante que, ao selecionar um destinatário diferente, o componente `<Chat>` será recriado do zero, incluindo qualquer estado na árvore abaixo dele. O React também recriará os elementos DOM em vez de reutilizá-los.
+Isso garante que, quando você selecionar um destinatário diferente, o componente `<Chat>` será recriado do zero, incluindo qualquer estado na árvore abaixo dele. O React também recriará os elementos DOM em vez de reutilizá-los.
 
 Agora, alternar o destinatário sempre limpa o campo de texto:
 
@@ -1227,9 +1227,9 @@ textarea {
 
 Em um aplicativo de chat real, você provavelmente gostaria de recuperar o estado da entrada quando o usuário selecionar o destinatário anterior novamente. Existem algumas maneiras de manter o estado "vivo" para um componente que não está mais visível:
 
-- Você poderia renderizar _todos_ os chats em vez de apenas o atual, mas ocultar todos os outros com CSS. Os chats não seriam removidos da árvore, então seu estado local seria preservado. Essa solução funciona bem para interfaces de usuário simples. Mas pode ficar muito lento se as árvores ocultas forem grandes e contiverem muitos nós DOM.
-- Você poderia [elevar o estado](/learn/sharing-state-between-components) e manter a mensagem pendente para cada destinatário no componente pai. Dessa forma, quando os componentes filhos forem removidos, não importa, pois é o pai que mantém as informações importantes. Esta é a solução mais comum.
-- Você também pode usar uma fonte diferente além do estado do React. Por exemplo, você provavelmente quer que um rascunho de mensagem persista mesmo que o usuário feche acidentalmente a página. Para implementar isso, você pode fazer o componente `Chat` inicializar seu estado lendo do [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), e salvar os rascunhos lá também.
+- Você poderia renderizar _todos_ os chats em vez de apenas o atual, mas ocultar todos os outros com CSS. Os chats não seriam removidos da árvore, então seu estado local seria preservado. Essa solução funciona bem para interfaces simples. Mas pode ficar muito lenta se as árvores ocultas forem grandes e contiverem muitos nós DOM.
+- Você poderia [elevar o estado](/learn/sharing-state-between-components) e manter a mensagem pendente para cada destinatário no componente pai. Dessa forma, quando os componentes filhos forem removidos, não importa, porque é o pai que mantém as informações importantes. Esta é a solução mais comum.
+- Você também pode usar uma fonte diferente além do estado do React. Por exemplo, você provavelmente quer que um rascunho de mensagem persista mesmo que o usuário feche acidentalmente a página. Para implementar isso, você pode fazer o componente `<Chat>` inicializar seu estado lendo do [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) e salvar os rascunhos lá também.
 
 Não importa qual estratégia você escolha, um chat _com Alice_ é conceitualmente distinto de um chat _com Bob_, então faz sentido dar uma `key` à árvore `<Chat>` com base no destinatário atual.
 
@@ -1238,7 +1238,7 @@ Não importa qual estratégia você escolha, um chat _com Alice_ é conceitualme
 <Recap>
 
 - O React mantém o estado enquanto o mesmo componente for renderizado na mesma posição.
-- O estado não é mantido em tags JSX. Ele está associado à posição da árvore onde você colocou esse JSX.
+- O estado não é mantido em tags JSX. Ele está associado à posição na árvore onde você colocou esse JSX.
 - Você pode forçar uma subárvore a redefinir seu estado dando a ela uma chave diferente.
 - Não aninhe definições de componentes, ou você redefinirá o estado acidentalmente.
 
@@ -1248,7 +1248,7 @@ Não importa qual estratégia você escolha, um chat _com Alice_ é conceitualme
 
 <Challenges>
 
-#### Corrigir o texto de entrada desaparecendo {/*fix-disappearing-input-text*/}
+#### Corrigir o texto de entrada que desaparece {/*fix-disappearing-input-text*/}
 
 Este exemplo mostra uma mensagem quando você pressiona o botão. No entanto, pressionar o botão também redefine acidentalmente a entrada. Por que isso acontece? Corrija para que pressionar o botão não redefina o texto da entrada.
 
@@ -1401,13 +1401,13 @@ Dessa forma, `Form` é sempre o segundo filho, então ele permanece na mesma pos
 
 #### Trocar dois campos de formulário {/*swap-two-form-fields*/}
 
-Este formulário permite que você insira o primeiro e o último nome. Ele também tem uma caixa de seleção que controla qual campo vai primeiro. Quando você marca a caixa de seleção, o campo "Last name" aparecerá antes do campo "First name".
+Este formulário permite que você insira o primeiro e o último nome. Ele também tem uma caixa de seleção que controla qual campo vai primeiro. Quando você marca a caixa, o campo "Último nome" aparece antes do campo "Primeiro nome".
 
-Quase funciona, mas há um bug. Se você preencher o campo "First name" e marcar a caixa, o texto permanecerá no primeiro campo (que agora é "Last name"). Corrija para que o texto da entrada também se mova ao reverter a ordem.
+Quase funciona, mas há um bug. Se você preencher a entrada "Primeiro nome" e marcar a caixa, o texto permanecerá na primeira entrada (que agora é "Último nome"). Corrija para que o texto da entrada também se mova quando você inverter a ordem.
 
 <Hint>
 
-Parece que para esses campos, sua posição dentro do pai não é suficiente. Existe alguma maneira de dizer ao React como associar o estado entre as renderizações?
+Parece que, para esses campos, sua posição dentro do pai não é suficiente. Existe alguma maneira de dizer ao React como corresponder o estado entre as renderizações?
 
 </Hint>
 
@@ -1471,7 +1471,7 @@ label { display: block; margin: 10px 0; }
 
 <Solution>
 
-Dê uma `key` a ambos os componentes `<Field>` em ambos os ramos `if` e `else`. Isso diz ao React como "associar" o estado correto para qualquer `<Field>`, mesmo que sua ordem dentro do pai mude:
+Dê uma `key` a ambos os componentes `<Field>` em ambos os ramos `if` e `else`. Isso diz ao React como "combinar" o estado correto para qualquer `<Field>`, mesmo que sua ordem dentro do pai mude:
 
 <Sandpack>
 
@@ -1535,9 +1535,9 @@ label { display: block; margin: 10px 0; }
 
 #### Redefinir um formulário de detalhes {/*reset-a-detail-form*/}
 
-Esta é uma lista de contatos editável. Você pode editar os detalhes do contato selecionado e, em seguida, pressionar "Save" para atualizá-lo ou "Reset" para desfazer suas alterações.
+Esta é uma lista de contatos editável. Você pode editar os detalhes do contato selecionado e, em seguida, pressionar "Salvar" para atualizá-lo, ou "Redefinir" para desfazer suas alterações.
 
-Quando você seleciona um contato diferente (por exemplo, Alice), o estado é atualizado, mas o formulário continua mostrando os detalhes do contato anterior. Corrija para que o formulário seja redefinido quando o contato selecionado mudar.
+Quando você seleciona um contato diferente (por exemplo, Alice), o estado é atualizado, mas o formulário continua exibindo os detalhes do contato anterior. Corrija para que o formulário seja redefinido quando o contato selecionado mudar.
 
 <Sandpack>
 
@@ -1689,7 +1689,7 @@ button {
 
 <Solution>
 
-Dê `key={selectedId}` ao componente `EditContact`. Dessa forma, alternar entre diferentes contatos redefinirá o formulário:
+Dê `key={selectedId}` ao componente `EditContact`. Dessa forma, alternar entre contatos diferentes redefinirá o formulário:
 
 <Sandpack>
 
@@ -1842,9 +1842,9 @@ button {
 
 </Solution>
 
-#### Limpar uma imagem enquanto ela está carregando {/*clear-an-image-while-its-loading*/}
+#### Limpar uma imagem enquanto ela carrega {/*clear-an-image-while-its-loading*/}
 
-Quando você pressiona "Next", o navegador começa a carregar a próxima imagem. No entanto, como ela é exibida na mesma tag `<img>`, por padrão você ainda veria a imagem anterior até que a próxima carregasse. Isso pode ser indesejável se for importante que o texto sempre corresponda à imagem. Altere para que, no momento em que você pressionar "Next", a imagem anterior seja limpa imediatamente.
+Ao pressionar "Próximo", o navegador começa a carregar a próxima imagem. No entanto, como ela é exibida na mesma tag `<img>`, por padrão você ainda veria a imagem anterior até que a próxima carregasse. Isso pode ser indesejável se for importante que o texto sempre corresponda à imagem. Altere para que, no momento em que você pressionar "Próximo", a imagem anterior seja imediatamente limpa.
 
 <Hint>
 
@@ -1918,7 +1918,7 @@ img { width: 150px; height: 150px; }
 
 <Solution>
 
-Você pode fornecer uma `key` à tag `<img>`. Quando essa `key` mudar, o React recriará o nó DOM `<img>` do zero. Isso causa um breve flash quando cada imagem carrega, então não é algo que você queira fazer para cada imagem em seu aplicativo. Mas faz sentido se você quiser garantir que a imagem sempre corresponda ao texto.
+Você pode fornecer uma `key` para a tag `<img>`. Quando essa `key` muda, o React recria o nó DOM `<img>` do zero. Isso causa um breve flash quando cada imagem carrega, então não é algo que você queira fazer para todas as imagens em seu aplicativo. Mas faz sentido se você quiser garantir que a imagem sempre corresponda ao texto.
 
 <Sandpack>
 
@@ -1986,9 +1986,9 @@ img { width: 150px; height: 150px; }
 
 </Solution>
 
-#### Corrigir estado mal posicionado na lista {/*fix-misplaced-state-in-the-list*/}
+#### Corrigir estado mal colocado na lista {/*fix-misplaced-state-in-the-list*/}
 
-Nesta lista, cada `Contact` tem um estado que determina se "Mostrar e-mail" foi pressionado para ele. Pressione "Mostrar e-mail" para Alice e, em seguida, marque a caixa de seleção "Mostrar em ordem inversa". Você notará que é o e-mail de _Taylor_ que está expandido agora, mas o de Alice - que se moveu para o final - aparece recolhido.
+Nesta lista, cada `Contact` tem um estado que determina se "Mostrar e-mail" foi pressionado para ele. Pressione "Mostrar e-mail" para Alice e, em seguida, marque a caixa de seleção "Mostrar em ordem inversa". Você notará que é o e-mail de _Taylor_ que está expandido agora, mas o de Alice - que foi para o final - aparece recolhido.
 
 Corrija para que o estado expandido seja associado a cada contato, independentemente da ordem escolhida.
 
@@ -2016,7 +2016,7 @@ export default function ContactList() {
             setReverse(e.target.checked)
           }}
         />{' '}
-        Mostrar em ordem inversa
+        Show in reverse order
       </label>
       <ul>
         {displayedContacts.map((contact, i) =>
@@ -2050,7 +2050,7 @@ export default function Contact({ contact }) {
       <button onClick={() => {
         setExpanded(!expanded);
       }}>
-        {expanded ? 'Esconder' : 'Mostrar'} e-mail
+        {expanded ? 'Hide' : 'Show'} email
       </button>
     </>
   );
@@ -2115,7 +2115,7 @@ export default function ContactList() {
             setReverse(e.target.checked)
           }}
         />{' '}
-        Mostrar em ordem inversa
+        Show in reverse order
       </label>
       <ul>
         {displayedContacts.map(contact =>
@@ -2149,7 +2149,7 @@ export default function Contact({ contact }) {
       <button onClick={() => {
         setExpanded(!expanded);
       }}>
-        {expanded ? 'Esconder' : 'Mostrar'} e-mail
+        {expanded ? 'Hide' : 'Show'} email
       </button>
     </>
   );

--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -4,25 +4,25 @@ title: Preserving and Resetting State
 
 <Intro>
 
-State is isolated between components. React keeps track of which state belongs to which component based on their place in the UI tree. You can control when to preserve state and when to reset it between re-renders.
+O estado é isolado entre componentes. O React acompanha qual estado pertence a qual componente com base em sua posição na árvore de UI. Você pode controlar quando preservar o estado e quando redefini-lo entre as re-renderizações.
 
 </Intro>
 
 <YouWillLearn>
 
-* When React chooses to preserve or reset the state
-* How to force React to reset component's state
-* How keys and types affect whether the state is preserved
+* Quando o React escolhe preservar ou redefinir o estado
+* Como forçar o React a redefinir o estado de um componente
+* Como as chaves e os tipos afetam se o estado é preservado
 
 </YouWillLearn>
 
-## State is tied to a position in the render tree {/*state-is-tied-to-a-position-in-the-tree*/}
+## O estado está vinculado a uma posição na árvore de renderização {/*state-is-tied-to-a-position-in-the-tree*/}
 
-React builds [render trees](learn/understanding-your-ui-as-a-tree#the-render-tree) for the component structure in your UI.
+O React constrói [árvores de renderização](learn/understanding-your-ui-as-a-tree#the-render-tree) para a estrutura de componentes em sua UI.
 
-When you give a component state, you might think the state "lives" inside the component. But the state is actually held inside React. React associates each piece of state it's holding with the correct component by where that component sits in the render tree.
+Quando você dá estado a um componente, pode pensar que o estado "vive" dentro do componente. Mas o estado é, na verdade, mantido dentro do React. O React associa cada pedaço de estado que está mantendo ao componente correto pela sua posição na árvore de renderização.
 
-Here, there is only one `<Counter />` JSX tag, but it's rendered at two different positions:
+Aqui, há apenas uma tag JSX `<Counter />`, mas ela é renderizada em duas posições diferentes:
 
 <Sandpack>
 
@@ -86,23 +86,23 @@ label {
 
 </Sandpack>
 
-Here's how these look as a tree:
+Veja como eles se parecem como uma árvore:
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_tree" height={248} width={395} alt="Diagram of a tree of React components. The root node is labeled 'div' and has two children. Each of the children are labeled 'Counter' and both contain a state bubble labeled 'count' with value 0.">
+<Diagram name="preserving_state_tree" height={248} width={395} alt="Diagrama de uma árvore de componentes React. O nó raiz é rotulado 'div' e tem dois filhos. Cada um dos filhos é rotulado 'Counter' e ambos contêm uma bolha de estado rotulada 'count' com valor 0.">
 
-React tree
+Árvore do React
 
 </Diagram>
 
 </DiagramGroup>
 
-**These are two separate counters because each is rendered at its own position in the tree.** You don't usually have to think about these positions to use React, but it can be useful to understand how it works.
+**Estes são dois contadores separados porque cada um é renderizado em sua própria posição na árvore.** Você normalmente não precisa pensar nessas posições para usar o React, mas pode ser útil entender como funciona.
 
-In React, each component on the screen has fully isolated state. For example, if you render two `Counter` components side by side, each of them will get its own, independent, `score` and `hover` states.
+No React, cada componente na tela tem um estado totalmente isolado. Por exemplo, se você renderizar dois componentes `Counter` lado a lado, cada um deles receberá seu próprio estado `score` e `hover` independente.
 
-Try clicking both counters and notice they don't affect each other:
+Tente clicar em ambos os contadores e observe que eles não afetam um ao outro:
 
 <Sandpack>
 
@@ -160,21 +160,21 @@ function Counter() {
 
 </Sandpack>
 
-As you can see, when one counter is updated, only the state for that component is updated:
+Como você pode ver, quando um contador é atualizado, apenas o estado desse componente é atualizado:
 
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_increment" height={248} width={441} alt="Diagram of a tree of React components. The root node is labeled 'div' and has two children. The left child is labeled 'Counter' and contains a state bubble labeled 'count' with value 0. The right child is labeled 'Counter' and contains a state bubble labeled 'count' with value 1. The state bubble of the right child is highlighted in yellow to indicate its value has updated.">
+<Diagram name="preserving_state_increment" height={248} width={441} alt="Diagrama de uma árvore de componentes React. O nó raiz é rotulado 'div' e tem dois filhos. O filho esquerdo é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0. O filho direito é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 1. A bolha de estado do filho direito está destacada em amarelo para indicar que seu valor foi atualizado.">
 
-Updating state
+Atualizando o estado
 
 </Diagram>
 
 </DiagramGroup>
 
 
-React will keep the state around for as long as you render the same component at the same position in the tree. To see this, increment both counters, then remove the second component by unchecking "Render the second counter" checkbox, and then add it back by ticking it again:
+O React manterá o estado ativo enquanto você renderizar o mesmo componente na mesma posição na árvore. Para ver isso, incremente ambos os contadores, depois remova o segundo componente desmarcando a caixa de seleção "Renderizar o segundo contador" e, em seguida, adicione-o de volta marcando-a novamente:
 
 <Sandpack>
 
@@ -248,35 +248,35 @@ label {
 
 </Sandpack>
 
-Notice how the moment you stop rendering the second counter, its state disappears completely. That's because when React removes a component, it destroys its state.
+Note como no momento em que você para de renderizar o segundo contador, seu estado desaparece completamente. Isso ocorre porque, quando o React remove um componente, ele destrói seu estado.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_remove_component" height={253} width={422} alt="Diagram of a tree of React components. The root node is labeled 'div' and has two children. The left child is labeled 'Counter' and contains a state bubble labeled 'count' with value 0. The right child is missing, and in its place is a yellow 'poof' image, highlighting the component being deleted from the tree.">
+<Diagram name="preserving_state_remove_component" height={253} width={422} alt="Diagrama de uma árvore de componentes React. O nó raiz é rotulado 'div' e tem dois filhos. O filho esquerdo é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0. O filho direito está faltando e em seu lugar há uma imagem de 'poof' amarela, destacando o componente sendo excluído da árvore.">
 
-Deleting a component
+Excluindo um componente
 
 </Diagram>
 
 </DiagramGroup>
 
-When you tick "Render the second counter", a second `Counter` and its state are initialized from scratch (`score = 0`) and added to the DOM.
+Quando você marca "Renderizar o segundo contador", um segundo `Counter` e seu estado são inicializados do zero (`score = 0`) e adicionados ao DOM.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_add_component" height={258} width={500} alt="Diagram of a tree of React components. The root node is labeled 'div' and has two children. The left child is labeled 'Counter' and contains a state bubble labeled 'count' with value 0. The right child is labeled 'Counter' and contains a state bubble labeled 'count' with value 0. The entire right child node is highlighted in yellow, indicating that it was just added to the tree.">
+<Diagram name="preserving_state_add_component" height={258} width={500} alt="Diagrama de uma árvore de componentes React. O nó raiz é rotulado 'div' e tem dois filhos. O filho esquerdo é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0. O filho direito é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0. Todo o nó filho direito está destacado em amarelo, indicando que ele acabou de ser adicionado à árvore.">
 
-Adding a component
+Adicionando um componente
 
 </Diagram>
 
 </DiagramGroup>
 
-**React preserves a component's state for as long as it's being rendered at its position in the UI tree.** If it gets removed, or a different component gets rendered at the same position, React discards its state.
+**O React preserva o estado de um componente enquanto ele estiver sendo renderizado em sua posição na árvore de UI.** Se ele for removido, ou um componente diferente for renderizado na mesma posição, o React descarta seu estado.
 
-## Same component at the same position preserves state {/*same-component-at-the-same-position-preserves-state*/}
+## O mesmo componente na mesma posição preserva o estado {/*same-component-at-the-same-position-preserves-state*/}
 
-In this example, there are two different `<Counter />` tags:
+Neste exemplo, existem duas tags `<Counter />` diferentes:
 
 <Sandpack>
 
@@ -361,24 +361,24 @@ label {
 
 </Sandpack>
 
-When you tick or clear the checkbox, the counter state does not get reset. Whether `isFancy` is `true` or `false`, you always have a `<Counter />` as the first child of the `div` returned from the root `App` component:
+Quando você marca ou desmarca a caixa de seleção, o estado do contador não é redefinido. Se `isFancy` for `true` ou `false`, você sempre terá um `<Counter />` como o primeiro filho do `div` retornado do componente raiz `App`:
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_same_component" height={461} width={600} alt="Diagram with two sections separated by an arrow transitioning between them. Each section contains a layout of components with a parent labeled 'App' containing a state bubble labeled isFancy. This component has one child labeled 'div', which leads to a prop bubble containing isFancy (highlighted in purple) passed down to the only child. The last child is labeled 'Counter' and contains a state bubble with label 'count' and value 3 in both diagrams. In the left section of the diagram, nothing is highlighted and the isFancy parent state value is false. In the right section of the diagram, the isFancy parent state value has changed to true and it is highlighted in yellow, and so is the props bubble below, which has also changed its isFancy value to true.">
+<Diagram name="preserving_state_same_component" height={461} width={600} alt="Diagrama com duas seções separadas por uma seta fazendo a transição entre elas. Cada seção contém um layout de componentes com um pai rotulado 'App' contendo uma bolha de estado rotulada isFancy. Este componente tem um filho rotulado 'div', que leva a uma bolha de props contendo isFancy (destacada em roxo) passada para o único filho. O último filho é rotulado 'Counter' e contém uma bolha de estado com o rótulo 'count' e valor 3 em ambos os diagramas. Na seção esquerda do diagrama, nada está destacado e o valor do estado pai isFancy é falso. Na seção direita do diagrama, o valor do estado pai isFancy mudou para true e ele está destacado em amarelo, assim como a bolha de props abaixo, que também mudou seu valor isFancy para true.">
 
-Updating the `App` state does not reset the `Counter` because `Counter` stays in the same position
+Atualizar o estado do `App` não redefine o `Counter` porque o `Counter` permanece na mesma posição
 
 </Diagram>
 
 </DiagramGroup>
 
 
-It's the same component at the same position, so from React's perspective, it's the same counter.
+É o mesmo componente na mesma posição, então, da perspectiva do React, é o mesmo contador.
 
 <Pitfall>
 
-Remember that **it's the position in the UI tree--not in the JSX markup--that matters to React!** This component has two `return` clauses with different `<Counter />` JSX tags inside and outside the `if`:
+Lembre-se de que **é a posição na árvore de UI — não no markup JSX — que importa para o React!** Este componente tem duas cláusulas `return` com tags JSX `<Counter />` diferentes dentro e fora do `if`:
 
 <Sandpack>
 
@@ -476,15 +476,15 @@ label {
 
 </Sandpack>
 
-You might expect the state to reset when you tick checkbox, but it doesn't! This is because **both of these `<Counter />` tags are rendered at the same position.** React doesn't know where you place the conditions in your function. All it "sees" is the tree you return.
+Você pode esperar que o estado seja redefinido ao marcar a caixa de seleção, mas não é! Isso ocorre porque **ambas essas tags `<Counter />` são renderizadas na mesma posição.** O React não sabe onde você coloca as condições em sua função. Tudo o que ele "vê" é a árvore que você retorna.
 
-In both cases, the `App` component returns a `<div>` with `<Counter />` as a first child. To React, these two counters have the same "address": the first child of the first child of the root. This is how React matches them up between the previous and next renders, regardless of how you structure your logic.
+Em ambos os casos, o componente `App` retorna um `<div>` com `<Counter />` como primeiro filho. Para o React, esses dois contadores têm o mesmo "endereço": o primeiro filho do primeiro filho da raiz. É assim que o React os associa entre a renderização anterior e a próxima, independentemente de como você estrutura sua lógica.
 
 </Pitfall>
 
-## Different components at the same position reset state {/*different-components-at-the-same-position-reset-state*/}
+## Componentes diferentes na mesma posição redefinem o estado {/*different-components-at-the-same-position-reset-state*/}
 
-In this example, ticking the checkbox will replace `<Counter>` with a `<p>`:
+Neste exemplo, marcar a caixa de seleção substituirá `<Counter>` por um `<p>`:
 
 <Sandpack>
 
@@ -561,13 +561,13 @@ label {
 
 </Sandpack>
 
-Here, you switch between _different_ component types at the same position. Initially, the first child of the `<div>` contained a `Counter`. But when you swapped in a `p`, React removed the `Counter` from the UI tree and destroyed its state.
+Aqui, você alterna entre tipos de componentes _diferentes_ na mesma posição. Inicialmente, o primeiro filho do `<div>` continha um `Counter`. Mas quando você trocou por um `p`, o React removeu o `Counter` da árvore de UI e destruiu seu estado.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_pt1" height={290} width={753} alt="Diagram with three sections, with an arrow transitioning each section in between. The first section contains a React component labeled 'div' with a single child labeled 'Counter' containing a state bubble labeled 'count' with value 3. The middle section has the same 'div' parent, but the child component has now been deleted, indicated by a yellow 'proof' image. The third section has the same 'div' parent again, now with a new child labeled 'p', highlighted in yellow.">
+<Diagram name="preserving_state_diff_pt1" height={290} width={753} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas o componente filho foi excluído, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'p', destacado em amarelo.">
 
-When `Counter` changes to `p`, the `Counter` is deleted and the `p` is added
+Quando `Counter` muda para `p`, o `Counter` é excluído e o `p` é adicionado
 
 </Diagram>
 
@@ -575,15 +575,15 @@ When `Counter` changes to `p`, the `Counter` is deleted and the `p` is added
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_pt2" height={290} width={753} alt="Diagram with three sections, with an arrow transitioning each section in between. The first section contains a React component labeled 'p'. The middle section has the same 'div' parent, but the child component has now been deleted, indicated by a yellow 'proof' image. The third section has the same 'div' parent again, now with a new child labeled 'Counter' containing a state bubble labeled 'count' with value 0, highlighted in yellow.">
+<Diagram name="preserving_state_diff_pt2" height={290} width={753} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'p'. A seção do meio tem o mesmo pai 'div', mas o componente filho foi excluído, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, destacado em amarelo.">
 
-When switching back, the `p` is deleted and the `Counter` is added
+Ao alternar de volta, o `p` é excluído e o `Counter` é adicionado
 
 </Diagram>
 
 </DiagramGroup>
 
-Also, **when you render a different component in the same position, it resets the state of its entire subtree.** To see how this works, increment the counter and then tick the checkbox:
+Além disso, **quando você renderiza um componente diferente na mesma posição, ele redefine o estado de toda a sua subárvore.** Para ver como isso funciona, incremente o contador e depois marque a caixa de seleção:
 
 <Sandpack>
 
@@ -672,13 +672,13 @@ label {
 
 </Sandpack>
 
-The counter state gets reset when you click the checkbox. Although you render a `Counter`, the first child of the `div` changes from a `section` to a `div`. When the child `section` was removed from the DOM, the whole tree below it (including the `Counter` and its state) was destroyed as well.
+O estado do contador é redefinido quando você clica na caixa de seleção. Embora você renderize um `Counter`, o primeiro filho do `div` muda de uma `section` para um `div`. Quando o `section` filho foi removido do DOM, toda a árvore abaixo dele (incluindo o `Counter` e seu estado) também foi destruída.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_same_pt1" height={350} width={794} alt="Diagram with three sections, with an arrow transitioning each section in between. The first section contains a React component labeled 'div' with a single child labeled 'section', which has a single child labeled 'Counter' containing a state bubble labeled 'count' with value 3. The middle section has the same 'div' parent, but the child components have now been deleted, indicated by a yellow 'proof' image. The third section has the same 'div' parent again, now with a new child labeled 'div', highlighted in yellow, also with a new child labeled 'Counter' containing a state bubble labeled 'count' with value 0, all highlighted in yellow.">
+<Diagram name="preserving_state_diff_same_pt1" height={350} width={794} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'section', que tem um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram excluídos, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'div', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, todos destacados em amarelo.">
 
-When `section` changes to `div`, the `section` is deleted and the new `div` is added
+Quando `section` muda para `div`, o `section` é excluído e o novo `div` é adicionado
 
 </Diagram>
 
@@ -686,21 +686,21 @@ When `section` changes to `div`, the `section` is deleted and the new `div` is a
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_same_pt2" height={350} width={794} alt="Diagram with three sections, with an arrow transitioning each section in between. The first section contains a React component labeled 'div' with a single child labeled 'div', which has a single child labeled 'Counter' containing a state bubble labeled 'count' with value 0. The middle section has the same 'div' parent, but the child components have now been deleted, indicated by a yellow 'proof' image. The third section has the same 'div' parent again, now with a new child labeled 'section', highlighted in yellow, also with a new child labeled 'Counter' containing a state bubble labeled 'count' with value 0, all highlighted in yellow.">
+<Diagram name="preserving_state_diff_same_pt2" height={350} width={794} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React rotulado 'div' com um único filho rotulado 'div', que tem um único filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram excluídos, indicado por uma imagem 'poof' amarela. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'section', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, todos destacados em amarelo.">
 
-When switching back, the `div` is deleted and the new `section` is added
+Ao alternar de volta, o `div` é excluído e o novo `section` é adicionado
 
 </Diagram>
 
 </DiagramGroup>
 
-As a rule of thumb, **if you want to preserve the state between re-renders, the structure of your tree needs to "match up"** from one render to another. If the structure is different, the state gets destroyed because React destroys state when it removes a component from the tree.
+Como regra geral, **se você quiser preservar o estado entre as re-renderizações, a estrutura da sua árvore precisa "corresponder"** de uma renderização para outra. Se a estrutura for diferente, o estado é destruído porque o React destrói o estado quando remove um componente da árvore.
 
 <Pitfall>
 
-This is why you should not nest component function definitions.
+É por isso que você não deve aninhar definições de funções de componentes.
 
-Here, the `MyTextField` component function is defined *inside* `MyComponent`:
+Aqui, a função do componente `MyTextField` é definida *dentro* de `MyComponent`:
 
 <Sandpack>
 
@@ -735,13 +735,13 @@ export default function MyComponent() {
 </Sandpack>
 
 
-Every time you click the button, the input state disappears! This is because a *different* `MyTextField` function is created for every render of `MyComponent`. You're rendering a *different* component in the same position, so React resets all state below. This leads to bugs and performance problems. To avoid this problem, **always declare component functions at the top level, and don't nest their definitions.**
+Toda vez que você clica no botão, o estado do input desaparece! Isso ocorre porque uma função `MyTextField` *diferente* é criada para cada renderização de `MyComponent`. Você está renderizando um componente *diferente* na mesma posição, então o React redefine todo o estado abaixo. Isso leva a bugs e problemas de desempenho. Para evitar esse problema, **sempre declare funções de componentes no nível superior e não aninhe suas definições.**
 
 </Pitfall>
 
-## Resetting state at the same position {/*resetting-state-at-the-same-position*/}
+## Resetando o estado na mesma posição {/*resetting-state-at-the-same-position*/}
 
-By default, React preserves state of a component while it stays at the same position. Usually, this is exactly what you want, so it makes sense as the default behavior. But sometimes, you may want to reset a component's state. Consider this app that lets two players keep track of their scores during each turn:
+Por padrão, o React preserva o estado de um componente enquanto ele permanece na mesma posição. Geralmente, é exatamente isso que você deseja, então faz sentido como comportamento padrão. Mas, às vezes, você pode querer resetar o estado de um componente. Considere este aplicativo que permite que dois jogadores acompanhem suas pontuações em cada turno:
 
 <Sandpack>
 
@@ -760,7 +760,7 @@ export default function Scoreboard() {
       <button onClick={() => {
         setIsPlayerA(!isPlayerA);
       }}>
-        Next player!
+        Próximo jogador!
       </button>
     </div>
   );
@@ -781,9 +781,9 @@ function Counter({ person }) {
       onPointerEnter={() => setHover(true)}
       onPointerLeave={() => setHover(false)}
     >
-      <h1>{person}'s score: {score}</h1>
+      <h1>Pontuação de {person}: {score}</h1>
       <button onClick={() => setScore(score + 1)}>
-        Add one
+        Adicionar um
       </button>
     </div>
   );
@@ -811,19 +811,19 @@ h1 {
 
 </Sandpack>
 
-Currently, when you change the player, the score is preserved. The two `Counter`s appear in the same position, so React sees them as *the same* `Counter` whose `person` prop has changed.
+Atualmente, ao trocar de jogador, a pontuação é preservada. Os dois `Counter`s aparecem na mesma posição, então o React os considera o *mesmo* `Counter` cuja prop `person` foi alterada.
 
-But conceptually, in this app they should be two separate counters. They might appear in the same place in the UI, but one is a counter for Taylor, and another is a counter for Sarah.
+Mas conceitualmente, neste aplicativo, eles deveriam ser dois contadores separados. Eles podem aparecer no mesmo lugar na UI, mas um é um contador para Taylor e outro é para Sarah.
 
-There are two ways to reset state when switching between them:
+Existem duas maneiras de resetar o estado ao alternar entre eles:
 
-1. Render components in different positions
-2. Give each component an explicit identity with `key`
+1. Renderizar componentes em posições diferentes
+2. Dar a cada componente uma identidade explícita com `key`
 
 
-### Option 1: Rendering a component in different positions {/*option-1-rendering-a-component-in-different-positions*/}
+### Opção 1: Renderizando um componente em posições diferentes {/*option-1-rendering-a-component-in-different-positions*/}
 
-If you want these two `Counter`s to be independent, you can render them in two different positions:
+Se você deseja que esses dois `Counter`s sejam independentes, pode renderizá-los em duas posições diferentes:
 
 <Sandpack>
 
@@ -843,7 +843,7 @@ export default function Scoreboard() {
       <button onClick={() => {
         setIsPlayerA(!isPlayerA);
       }}>
-        Next player!
+        Próximo jogador!
       </button>
     </div>
   );
@@ -864,9 +864,9 @@ function Counter({ person }) {
       onPointerEnter={() => setHover(true)}
       onPointerLeave={() => setHover(false)}
     >
-      <h1>{person}'s score: {score}</h1>
+      <h1>Pontuação de {person}: {score}</h1>
       <button onClick={() => setScore(score + 1)}>
-        Add one
+        Adicionar um
       </button>
     </div>
   );
@@ -894,42 +894,42 @@ h1 {
 
 </Sandpack>
 
-* Initially, `isPlayerA` is `true`. So the first position contains `Counter` state, and the second one is empty.
-* When you click the "Next player" button the first position clears but the second one now contains a `Counter`.
+* Inicialmente, `isPlayerA` é `true`. Portanto, a primeira posição contém o estado do `Counter`, e a segunda está vazia.
+* Ao clicar no botão "Próximo jogador", a primeira posição é limpa, mas a segunda agora contém um `Counter`.
 
 <DiagramGroup>
 
-<Diagram name="preserving_state_diff_position_p1" height={375} width={504} alt="Diagram with a tree of React components. The parent is labeled 'Scoreboard' with a state bubble labeled isPlayerA with value 'true'. The only child, arranged to the left, is labeled Counter with a state bubble labeled 'count' and value 0. All of the left child is highlighted in yellow, indicating it was added.">
+<Diagram name="preserving_state_diff_position_p1" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'true'. O único filho, organizado à esquerda, é rotulado Counter com uma bolha de estado rotulada 'count' e valor 0. Todo o filho esquerdo está destacado em amarelo, indicando que foi adicionado.">
 
-Initial state
-
-</Diagram>
-
-<Diagram name="preserving_state_diff_position_p2" height={375} width={504} alt="Diagram with a tree of React components. The parent is labeled 'Scoreboard' with a state bubble labeled isPlayerA with value 'false'. The state bubble is highlighted in yellow, indicating that it has changed. The left child is replaced with a yellow 'poof' image indicating that it has been deleted and there is a new child on the right, highlighted in yellow indicating that it was added. The new child is labeled 'Counter' and contains a state bubble labeled 'count' with value 0.">
-
-Clicking "next"
+Estado inicial
 
 </Diagram>
 
-<Diagram name="preserving_state_diff_position_p3" height={375} width={504} alt="Diagram with a tree of React components. The parent is labeled 'Scoreboard' with a state bubble labeled isPlayerA with value 'true'. The state bubble is highlighted in yellow, indicating that it has changed. There is a new child on the left, highlighted in yellow indicating that it was added. The new child is labeled 'Counter' and contains a state bubble labeled 'count' with value 0. The right child is replaced with a yellow 'poof' image indicating that it has been deleted.">
+<Diagram name="preserving_state_diff_position_p2" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'false'. A bolha de estado está destacada em amarelo, indicando que foi alterada. O filho esquerdo é substituído por uma imagem de 'poof' amarela indicando que foi excluído e há um novo filho à direita, destacado em amarelo indicando que foi adicionado. O novo filho é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0.">
 
-Clicking "next" again
+Clicando em "próximo"
+
+</Diagram>
+
+<Diagram name="preserving_state_diff_position_p3" height={375} width={504} alt="Diagrama com uma árvore de componentes React. O pai é rotulado 'Scoreboard' com uma bolha de estado rotulada isPlayerA com o valor 'true'. A bolha de estado está destacada em amarelo, indicando que foi alterada. Há um novo filho à esquerda, destacado em amarelo indicando que foi adicionado. O novo filho é rotulado 'Counter' e contém uma bolha de estado rotulada 'count' com valor 0. O filho direito é substituído por uma imagem de 'poof' amarela indicando que foi excluído.">
+
+Clicando em "próximo" novamente
 
 </Diagram>
 
 </DiagramGroup>
 
-Each `Counter`'s state gets destroyed each time it's removed from the DOM. This is why they reset every time you click the button.
+O estado de cada `Counter` é destruído toda vez que ele é removido do DOM. É por isso que eles resetam toda vez que você clica no botão.
 
-This solution is convenient when you only have a few independent components rendered in the same place. In this example, you only have two, so it's not a hassle to render both separately in the JSX.
+Esta solução é conveniente quando você tem apenas alguns componentes independentes renderizados no mesmo local. Neste exemplo, você tem apenas dois, então não é um incômodo renderizá-los separadamente no JSX.
 
-### Option 2: Resetting state with a key {/*option-2-resetting-state-with-a-key*/}
+### Opção 2: Resetando o estado com uma chave {/*option-2-resetting-state-with-a-key*/}
 
-There is also another, more generic, way to reset a component's state.
+Há também outra maneira, mais genérica, de resetar o estado de um componente.
 
-You might have seen `key`s when [rendering lists.](/learn/rendering-lists#keeping-list-items-in-order-with-key) Keys aren't just for lists! You can use keys to make React distinguish between any components. By default, React uses order within the parent ("first counter", "second counter") to discern between components. But keys let you tell React that this is not just a *first* counter, or a *second* counter, but a specific counter--for example, *Taylor's* counter. This way, React will know *Taylor's* counter wherever it appears in the tree!
+Você pode ter visto `key`s ao [renderizar listas.](/learn/rendering-lists#keeping-list-items-in-order-with-key) As chaves não servem apenas para listas! Você pode usar chaves para fazer o React distinguir entre quaisquer componentes. Por padrão, o React usa a ordem dentro do pai ("primeiro contador", "segundo contador") para discernir entre componentes. Mas as chaves permitem que você diga ao React que este não é apenas um *primeiro* contador, ou um *segundo* contador, mas um contador específico - por exemplo, o contador *de Taylor*. Dessa forma, o React saberá o contador *de Taylor* onde quer que ele apareça na árvore!
 
-In this example, the two `<Counter />`s don't share state even though they appear in the same place in JSX:
+Neste exemplo, os dois `<Counter />`s não compartilham estado, mesmo que apareçam no mesmo lugar no JSX:
 
 <Sandpack>
 
@@ -948,7 +948,7 @@ export default function Scoreboard() {
       <button onClick={() => {
         setIsPlayerA(!isPlayerA);
       }}>
-        Next player!
+        Próximo jogador!
       </button>
     </div>
   );
@@ -969,9 +969,9 @@ function Counter({ person }) {
       onPointerEnter={() => setHover(true)}
       onPointerLeave={() => setHover(false)}
     >
-      <h1>{person}'s score: {score}</h1>
+      <h1>Pontuação de {person}: {score}</h1>
       <button onClick={() => setScore(score + 1)}>
-        Add one
+        Adicionar um
       </button>
     </div>
   );
@@ -999,7 +999,7 @@ h1 {
 
 </Sandpack>
 
-Switching between Taylor and Sarah does not preserve the state. This is because **you gave them different `key`s:**
+Alternar entre Taylor e Sarah não preserva o estado. Isso ocorre porque **você deu a eles `key`s diferentes**:
 
 ```js
 {isPlayerA ? (
@@ -1009,19 +1009,19 @@ Switching between Taylor and Sarah does not preserve the state. This is because 
 )}
 ```
 
-Specifying a `key` tells React to use the `key` itself as part of the position, instead of their order within the parent. This is why, even though you render them in the same place in JSX, React sees them as two different counters, and so they will never share state. Every time a counter appears on the screen, its state is created. Every time it is removed, its state is destroyed. Toggling between them resets their state over and over.
+Especificar uma `key` diz ao React para usar a própria `key` como parte da posição, em vez de sua ordem dentro do pai. É por isso que, mesmo que você os renderize no mesmo lugar no JSX, o React os vê como dois contadores diferentes, e assim eles nunca compartilharão estado. Toda vez que um contador aparece na tela, seu estado é criado. Toda vez que ele é removido, seu estado é destruído. Alternar entre eles reseta seus estados repetidamente.
 
 <Note>
 
-Remember that keys are not globally unique. They only specify the position *within the parent*.
+Lembre-se que as chaves não são globalmente únicas. Elas apenas especificam a posição *dentro do pai*.
 
 </Note>
 
-### Resetting a form with a key {/*resetting-a-form-with-a-key*/}
+### Resetando um formulário com uma chave {/*resetting-a-form-with-a-key*/}
 
-Resetting state with a key is particularly useful when dealing with forms.
+Resetar o estado com uma chave é particularmente útil ao lidar com formulários.
 
-In this chat app, the `<Chat>` component contains the text input state:
+Neste aplicativo de chat, o componente `<Chat>` contém o estado da entrada de texto:
 
 <Sandpack>
 
@@ -1116,17 +1116,17 @@ textarea {
 
 </Sandpack>
 
-Try entering something into the input, and then press "Alice" or "Bob" to choose a different recipient. You will notice that the input state is preserved because the `<Chat>` is rendered at the same position in the tree.
+Tente digitar algo na entrada e, em seguida, pressione "Alice" ou "Bob" para escolher um destinatário diferente. Você notará que o estado da entrada é preservado porque o `<Chat>` é renderizado na mesma posição na árvore.
 
-**In many apps, this may be the desired behavior, but not in a chat app!** You don't want to let the user send a message they already typed to a wrong person due to an accidental click. To fix it, add a `key`:
+**Em muitos aplicativos, este pode ser o comportamento desejado, mas não em um aplicativo de chat!** Você não quer permitir que o usuário envie uma mensagem que já digitou para a pessoa errada devido a um clique acidental. Para corrigir isso, adicione uma `key`:
 
 ```js
 <Chat key={to.id} contact={to} />
 ```
 
-This ensures that when you select a different recipient, the `Chat` component will be recreated from scratch, including any state in the tree below it. React will also re-create the DOM elements instead of reusing them.
+Isso garante que, ao selecionar um destinatário diferente, o componente `<Chat>` será recriado do zero, incluindo qualquer estado na árvore abaixo dele. O React também recriará os elementos DOM em vez de reutilizá-los.
 
-Now switching the recipient always clears the text field:
+Agora, alternar o destinatário sempre limpa o campo de texto:
 
 <Sandpack>
 
@@ -1223,24 +1223,24 @@ textarea {
 
 <DeepDive>
 
-#### Preserving state for removed components {/*preserving-state-for-removed-components*/}
+#### Preservando o estado para componentes removidos {/*preserving-state-for-removed-components*/}
 
-In a real chat app, you'd probably want to recover the input state when the user selects the previous recipient again. There are a few ways to keep the state "alive" for a component that's no longer visible:
+Em um aplicativo de chat real, você provavelmente gostaria de recuperar o estado da entrada quando o usuário selecionar o destinatário anterior novamente. Existem algumas maneiras de manter o estado "vivo" para um componente que não está mais visível:
 
-- You could render _all_ chats instead of just the current one, but hide all the others with CSS. The chats would not get removed from the tree, so their local state would be preserved. This solution works great for simple UIs. But it can get very slow if the hidden trees are large and contain a lot of DOM nodes.
-- You could [lift the state up](/learn/sharing-state-between-components) and hold the pending message for each recipient in the parent component. This way, when the child components get removed, it doesn't matter, because it's the parent that keeps the important information. This is the most common solution.
-- You might also use a different source in addition to React state. For example, you probably want a message draft to persist even if the user accidentally closes the page. To implement this, you could have the `Chat` component initialize its state by reading from the [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), and save the drafts there too.
+- Você poderia renderizar _todos_ os chats em vez de apenas o atual, mas ocultar todos os outros com CSS. Os chats não seriam removidos da árvore, então seu estado local seria preservado. Essa solução funciona bem para interfaces de usuário simples. Mas pode ficar muito lento se as árvores ocultas forem grandes e contiverem muitos nós DOM.
+- Você poderia [elevar o estado](/learn/sharing-state-between-components) e manter a mensagem pendente para cada destinatário no componente pai. Dessa forma, quando os componentes filhos forem removidos, não importa, pois é o pai que mantém as informações importantes. Esta é a solução mais comum.
+- Você também pode usar uma fonte diferente além do estado do React. Por exemplo, você provavelmente quer que um rascunho de mensagem persista mesmo que o usuário feche acidentalmente a página. Para implementar isso, você pode fazer o componente `Chat` inicializar seu estado lendo do [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), e salvar os rascunhos lá também.
 
-No matter which strategy you pick, a chat _with Alice_ is conceptually distinct from a chat _with Bob_, so it makes sense to give a `key` to the `<Chat>` tree based on the current recipient.
+Não importa qual estratégia você escolha, um chat _com Alice_ é conceitualmente distinto de um chat _com Bob_, então faz sentido dar uma `key` à árvore `<Chat>` com base no destinatário atual.
 
 </DeepDive>
 
 <Recap>
 
-- React keeps state for as long as the same component is rendered at the same position.
-- State is not kept in JSX tags. It's associated with the tree position in which you put that JSX.
-- You can force a subtree to reset its state by giving it a different key.
-- Don't nest component definitions, or you'll reset state by accident.
+- O React mantém o estado enquanto o mesmo componente for renderizado na mesma posição.
+- O estado não é mantido em tags JSX. Ele está associado à posição da árvore onde você colocou esse JSX.
+- Você pode forçar uma subárvore a redefinir seu estado dando a ela uma chave diferente.
+- Não aninhe definições de componentes, ou você redefinirá o estado acidentalmente.
 
 </Recap>
 
@@ -1248,9 +1248,9 @@ No matter which strategy you pick, a chat _with Alice_ is conceptually distinct 
 
 <Challenges>
 
-#### Fix disappearing input text {/*fix-disappearing-input-text*/}
+#### Corrigir o texto de entrada desaparecendo {/*fix-disappearing-input-text*/}
 
-This example shows a message when you press the button. However, pressing the button also accidentally resets the input. Why does this happen? Fix it so that pressing the button does not reset the input text.
+Este exemplo mostra uma mensagem quando você pressiona o botão. No entanto, pressionar o botão também redefine acidentalmente a entrada. Por que isso acontece? Corrija para que pressionar o botão não redefina o texto da entrada.
 
 <Sandpack>
 
@@ -1299,9 +1299,9 @@ textarea { display: block; margin: 10px 0; }
 
 <Solution>
 
-The problem is that `Form` is rendered in different positions. In the `if` branch, it is the second child of the `<div>`, but in the `else` branch, it is the first child. Therefore, the component type in each position changes. The first position changes between holding a `p` and a `Form`, while the second position changes between holding a `Form` and a `button`. React resets the state every time the component type changes.
+O problema é que `Form` é renderizado em posições diferentes. No ramo `if`, ele é o segundo filho do `<div>`, mas no ramo `else`, ele é o primeiro filho. Portanto, o tipo do componente em cada posição muda. A primeira posição muda entre conter um `p` e um `Form`, enquanto a segunda posição muda entre conter um `Form` e um `button`. O React redefine o estado toda vez que o tipo do componente muda.
 
-The easiest solution is to unify the branches so that `Form` always renders in the same position:
+A solução mais fácil é unificar os ramos para que `Form` sempre seja renderizado na mesma posição:
 
 <Sandpack>
 
@@ -1347,7 +1347,7 @@ textarea { display: block; margin: 10px 0; }
 </Sandpack>
 
 
-Technically, you could also add `null` before `<Form />` in the `else` branch to match the `if` branch structure:
+Tecnicamente, você também poderia adicionar `null` antes de `<Form />` no ramo `else` para corresponder à estrutura do ramo `if`:
 
 <Sandpack>
 
@@ -1395,19 +1395,19 @@ textarea { display: block; margin: 10px 0; }
 
 </Sandpack>
 
-This way, `Form` is always the second child, so it stays in the same position and keeps its state. But this approach is much less obvious and introduces a risk that someone else will remove that `null`.
+Dessa forma, `Form` é sempre o segundo filho, então ele permanece na mesma posição e mantém seu estado. Mas essa abordagem é muito menos óbvia e introduz o risco de alguém remover esse `null`.
 
 </Solution>
 
-#### Swap two form fields {/*swap-two-form-fields*/}
+#### Trocar dois campos de formulário {/*swap-two-form-fields*/}
 
-This form lets you enter first and last name. It also has a checkbox controlling which field goes first. When you tick the checkbox, the "Last name" field will appear before the "First name" field.
+Este formulário permite que você insira o primeiro e o último nome. Ele também tem uma caixa de seleção que controla qual campo vai primeiro. Quando você marca a caixa de seleção, o campo "Last name" aparecerá antes do campo "First name".
 
-It almost works, but there is a bug. If you fill in the "First name" input and tick the checkbox, the text will stay in the first input (which is now "Last name"). Fix it so that the input text *also* moves when you reverse the order.
+Quase funciona, mas há um bug. Se você preencher o campo "First name" e marcar a caixa, o texto permanecerá no primeiro campo (que agora é "Last name"). Corrija para que o texto da entrada também se mova ao reverter a ordem.
 
 <Hint>
 
-It seems like for these fields, their position within the parent is not enough. Is there some way to tell React how to match up the state between re-renders?
+Parece que para esses campos, sua posição dentro do pai não é suficiente. Existe alguma maneira de dizer ao React como associar o estado entre as renderizações?
 
 </Hint>
 
@@ -1471,7 +1471,7 @@ label { display: block; margin: 10px 0; }
 
 <Solution>
 
-Give a `key` to both `<Field>` components in both `if` and `else` branches. This tells React how to "match up" the correct state for either `<Field>` even if their order within the parent changes:
+Dê uma `key` a ambos os componentes `<Field>` em ambos os ramos `if` e `else`. Isso diz ao React como "associar" o estado correto para qualquer `<Field>`, mesmo que sua ordem dentro do pai mude:
 
 <Sandpack>
 
@@ -1533,11 +1533,11 @@ label { display: block; margin: 10px 0; }
 
 </Solution>
 
-#### Reset a detail form {/*reset-a-detail-form*/}
+#### Redefinir um formulário de detalhes {/*reset-a-detail-form*/}
 
-This is an editable contact list. You can edit the selected contact's details and then either press "Save" to update it, or "Reset" to undo your changes.
+Esta é uma lista de contatos editável. Você pode editar os detalhes do contato selecionado e, em seguida, pressionar "Save" para atualizá-lo ou "Reset" para desfazer suas alterações.
 
-When you select a different contact (for example, Alice), the state updates but the form keeps showing the previous contact's details. Fix it so that the form gets reset when the selected contact changes.
+Quando você seleciona um contato diferente (por exemplo, Alice), o estado é atualizado, mas o formulário continua mostrando os detalhes do contato anterior. Corrija para que o formulário seja redefinido quando o contato selecionado mudar.
 
 <Sandpack>
 
@@ -1689,7 +1689,7 @@ button {
 
 <Solution>
 
-Give `key={selectedId}` to the `EditContact` component. This way, switching between different contacts will reset the form:
+Dê `key={selectedId}` ao componente `EditContact`. Dessa forma, alternar entre diferentes contatos redefinirá o formulário:
 
 <Sandpack>
 
@@ -1842,13 +1842,13 @@ button {
 
 </Solution>
 
-#### Clear an image while it's loading {/*clear-an-image-while-its-loading*/}
+#### Limpar uma imagem enquanto ela está carregando {/*clear-an-image-while-its-loading*/}
 
-When you press "Next", the browser starts loading the next image. However, because it's displayed in the same `<img>` tag, by default you would still see the previous image until the next one loads. This may be undesirable if it's important for the text to always match the image. Change it so that the moment you press "Next", the previous image immediately clears.
+Quando você pressiona "Next", o navegador começa a carregar a próxima imagem. No entanto, como ela é exibida na mesma tag `<img>`, por padrão você ainda veria a imagem anterior até que a próxima carregasse. Isso pode ser indesejável se for importante que o texto sempre corresponda à imagem. Altere para que, no momento em que você pressionar "Next", a imagem anterior seja limpa imediatamente.
 
 <Hint>
 
-Is there a way to tell React to re-create the DOM instead of reusing it?
+Existe uma maneira de dizer ao React para recriar o DOM em vez de reutilizá-lo?
 
 </Hint>
 
@@ -1918,7 +1918,7 @@ img { width: 150px; height: 150px; }
 
 <Solution>
 
-You can provide a `key` to the `<img>` tag. When that `key` changes, React will re-create the `<img>` DOM node from scratch. This causes a brief flash when each image loads, so it's not something you'd want to do for every image in your app. But it makes sense if you want to ensure the image always matches the text.
+Você pode fornecer uma `key` à tag `<img>`. Quando essa `key` mudar, o React recriará o nó DOM `<img>` do zero. Isso causa um breve flash quando cada imagem carrega, então não é algo que você queira fazer para cada imagem em seu aplicativo. Mas faz sentido se você quiser garantir que a imagem sempre corresponda ao texto.
 
 <Sandpack>
 
@@ -1986,11 +1986,11 @@ img { width: 150px; height: 150px; }
 
 </Solution>
 
-#### Fix misplaced state in the list {/*fix-misplaced-state-in-the-list*/}
+#### Corrigir estado mal posicionado na lista {/*fix-misplaced-state-in-the-list*/}
 
-In this list, each `Contact` has state that determines whether "Show email" has been pressed for it. Press "Show email" for Alice, and then tick the "Show in reverse order" checkbox. You will notice that it's _Taylor's_ email that is expanded now, but Alice's--which has moved to the bottom--appears collapsed.
+Nesta lista, cada `Contact` tem um estado que determina se "Mostrar e-mail" foi pressionado para ele. Pressione "Mostrar e-mail" para Alice e, em seguida, marque a caixa de seleção "Mostrar em ordem inversa". Você notará que é o e-mail de _Taylor_ que está expandido agora, mas o de Alice - que se moveu para o final - aparece recolhido.
 
-Fix it so that the expanded state is associated with each contact, regardless of the chosen ordering.
+Corrija para que o estado expandido seja associado a cada contato, independentemente da ordem escolhida.
 
 <Sandpack>
 
@@ -2016,7 +2016,7 @@ export default function ContactList() {
             setReverse(e.target.checked)
           }}
         />{' '}
-        Show in reverse order
+        Mostrar em ordem inversa
       </label>
       <ul>
         {displayedContacts.map((contact, i) =>
@@ -2050,7 +2050,7 @@ export default function Contact({ contact }) {
       <button onClick={() => {
         setExpanded(!expanded);
       }}>
-        {expanded ? 'Hide' : 'Show'} email
+        {expanded ? 'Esconder' : 'Mostrar'} e-mail
       </button>
     </>
   );
@@ -2080,16 +2080,16 @@ button {
 
 <Solution>
 
-The problem is that this example was using index as a `key`:
+O problema é que este exemplo estava usando o índice como `key`:
 
 ```js
 {displayedContacts.map((contact, i) =>
   <li key={i}>
 ```
 
-However, you want the state to be associated with _each particular contact_.
+No entanto, você quer que o estado seja associado a _cada contato específico_.
 
-Using the contact ID as a `key` instead fixes the issue:
+Usar o ID do contato como `key` em vez disso corrige o problema:
 
 <Sandpack>
 
@@ -2115,7 +2115,7 @@ export default function ContactList() {
             setReverse(e.target.checked)
           }}
         />{' '}
-        Show in reverse order
+        Mostrar em ordem inversa
       </label>
       <ul>
         {displayedContacts.map(contact =>
@@ -2149,7 +2149,7 @@ export default function Contact({ contact }) {
       <button onClick={() => {
         setExpanded(!expanded);
       }}>
-        {expanded ? 'Hide' : 'Show'} email
+        {expanded ? 'Esconder' : 'Mostrar'} e-mail
       </button>
     </>
   );
@@ -2177,7 +2177,7 @@ button {
 
 </Sandpack>
 
-State is associated with the tree position. A `key` lets you specify a named position instead of relying on order.
+O estado é associado à posição na árvore. Uma `key` permite que você especifique uma posição nomeada em vez de depender da ordem.
 
 </Solution>
 


### PR DESCRIPTION
Este PR contém uma tradução automatizada da página referenciada para **Português (Brasil)**.

> [!IMPORTANT]
> Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

<details>
<summary>Detalhes</summary>

### Estatísticas de Processamento



| Métrica | Valor |
|--------|-------|
| **Tamanho do Arquivo Fonte** | 55.1 kB |
| **Tamanho da Tradução** | 56.1 kB |
| **Razão de Conteúdo** | 1.02x [^content-ratio] |
| **Caminho do Arquivo** | `src/content/learn/preserving-and-resetting-state.md` |
| **Tempo de Processamento** | ~13 minutos [^processing-time] |

### Informações Técnicas

- **Data de Geração**: 2026-06-02
- **Branch**: `refs/heads/translate/learn/preserving-and-resetting-state.md`
- **Modelo de tradução (LLM)**: `google/gemini-2.5-flash-lite`
- **Execução do workflow**: [`Poll upstream React docs` · #26825420300](https://github.com/NivaldoFarias/translate-react/actions/runs/26825420300)


</details>

Guia para revisores: [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers).

---

[^content-ratio]: `Razão de Conteúdo` indica como o comprimento da tradução se compara à fonte (~1.0x: mesmo comprimento, >1.0x: tradução é mais longa). Diferentes idiomas naturalmente têm níveis variados de verbosidade.
[^processing-time]: `Tempo de Processamento` baseia-se no cálculo do tempo total desde o início do fluxo até a conclusão da tradução deste arquivo específico.
