### PR TITLE
Tradução de `index.md` para Português (Brasil)

### DIFF
--- a/src/content/reference/eslint-plugin-react-hooks/index.md
+++ b/src/content/reference/eslint-plugin-react-hooks/index.md
@@ -5,36 +5,36 @@ version: rc
 
 <Intro>
 
-`eslint-plugin-react-hooks` provides ESLint rules to enforce the [Rules of React](/reference/rules).
+O `eslint-plugin-react-hooks` fornece regras do ESLint para impor as [Regras do React](/reference/rules).
 
 </Intro>
 
-This plugin helps you catch violations of React's rules at build time, ensuring your components and hooks follow React's rules for correctness and performance. The lints cover both fundamental React patterns (exhaustive-deps and rules-of-hooks) and issues flagged by React Compiler. React Compiler diagnostics are automatically surfaced by this ESLint plugin, and can be used even if your app hasn't adopted the compiler yet.
+Este plugin ajuda você a detectar violações das regras do React em tempo de compilação, garantindo que seus componentes e hooks sigam as regras do React para correção e desempenho. Os lints cobrem tanto padrões fundamentais do React (exhaustive-deps e rules-of-hooks) quanto problemas sinalizados pelo React Compiler. Os diagnósticos do React Compiler são automaticamente exibidos por este plugin ESLint e podem ser usados mesmo que seu aplicativo ainda não tenha adotado o compilador.
 
 <Note>
-When the compiler reports a diagnostic, it means that the compiler was able to statically detect a pattern that is not supported or breaks the Rules of React. When it detects this, it **automatically** skips over those components and hooks, while keeping the rest of your app compiled. This ensures optimal coverage of safe optimizations that won't break your app.
+Quando o compilador relata um diagnóstico, isso significa que o compilador foi capaz de detectar estaticamente um padrão que não é suportado ou quebra as Regras do React. Quando ele detecta isso, ele **automaticamente** ignora esses componentes e hooks, enquanto mantém o restante do seu aplicativo compilado. Isso garante uma cobertura ideal de otimizações seguras que não quebrarão seu aplicativo.
 
-What this means for linting, is that you don’t need to fix all violations immediately. Address them at your own pace to gradually increase the number of optimized components.
+O que isso significa para o linting é que você não precisa corrigir todas as violações imediatamente. Resolva-as no seu próprio ritmo para aumentar gradualmente o número de componentes otimizados.
 </Note>
 
-## Recommended Rules {/*recommended*/}
+## Regras Recomendadas {/*recommended*/}
 
-These rules are included in the `recommended` preset in `eslint-plugin-react-hooks`:
+Estas regras estão incluídas no preset `recommended` em `eslint-plugin-react-hooks`:
 
