### PR TITLE
Tradução de `react-performance-tracks.md` para Português (Brasil)

### DIFF
--- a/src/content/reference/dev-tools/react-performance-tracks.md
+++ b/src/content/reference/dev-tools/react-performance-tracks.md
@@ -4,156 +4,156 @@ title: React Performance tracks
 
 <Intro>
 
-React Performance tracks are specialized custom entries that appear on the Performance panel's timeline in your browser developer tools.
+As trilhas de Performance do React são entradas personalizadas especializadas que aparecem na linha do tempo do painel Performance em suas ferramentas de desenvolvedor do navegador.
 
 </Intro>
 
-These tracks are designed to provide developers with comprehensive insights into their React application's performance by visualizing React-specific events and metrics alongside other critical data sources such as network requests, JavaScript execution, and event loop activity, all synchronized on a unified timeline within the Performance panel for a complete understanding of application behavior.
+Essas trilhas são projetadas para fornecer aos desenvolvedores insights abrangentes sobre o desempenho de sua aplicação React, visualizando eventos e métricas específicas do React ao lado de outras fontes de dados críticas, como requisições de rede, execução de JavaScript e atividade do loop de eventos, tudo sincronizado em uma linha do tempo unificada dentro do painel Performance para uma compreensão completa do comportamento da aplicação.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/overview.png" alt="React Performance Tracks" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/overview.dark.png" alt="React Performance Tracks" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/overview.png" alt="Trilhas de Performance do React" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/overview.dark.png" alt="Trilhas de Performance do React" />
 </div>
 
 <InlineToc />
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-React Performance tracks are only available in development and profiling builds of React:
+As trilhas de Performance do React estão disponíveis apenas em builds de desenvolvimento e profiling do React:
 
-- **Development**: enabled by default.
-- **Profiling**: Only Scheduler tracks are enabled by default. The Components track only lists Components that are in subtrees wrapped with [`<Profiler>`](/reference/react/Profiler). If you have [React Developer Tools extension](/learn/react-developer-tools) enabled, all Components are included in the Components track even if they're not wrapped in `<Profiler>`. Server tracks are not available in profiling builds.
+- **Desenvolvimento**: habilitado por padrão.
+- **Profiling**: Apenas as trilhas do Scheduler estão habilitadas por padrão. A trilha de Componentes lista apenas Componentes que estão em subárvores envolvidas com [`<Profiler>`](/reference/react/Profiler). Se você tiver a extensão [React Developer Tools](/learn/react-developer-tools) habilitada, todos os Componentes são incluídos na trilha de Componentes, mesmo que não estejam envolvidos em `<Profiler>`. As trilhas do Servidor não estão disponíveis em builds de profiling.
 
