### PR TITLE
Tradução de `config.md` para Português (Brasil)

### DIFF
--- a/src/content/reference/eslint-plugin-react-hooks/lints/config.md
+++ b/src/content/reference/eslint-plugin-react-hooks/lints/config.md
@@ -4,44 +4,44 @@ title: config
 
 <Intro>
 
-Validates the compiler [configuration options](/reference/react-compiler/configuration).
+Valida as [opções de configuração](/reference/react-compiler/configuration) do compilador.
 
 </Intro>
 
-## Rule Details {/*rule-details*/}
+## Detalhes da Regra {/*rule-details*/}
 
-React Compiler accepts various [configuration options](/reference/react-compiler/configuration)  to control its behavior. This rule validates that your configuration uses correct option names and value types, preventing silent failures from typos or incorrect settings.
+O React Compiler aceita várias [opções de configuração](/reference/react-compiler/configuration) para controlar seu comportamento. Esta regra valida que sua configuração usa nomes de opções e tipos de valor corretos, prevenindo falhas silenciosas por erros de digitação ou configurações incorretas.
 
-### Invalid {/*invalid*/}
+### Inválido {/*invalid*/}
 
-Examples of incorrect code for this rule:
+Exemplos de código incorreto para esta regra:
 
 ```js
-// ❌ Unknown option name
+// ❌ Nome de opção desconhecido
 module.exports = {
   plugins: [
     ['babel-plugin-react-compiler', {
-      compileMode: 'all' // Typo: should be compilationMode
+      compileMode: 'all' // Erro de digitação: deveria ser compilationMode
     }]
   ]
 };
 
-// ❌ Invalid option value
+// ❌ Valor de opção inválido
 module.exports = {
   plugins: [
     ['babel-plugin-react-compiler', {
-      compilationMode: 'everything' // Invalid: use 'all' or 'infer'
+      compilationMode: 'everything' // Inválido: use 'all' ou 'infer'
     }]
   ]
 };
 ```
 
-### Valid {/*valid*/}
+### Válido {/*valid*/}
 
-Examples of correct code for this rule:
+Exemplos de código correto para esta regra:
 
 ```js
-// ✅ Valid compiler configuration
+// ✅ Configuração de compilador válida
 module.exports = {
   plugins: [
     ['babel-plugin-react-compiler', {
@@ -52,38 +52,38 @@ module.exports = {
 };
 ```
 
-## Troubleshooting {/*troubleshooting*/}
+## Solução de Problemas {/*troubleshooting*/}
 
-### Configuration not working as expected {/*config-not-working*/}
+### Configuração não funciona como esperado {/*config-not-working*/}
 
-Your compiler configuration might have typos or incorrect values:
+Sua configuração do compilador pode ter erros de digitação ou valores incorretos:
 
 ```js
-// ❌ Wrong: Common configuration mistakes
+// ❌ Errado: Erros comuns de configuração
 module.exports = {
   plugins: [
     ['babel-plugin-react-compiler', {
-      // Typo in option name
+      // Erro de digitação no nome da opção
       compilationMod: 'all',
-      // Wrong value type
+      // Tipo de valor incorreto
       panicThreshold: true,
-      // Unknown option
+      // Opção desconhecida
       optimizationLevel: 'max'
     }]
   ]
 };
 ```
 
-Check the [configuration documentation](/reference/react-compiler/configuration) for valid options:
+Verifique a [documentação de configuração](/reference/react-compiler/configuration) para opções válidas:
 
 ```js
-// ✅ Better: Valid configuration
+// ✅ Melhor: Configuração válida
 module.exports = {
   plugins: [
     ['babel-plugin-react-compiler', {
-      compilationMode: 'all', // or 'infer'
-      panicThreshold: 'none', // or 'critical_errors', 'all_errors'
-      // Only use documented options
+      compilationMode: 'all', // ou 'infer'
+      panicThreshold: 'none', // ou 'critical_errors', 'all_errors'
+      // Use apenas opções documentadas
     }]
   ]
 };


### PR DESCRIPTION
Este PR contém uma tradução automatizada da página referenciada para **Português (Brasil)**.

> [!IMPORTANT]
> Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

<details>
<summary>Detalhes</summary>

### Estatísticas de Processamento



| Métrica | Valor |
|--------|-------|
| **Tamanho do Arquivo Fonte** | 1.99 kB |
| **Tamanho da Tradução** | 2.13 kB |
| **Razão de Conteúdo** | 1.07x [^content-ratio] |
| **Caminho do Arquivo** | `src/content/reference/eslint-plugin-react-hooks/lints/config.md` |
| **Tempo de Processamento** | ~19 minutos [^processing-time] |

### Informações Técnicas

- **Data de Geração**: 2026-06-02
- **Branch**: `refs/heads/translate/reference/eslint-plugin-react-hooks/lints/config.md`
- **Modelo de tradução (LLM)**: `google/gemini-2.5-flash-lite`
- **Execução do workflow**: [`Poll upstream React docs` · #26825420300](https://github.com/NivaldoFarias/translate-react/actions/runs/26825420300)


</details>

Guia para revisores: [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers).

---

[^content-ratio]: `Razão de Conteúdo` indica como o comprimento da tradução se compara à fonte (~1.0x: mesmo comprimento, >1.0x: tradução é mais longa). Diferentes idiomas naturalmente têm níveis variados de verbosidade.
[^processing-time]: `Tempo de Processamento` baseia-se no cálculo do tempo total desde o início do fluxo até a conclusão da tradução deste arquivo específico.
