### PR TITLE
Tradução de `resumeAndPrerender.md` para Português (Brasil)

### DIFF
--- a/src/content/reference/react-dom/static/resumeAndPrerender.md
+++ b/src/content/reference/react-dom/static/resumeAndPrerender.md
@@ -4,7 +4,7 @@ title: resumeAndPrerender
 
 <Intro>
 
-`resumeAndPrerender` continues a prerendered React tree to a static HTML string using a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
+`resumeAndPrerender` continua uma árvore React pré-renderizada para uma string HTML estática usando um [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
 
 ```js
 const { prelude,postpone } = await resumeAndPrerender(reactNode, postponedState, options?)
@@ -16,17 +16,17 @@ const { prelude,postpone } = await resumeAndPrerender(reactNode, postponedState,
 
 <Note>
 
-This API depends on [Web Streams.](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) For Node.js, use [`resumeAndPrerenderToNodeStream`](/reference/react-dom/static/resumeAndPrerenderToNodeStream) instead.
+Esta API depende de [Web Streams.](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) Para Node.js, use [`resumeAndPrerenderToNodeStream`](/reference/react-dom/static/resumeAndPrerenderToNodeStream) em vez disso.
 
 </Note>
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `resumeAndPrerender(reactNode, postponedState, options?)` {/*resumeandprerender*/}
 
-Call `resumeAndPrerender` to continue a prerendered React tree to a static HTML string.
+Chame `resumeAndPrerender` para continuar uma árvore React pré-renderizada para uma string HTML estática.
 
 ```js
 import { resumeAndPrerender } from 'react-dom/static';
@@ -43,45 +43,45 @@ async function handler(request, response) {
 }
 ```
 
-On the client, call [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) to make the server-generated HTML interactive.
+No cliente, chame [`hydrateRoot`](/reference/react-dom/client/hydrateRoot) para tornar o HTML gerado pelo servidor interativo.
 
-[See more examples below.](#usage)
+[Veja mais exemplos abaixo.](#usage)
 
-#### Parameters {/*parameters*/}
+#### Parâmetros {/*parameters*/}
 
-* `reactNode`: The React node you called `prerender` (or a previous `resumeAndPrerender`) with. For example, a JSX element like `<App />`. It is expected to represent the entire document, so the `App` component should render the `<html>` tag.
-* `postponedState`: The opaque `postpone` object returned from a [prerender API](/reference/react-dom/static/index), loaded from wherever you stored it (e.g. redis, a file, or S3).
-* **optional** `options`: An object with streaming options.
-  * **optional** `signal`: An [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that lets you [abort server rendering](#aborting-server-rendering) and render the rest on the client.
-  * **optional** `onError`: A callback that fires whenever there is a server error, whether [recoverable](#recovering-from-errors-outside-the-shell) or [not.](#recovering-from-errors-inside-the-shell) By default, this only calls `console.error`. If you override it to [log crash reports,](#logging-crashes-on-the-server) make sure that you still call `console.error`.
+* `reactNode`: O nó React que você chamou `prerender` (ou um `resumeAndPrerender` anterior) com. Por exemplo, um elemento JSX como `<App />`. Espera-se que ele represente o documento inteiro, então o componente `App` deve renderizar a tag `<html>`.
+* `postponedState`: O objeto `postpone` opaco retornado de uma [API de pré-renderização](/reference/react-dom/static/index), carregado de onde quer que você o tenha armazenado (por exemplo, redis, um arquivo ou S3).
+* **opcional** `options`: Um objeto com opções de streaming.
+  * **opcional** `signal`: Um [sinal de abortar](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) que permite [abortar a renderização do servidor](#aborting-server-rendering) e renderizar o restante no cliente.
+  * **opcional** `onError`: Uma função de callback que é acionada sempre que ocorre um erro no servidor, seja [recuperável](#recovering-from-errors-outside-the-shell) ou [não.](#recovering-from-errors-inside-the-shell) Por padrão, isso apenas chama `console.error`. Se você o substituir para [registrar relatórios de falha,](#logging-crashes-on-the-server) certifique-se de ainda chamar `console.error`.
 
-#### Returns {/*returns*/}
+#### Retorna {/*returns*/}
 
-`prerender` returns a Promise:
-- If rendering the is successful, the Promise will resolve to an object containing:
-  - `prelude`: a [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of HTML. You can use this stream to send a response in chunks, or you can read the entire stream into a string.
-  - `postponed`: an JSON-serializeable, opaque object that can be passed to [`resume`](/reference/react-dom/server/resume) or [`resumeAndPrerender`](/reference/react-dom/static/resumeAndPrerender) if `prerender` is aborted.
-- If rendering fails, the Promise will be rejected. [Use this to output a fallback shell.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
+`prerender` retorna uma Promise:
+- Se a renderização for bem-sucedida, a Promise será resolvida para um objeto contendo:
+  - `prelude`: um [Web Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) de HTML. Você pode usar este stream para enviar uma resposta em pedaços, ou pode ler o stream inteiro em uma string.
+  - `postponed`: um objeto opaco e serializável em JSON que pode ser passado para [`resume`](/reference/react-dom/server/resume) ou [`resumeAndPrerender`](/reference/react-dom/static/resumeAndPrerender) se `prerender` for abortado.
+- Se a renderização falhar, a Promise será rejeitada. [Use isso para gerar um shell de fallback.](/reference/react-dom/server/renderToReadableStream#recovering-from-errors-inside-the-shell)
 
-#### Caveats {/*caveats*/}
+#### Ressalvas {/*caveats*/}
 
-`nonce` is not an available option when prerendering. Nonces must be unique per request and if you use nonces to secure your application with [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) it would be inappropriate and insecure to include the nonce value in the prerender itself.
+`nonce` não é uma opção disponível ao pré-renderizar. Nonces devem ser únicos por solicitação e se você usar nonces para proteger sua aplicação com [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) seria inadequado e inseguro incluir o valor do nonce na própria pré-renderização.
 
 <Note>
 
-### When should I use `resumeAndPrerender`? {/*when-to-use-prerender*/}
+### Quando devo usar `resumeAndPrerender`? {/*when-to-use-prerender*/}
 
-The static `resumeAndPrerender` API is used for static server-side generation (SSG). Unlike `renderToString`, `resumeAndPrerender` waits for all data to load before resolving. This makes it suitable for generating static HTML for a full page, including data that needs to be fetched using Suspense. To stream content as it loads, use a streaming server-side render (SSR) API like [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
+A API estática `resumeAndPrerender` é usada para geração estática do lado do servidor (SSG). Ao contrário de `renderToString`, `resumeAndPrerender` espera que todos os dados sejam carregados antes de resolver. Isso o torna adequado para gerar HTML estático para uma página inteira, incluindo dados que precisam ser buscados usando Suspense. Para transmitir conteúdo à medida que ele é carregado, use uma API de renderização do lado do servidor (SSR) de streaming como [renderToReadableStream](/reference/react-dom/server/renderToReadableStream).
 
-`resumeAndPrerender` can be aborted and later either continued with another `resumeAndPrerender` or resumed with `resume` to support partial pre-rendering.
+`resumeAndPrerender` pode ser abortado e, posteriormente, continuado com outro `resumeAndPrerender` ou retomado com `resume` para suportar pré-renderização parcial.
 
 </Note>
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Further reading {/*further-reading*/}
+### Leitura adicional {/*further-reading*/}
 
-`resumeAndPrerender` behaves similarly to [`prerender`](/reference/react-dom/static/prerender) but can be used to continue a previously started prerendering process that was aborted.
-For more information about resuming a prerendered tree, see the [resume documentation](/reference/react-dom/server/resume#resuming-a-prerender).
+`resumeAndPrerender` se comporta de forma semelhante a [`prerender`](/reference/react-dom/static/prerender), mas pode ser usado para continuar um processo de pré-renderização iniciado anteriormente que foi abortado.
+Para mais informações sobre como continuar uma árvore pré-renderizada, veja a [documentação do resume](/reference/react-dom/server/resume#resuming-a-prerender).


### PR DESCRIPTION
Este PR contém uma tradução automatizada da página referenciada para **Português (Brasil)**.

> [!IMPORTANT]
> Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

<details>
<summary>Detalhes</summary>

### Estatísticas de Processamento



| Métrica | Valor |
|--------|-------|
| **Tamanho do Arquivo Fonte** | 4.64 kB |
| **Tamanho da Tradução** | 4.95 kB |
| **Razão de Conteúdo** | 1.07x [^content-ratio] |
| **Caminho do Arquivo** | `src/content/reference/react-dom/static/resumeAndPrerender.md` |
| **Tempo de Processamento** | ~22 minutos [^processing-time] |

### Informações Técnicas

- **Data de Geração**: 2026-06-02
- **Branch**: `refs/heads/translate/reference/react-dom/static/resumeAndPrerender.md`
- **Modelo de tradução (LLM)**: `google/gemini-2.5-flash-lite`
- **Execução do workflow**: [`Poll upstream React docs` · #26825420300](https://github.com/NivaldoFarias/translate-react/actions/runs/26825420300)


</details>

Guia para revisores: [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers).

---

[^content-ratio]: `Razão de Conteúdo` indica como o comprimento da tradução se compara à fonte (~1.0x: mesmo comprimento, >1.0x: tradução é mais longa). Diferentes idiomas naturalmente têm níveis variados de verbosidade.
[^processing-time]: `Tempo de Processamento` baseia-se no cálculo do tempo total desde o início do fluxo até a conclusão da tradução deste arquivo específico.