-If enabled, tracks should appear automatically in the traces you record with the Performance panel of browsers that provide [extensibility APIs](https://developer.chrome.com/docs/devtools/performance/extension).
+Se habilitadas, as trilhas devem aparecer automaticamente nos traces que você grava com o painel Performance de navegadores que fornecem [APIs de extensibilidade](https://developer.chrome.com/docs/devtools/performance/extension).
 
 <Pitfall>
 
-The profiling instrumentation that powers React Performance tracks adds some additional overhead, so it is disabled in production builds by default.
-Server Components and Server Requests tracks are only available in development builds.
+A instrumentação de profiling que alimenta as trilhas de Performance do React adiciona alguma sobrecarga adicional, portanto, ela é desabilitada em builds de produção por padrão.
+As trilhas de Componentes do Servidor e Requisições do Servidor estão disponíveis apenas em builds de desenvolvimento.
 
 </Pitfall>
 
-### Using profiling builds {/*using-profiling-builds*/}
+### Usando builds de profiling {/*using-profiling-builds*/}
 
-In addition to production and development builds, React also includes a special profiling build.
-To use profiling builds, you have to use `react-dom/profiling` instead of `react-dom/client`.
-We recommend that you alias `react-dom/client` to `react-dom/profiling` at build time via bundler aliases instead of manually updating each `react-dom/client` import.
-Your framework might have built-in support for enabling React's profiling build.
+Além dos builds de produção e desenvolvimento, o React também inclui um build de profiling especial.
+Para usar builds de profiling, você precisa usar `react-dom/profiling` em vez de `react-dom/client`.
+Recomendamos que você crie um alias para `react-dom/client` como `react-dom/profiling` em tempo de build através de aliases do bundler em vez de atualizar manualmente cada importação de `react-dom/client`.
+Seu framework pode ter suporte integrado para habilitar o build de profiling do React.
 
 ---
 
-## Tracks {/*tracks*/}
+## Trilhas {/*tracks*/}
 
 ### Scheduler {/*scheduler*/}
 
-The Scheduler is an internal React concept used for managing tasks with different priorities. This track consists of 4 subtracks, each representing work of a specific priority:
+O Scheduler é um conceito interno do React usado para gerenciar tarefas com diferentes prioridades. Esta trilha consiste em 4 subtilhas, cada uma representando trabalho de uma prioridade específica:
 
-- **Blocking** - The synchronous updates, which could've been initiated by user interactions.
-- **Transition** - Non-blocking work that happens in the background, usually initiated via [`startTransition`](/reference/react/startTransition).
-- **Suspense** - Work related to Suspense boundaries, such as displaying fallbacks or revealing content.
-- **Idle** - The lowest priority work that is done when there are no other tasks with higher priority.
+- **Blocking** - As atualizações síncronas, que poderiam ter sido iniciadas por interações do usuário.
+- **Transition** - Trabalho não bloqueante que acontece em segundo plano, geralmente iniciado via [`startTransition`](/reference/react/startTransition).
+- **Suspense** - Trabalho relacionado a limites de Suspense, como exibir fallbacks ou revelar conteúdo.
+- **Idle** - O trabalho de menor prioridade que é feito quando não há outras tarefas com prioridade mais alta.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/scheduler.png" alt="Scheduler track" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/scheduler.dark.png" alt="Scheduler track" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/scheduler.png" alt="Trilha do Scheduler" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/scheduler.dark.png" alt="Trilha do Scheduler" />
 </div>
 
 #### Renders {/*renders*/}
 
-Every render pass consists of multiple phases that you can see on a timeline:
+Cada passagem de renderização consiste em várias fases que você pode ver em uma linha do tempo:
 
-- **Update** - this is what caused a new render pass.
-- **Render** - React renders the updated subtree by calling render functions of components. You can see the rendered components subtree on [Components track](#components), which follows the same color scheme.
-- **Commit** - After rendering components, React will submit the changes to the DOM and run layout effects, like [`useLayoutEffect`](/reference/react/useLayoutEffect).
-- **Remaining Effects** - React runs passive effects of a rendered subtree. This usually happens after the paint, and this is when React runs hooks like [`useEffect`](/reference/react/useEffect). One known exception is user interactions, like clicks, or other discrete events. In this scenario, this phase could run before the paint.
+- **Update** - isso é o que causou uma nova passagem de renderização.
+- **Render** - O React renderiza a subárvore atualizada chamando as funções de renderização dos componentes. Você pode ver a subárvore de componentes renderizados na [trilha de Componentes](#components), que segue o mesmo esquema de cores.
+- **Commit** - Após renderizar os componentes, o React submeterá as alterações ao DOM e executará efeitos de layout, como [`useLayoutEffect`](/reference/react/useLayoutEffect).
+- **Remaining Effects** - O React executa os efeitos passivos de uma subárvore renderizada. Isso geralmente acontece após a pintura, e é quando o React executa hooks como [`useEffect`](/reference/react/useEffect). Uma exceção conhecida são as interações do usuário, como cliques, ou outros eventos discretos. Nesse cenário, essa fase pode ocorrer antes da pintura.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/scheduler-update.png" alt="Scheduler track: updates" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/scheduler-update.dark.png" alt="Scheduler track: updates" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/scheduler-update.png" alt="Trilha do Scheduler: atualizações" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/scheduler-update.dark.png" alt="Trilha do Scheduler: atualizações" />
 </div>
 
-[Learn more about renders and commits](/learn/render-and-commit).
+[Saiba mais sobre renders e commits](/learn/render-and-commit).
 
-#### Cascading updates {/*cascading-updates*/}
+#### Atualizações em cascata {/*cascading-updates*/}
 
-Cascading updates is one of the patterns for performance regressions. If an update was scheduled during a render pass, React could discard completed work and start a new pass.
+Atualizações em cascata são um dos padrões para regressões de desempenho. Se uma atualização foi agendada durante uma passagem de renderização, o React pode descartar o trabalho concluído e iniciar uma nova passagem.
 
-In development builds, React can show you which Component scheduled a new update. This includes both general updates and cascading ones. You can see the enhanced stack trace by clicking on the "Cascading update" entry, which should also display the name of the method that scheduled an update.
+Em builds de desenvolvimento, o React pode mostrar qual Componente agendou uma nova atualização. Isso inclui atualizações gerais e em cascata. Você pode ver o trace de pilha aprimorado clicando na entrada "Cascading update", que também deve exibir o nome do método que agendou uma atualização.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/scheduler-cascading-update.png" alt="Scheduler track: cascading updates" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/scheduler-cascading-update.dark.png" alt="Scheduler track: cascading updates" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/scheduler-cascading-update.png" alt="Trilha do Scheduler: atualizações em cascata" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/scheduler-cascading-update.dark.png" alt="Trilha do Scheduler: atualizações em cascata" />
 </div>
 
-[Learn more about Effects](/learn/you-might-not-need-an-effect).
+[Saiba mais sobre Efeitos](/learn/you-might-not-need-an-effect).
 
-### Components {/*components*/}
+### Componentes {/*components*/}
 
-The Components track visualizes the durations of React components. They are displayed as a flamegraph, where each entry represents the duration of the corresponding component render and all its descendant children components.
+A trilha de Componentes visualiza as durações dos componentes React. Eles são exibidos como um flamegraph, onde cada entrada representa a duração da renderização do componente correspondente e todos os seus componentes filhos descendentes.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/components-render.png" alt="Components track: render durations" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/components-render.dark.png" alt="Components track: render durations" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/components-render.png" alt="Trilha de Componentes: durações de renderização" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/components-render.dark.png" alt="Trilha de Componentes: durações de renderização" />
 </div>
 
-Similar to render durations, effect durations are also represented as a flamegraph, but with a different color scheme that aligns with the corresponding phase on the Scheduler track.
+Semelhante às durações de renderização, as durações de efeitos também são representadas como um flamegraph, mas com um esquema de cores diferente que se alinha com a fase correspondente na trilha do Scheduler.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/components-effects.png" alt="Components track: effects durations" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/components-effects.dark.png" alt="Components track: effects durations" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/components-effects.png" alt="Trilha de Componentes: durações de efeitos" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/components-effects.dark.png" alt="Trilha de Componentes: durações de efeitos" />
 </div>
 
 <Note>
 
-Unlike renders, not all effects are shown on the Components track by default.
+Ao contrário das renderizações, nem todos os efeitos são exibidos na trilha de Componentes por padrão.
 
-To maintain performance and prevent UI clutter, React will only display those effects, which had a duration of 0.05ms or longer, or triggered an update.
+Para manter o desempenho e evitar poluição visual da interface, o React exibirá apenas aqueles efeitos que tiveram uma duração de 0,05ms ou mais, ou que acionaram uma atualização.
 
 </Note>
 
-Additional events may be displayed during the render and effects phases:
+Eventos adicionais podem ser exibidos durante as fases de renderização e efeitos:
 
-- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Mount</span> - A corresponding subtree of component renders or effects was mounted.
-- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Unmount</span> - A corresponding subtree of component renders or effects was unmounted.
-- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Reconnect</span> - Similar to Mount, but limited to cases when [`<Activity>`](/reference/react/Activity) is used.
-- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Disconnect</span> - Similar to Unmount, but limited to cases when [`<Activity>`](/reference/react/Activity) is used.
+- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Mount</span> - Uma subárvore correspondente de renderizações ou efeitos de componentes foi montada.
+- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Unmount</span> - Uma subárvore correspondente de renderizações ou efeitos de componentes foi desmontada.
+- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Reconnect</span> - Semelhante a Mount, mas limitado a casos em que [`<Activity>`](/reference/react/Activity) é usado.
+- <span style={{padding: '0.125rem 0.25rem', backgroundColor: '#facc15', color: '#1f1f1fff'}}>Disconnect</span> - Semelhante a Unmount, mas limitado a casos em que [`<Activity>`](/reference/react/Activity) é usado.
 
-#### Changed props {/*changed-props*/}
+#### Props alteradas {/*changed-props*/}
 
-In development builds, when you click on a component render entry, you can inspect potential changes in props. You can use this information to identify unnecessary renders.
-
-<div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/changed-props.png" alt="Components track: changed props" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/changed-props.dark.png" alt="Components track: changed props" />
-</div>
-
-### Server {/*server*/}
+Em builds de desenvolvimento, ao clicar em uma entrada de renderização de componente, você pode inspecionar possíveis alterações nas props. Você pode usar essas informações para identificar renderizações desnecessárias.
 
 <div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
-  <img className="w-full light-image" src="/images/docs/performance-tracks/server-overview.png" alt="React Server Performance Tracks" />
-  <img className="w-full dark-image" src="/images/docs/performance-tracks/server-overview.dark.png" alt="React Server Performance Tracks" />
+  <img className="w-full light-image" src="/images/docs/performance-tracks/changed-props.png" alt="Trilha de Componentes: props alteradas" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/changed-props.dark.png" alt="Trilha de Componentes: props alteradas" />
 </div>
 
-#### Server Requests {/*server-requests*/}
+### Servidor {/*server*/}
 
-The Server Requests track visualized all Promises that eventually end up in a React Server Component. This includes any `async` operations like calling `fetch` or async Node.js file operations.
+<div style={{display: 'flex', justifyContent: 'center', marginBottom: '1rem'}}>
+  <img className="w-full light-image" src="/images/docs/performance-tracks/server-overview.png" alt="Trilhas de Performance do Servidor React" />
+  <img className="w-full dark-image" src="/images/docs/performance-tracks/server-overview.dark.png" alt="Trilhas de Performance do Servidor React" />
+</div>
 
-React will try to combine Promises that are started from inside third-party code into a single span representing the the duration of the entire operation blocking 1st party code.
-For example, a third party library method called `getUser` that calls `fetch` internally multiple times will be represented as a single span called `getUser`, instead of showing multiple `fetch` spans.
+#### Requisições do Servidor {/*server-requests*/}
 
-Clicking on spans will show you a stack trace of where the Promise was created as well as a view of the value that the Promise resolved to, if available.
+A trilha de Requisições do Servidor visualiza todas as Promises que eventualmente acabam em um Componente de Servidor React. Isso inclui quaisquer operações `async`, como chamar `fetch` ou operações de arquivo assíncronas do Node.js.
 
-Rejected Promises are displayed as red with their rejected value.
+O React tentará combinar Promises que são iniciadas a partir de código de terceiros em um único span que representa a duração de toda a operação que bloqueia o código de primeira parte.
+Por exemplo, um método de biblioteca de terceiros chamado `getUser` que chama `fetch` internamente várias vezes será representado como um único span chamado `getUser`, em vez de mostrar múltiplos spans `fetch`.
 
-#### Server Components {/*server-components*/}
+Clicar em spans mostrará um trace de pilha de onde a Promise foi criada, bem como uma visualização do valor para o qual a Promise foi resolvida, se disponível.
 
-The Server Components tracks visualize the durations of React Server Components Promises they awaited. Timings are displayed as a flamegraph, where each entry represents the duration of the corresponding component render and all its descendant children components.
+Promises rejeitadas são exibidas em vermelho com seu valor rejeitado.
 
-If you await a Promise, React will display duration of that Promise. To see all I/O operations, use the Server Requests track.
+#### Componentes do Servidor {/*server-components*/}
 
-Different colors are used to indicate the duration of the component render. The darker the color, the longer the duration.
+As trilhas de Componentes do Servidor visualizam as durações das Promises de Componentes de Servidor React que eles aguardaram. Os tempos são exibidos como um flamegraph, onde cada entrada representa a duração da renderização do componente correspondente e todos os seus componentes filhos descendentes.
 
-The Server Components track group will always contain a "Primary" track. If React is able to render Server Components concurrently, it will display addititional "Parallel" tracks.
-If more than 8 Server Components are rendered concurrently, React will associate them with the last "Parallel" track instead of adding more tracks.
+Se você aguardar uma Promise, o React exibirá a duração dessa Promise. Para ver todas as operações de I/O, use a trilha de Requisições do Servidor.
+
+Cores diferentes são usadas para indicar a duração da renderização do componente. Quanto mais escura a cor, maior a duração.
+
+O grupo de trilhas de Componentes do Servidor sempre conterá uma trilha "Primary". Se o React for capaz de renderizar Componentes do Servidor concorrentemente, ele exibirá trilhas "Parallel" adicionais.
+Se mais de 8 Componentes do Servidor forem renderizados concorrentemente, o React os associará à última trilha "Parallel" em vez de adicionar mais trilhas.


### PR DESCRIPTION
Este PR contém uma tradução automatizada da página referenciada para **Português (Brasil)**.

> [!IMPORTANT]
> Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

<details>
<summary>Detalhes</summary>

### Estatísticas de Processamento



| Métrica | Valor |
|--------|-------|
| **Tamanho do Arquivo Fonte** | 10.8 kB |
| **Tamanho da Tradução** | 11.8 kB |
| **Razão de Conteúdo** | 1.09x [^content-ratio] |
| **Caminho do Arquivo** | `src/content/reference/dev-tools/react-performance-tracks.md` |
| **Tempo de Processamento** | ~19 minutos [^processing-time] |

### Informações Técnicas

- **Data de Geração**: 2026-06-02
- **Branch**: `refs/heads/translate/reference/dev-tools/react-performance-tracks.md`
- **Modelo de tradução (LLM)**: `google/gemini-2.5-flash-lite`
- **Execução do workflow**: [`Poll upstream React docs` · #26825420300](https://github.com/NivaldoFarias/translate-react/actions/runs/26825420300)


</details>

Guia para revisores: [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers).

---

[^content-ratio]: `Razão de Conteúdo` indica como o comprimento da tradução se compara à fonte (~1.0x: mesmo comprimento, >1.0x: tradução é mais longa). Diferentes idiomas naturalmente têm níveis variados de verbosidade.
[^processing-time]: `Tempo de Processamento` baseia-se no cálculo do tempo total desde o início do fluxo até a conclusão da tradução deste arquivo específico.