-* [`exhaustive-deps`](/reference/eslint-plugin-react-hooks/lints/exhaustive-deps) - Validates that dependency arrays for React hooks contain all necessary dependencies
-* [`rules-of-hooks`](/reference/eslint-plugin-react-hooks/lints/rules-of-hooks) - Validates that components and hooks follow the Rules of Hooks
-* [`component-hook-factories`](/reference/eslint-plugin-react-hooks/lints/component-hook-factories) - Validates higher order functions defining nested components or hooks
-* [`config`](/reference/eslint-plugin-react-hooks/lints/config) - Validates the compiler configuration options
-* [`error-boundaries`](/reference/eslint-plugin-react-hooks/lints/error-boundaries) - Validates usage of Error Boundaries instead of try/catch for child errors
-* [`gating`](/reference/eslint-plugin-react-hooks/lints/gating) - Validates configuration of gating mode
-* [`globals`](/reference/eslint-plugin-react-hooks/lints/globals) - Validates against assignment/mutation of globals during render
-* [`immutability`](/reference/eslint-plugin-react-hooks/lints/immutability) - Validates against mutating props, state, and other immutable values
-* [`incompatible-library`](/reference/eslint-plugin-react-hooks/lints/incompatible-library) - Validates against usage of libraries which are incompatible with memoization
-* [`preserve-manual-memoization`](/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization) - Validates that existing manual memoization is preserved by the compiler
-* [`purity`](/reference/eslint-plugin-react-hooks/lints/purity) - Validates that components/hooks are pure by checking known-impure functions
-* [`refs`](/reference/eslint-plugin-react-hooks/lints/refs) - Validates correct usage of refs, not reading/writing during render
-* [`set-state-in-effect`](/reference/eslint-plugin-react-hooks/lints/set-state-in-effect) - Validates against calling setState synchronously in an effect
-* [`set-state-in-render`](/reference/eslint-plugin-react-hooks/lints/set-state-in-render) - Validates against setting state during render
-* [`static-components`](/reference/eslint-plugin-react-hooks/lints/static-components) - Validates that components are static, not recreated every render
-* [`unsupported-syntax`](/reference/eslint-plugin-react-hooks/lints/unsupported-syntax) - Validates against syntax that React Compiler does not support
-* [`use-memo`](/reference/eslint-plugin-react-hooks/lints/use-memo) - Validates usage of the `useMemo` hook without a return value
+* [`exhaustive-deps`](/reference/eslint-plugin-react-hooks/lints/exhaustive-deps) - Valida que os arrays de dependência para hooks do React contêm todas as dependências necessárias
+* [`rules-of-hooks`](/reference/eslint-plugin-react-hooks/lints/rules-of-hooks) - Valida que componentes e hooks seguem as Regras dos Hooks
+* [`component-hook-factories`](/reference/eslint-plugin-react-hooks/lints/component-hook-factories) - Valida funções de ordem superior que definem componentes ou hooks aninhados
+* [`config`](/reference/eslint-plugin-react-hooks/lints/config) - Valida as opções de configuração do compilador
+* [`error-boundaries`](/reference/eslint-plugin-react-hooks/lints/error-boundaries) - Valida o uso de Error Boundaries em vez de try/catch para erros de filhos
+* [`gating`](/reference/eslint-plugin-react-hooks/lints/gating) - Valida a configuração do modo de gating
+* [`globals`](/reference/eslint-plugin-react-hooks/lints/globals) - Valida contra atribuição/mutação de globais durante a renderização
+* [`immutability`](/reference/eslint-plugin-react-hooks/lints/immutability) - Valida contra mutação de props, estado e outros valores imutáveis
+* [`incompatible-library`](/reference/eslint-plugin-react-hooks/lints/incompatible-library) - Valida contra o uso de bibliotecas incompatíveis com memoização
+* [`preserve-manual-memoization`](/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization) - Valida que a memoização manual existente é preservada pelo compilador
+* [`purity`](/reference/eslint-plugin-react-hooks/lints/purity) - Valida que componentes/hooks são puros verificando funções conhecidas como impuras
+* [`refs`](/reference/eslint-plugin-react-hooks/lints/refs) - Valida o uso correto de refs, não lendo/escrevendo durante a renderização
+* [`set-state-in-effect`](/reference/eslint-plugin-react-hooks/lints/set-state-in-effect) - Valida contra a chamada de setState síncronamente em um effect
+* [`set-state-in-render`](/reference/eslint-plugin-react-hooks/lints/set-state-in-render) - Valida contra a definição de estado durante a renderização
+* [`static-components`](/reference/eslint-plugin-react-hooks/lints/static-components) - Valida que os componentes são estáticos, não recriados a cada renderização
+* [`unsupported-syntax`](/reference/eslint-plugin-react-hooks/lints/unsupported-syntax) - Valida contra sintaxe que o React Compiler não suporta
+* [`use-memo`](/reference/eslint-plugin-react-hooks/lints/use-memo) - Valida o uso do hook `useMemo` sem um valor de retorno


### PR DESCRIPTION
Este PR contém uma tradução automatizada da página referenciada para **Português (Brasil)**.

> [!IMPORTANT]
> Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

<details>
<summary>Detalhes</summary>

### Estatísticas de Processamento



| Métrica | Valor |
|--------|-------|
| **Tamanho do Arquivo Fonte** | 3.77 kB |
| **Tamanho da Tradução** | 3.92 kB |
| **Razão de Conteúdo** | 1.04x [^content-ratio] |
| **Caminho do Arquivo** | `src/content/reference/eslint-plugin-react-hooks/index.md` |
| **Tempo de Processamento** | ~19 minutos [^processing-time] |

### Informações Técnicas

- **Data de Geração**: 2026-06-02
- **Branch**: `refs/heads/translate/reference/eslint-plugin-react-hooks/index.md`
- **Modelo de tradução (LLM)**: `google/gemini-2.5-flash-lite`
- **Execução do workflow**: [`Poll upstream React docs` · #26825420300](https://github.com/NivaldoFarias/translate-react/actions/runs/26825420300)


</details>

Guia para revisores: [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers).

---

[^content-ratio]: `Razão de Conteúdo` indica como o comprimento da tradução se compara à fonte (~1.0x: mesmo comprimento, >1.0x: tradução é mais longa). Diferentes idiomas naturalmente têm níveis variados de verbosidade.
[^processing-time]: `Tempo de Processamento` baseia-se no cálculo do tempo total desde o início do fluxo até a conclusão da tradução deste arquivo específico.
