### PR TITLE
Tradução de `ViewTransition.md` para Português (Brasil)

### DIFF
--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -9,13 +9,13 @@ version: canary
 
 <Canary>
 
-**The `<ViewTransition />` API is currently only available in React’s Canary and Experimental channels.**
+**A API `<ViewTransition />` está atualmente disponível apenas nos canais Canary e Experimental do React.**
 
-[Learn more about React’s release channels here.](/community/versioning-policy#all-release-channels)
+[Saiba mais sobre os canais de lançamento do React aqui.](/community/versioning-policy#all-release-channels)
 
 </Canary>
 
-`<ViewTransition>` lets you animate a component tree with Transitions and Suspense.
+`<ViewTransition>` permite animar uma árvore de componentes com Transitions e Suspense.
 
 ```js
 import {ViewTransition} from 'react';
@@ -31,11 +31,11 @@ import {ViewTransition} from 'react';
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `<ViewTransition>` {/*viewtransition*/}
 
-Wrap a component tree in `<ViewTransition>` to animate it:
+Envolva uma árvore de componentes com `<ViewTransition>` para animá-la:
 
 ```js
 <ViewTransition>
@@ -43,77 +43,77 @@ Wrap a component tree in `<ViewTransition>` to animate it:
 </ViewTransition>
 ```
 
-[See more examples below.](#usage)
+[Veja mais exemplos abaixo.](#usage)
 
 <DeepDive>
 
-#### How does `<ViewTransition>` work? {/*how-does-viewtransition-work*/}
+#### Como `<ViewTransition>` funciona? {/*how-does-viewtransition-work*/}
 
-Under the hood, React applies `view-transition-name` to inline styles of the nearest DOM node nested inside the `<ViewTransition>` component. If there are multiple sibling DOM nodes like `<ViewTransition><div /><div /></ViewTransition>` then React adds a suffix to the name to make each unique but conceptually they're part of the same one. React doesn't apply these eagerly but only at the time that boundary should participate in an animation.
+Por baixo dos panos, o React aplica `view-transition-name` a estilos inline do nó DOM mais próximo aninhado dentro do componente `<ViewTransition>`. Se houver múltiplos nós DOM irmãos como `<ViewTransition><div /><div /></ViewTransition>`, então o React adiciona um sufixo ao nome para tornar cada um único, mas conceitualmente eles fazem parte do mesmo. O React não aplica isso de forma proativa, mas apenas no momento em que o limite deve participar de uma animação.
 
-React automatically calls `startViewTransition` itself behind the scenes so you should never do that yourself. In fact, if you have something else on the page running a ViewTransition React will interrupt it. So it's recommended that you use React itself to coordinate these. If you had other ways to trigger ViewTransitions in the past, we recommend that you migrate to the built-in way.
+O React chama automaticamente `startViewTransition` nos bastidores, então você nunca deve fazer isso sozinho. Na verdade, se você tiver algo mais na página executando uma ViewTransition, o React a interromperá. Portanto, é recomendado que você use o próprio React para coordenar isso. Se você teve outras maneiras de acionar ViewTransitions no passado, recomendamos que migre para a maneira integrada.
 
-If there are other React ViewTransitions already running then React will wait for them to finish before starting the next one. However, importantly if there are multiple updates happening while the first one is running, those will all be batched into one. If you start A->B. Then in the meantime you get an update to go to C and then D. When the first A->B animation finishes the next one will animate from B->D.
+Se houver outras ViewTransitions do React já em execução, o React esperará que elas terminem antes de iniciar a próxima. No entanto, é importante notar que se houver várias atualizações ocorrendo enquanto a primeira está em execução, todas elas serão agrupadas em uma. Se você iniciar A->B. Então, nesse ínterim, você recebe uma atualização para ir para C e depois D. Quando a primeira animação A->B terminar, a próxima animará de B->D.
 
-The `getSnapshotBeforeUpdate` lifecycle will be called before `startViewTransition` and some `view-transition-name` will update at the same time.
+O ciclo de vida `getSnapshotBeforeUpdate` será chamado antes de `startViewTransition` e alguns `view-transition-name` serão atualizados ao mesmo tempo.
 
-Then React calls `startViewTransition`. Inside the `updateCallback`, React will:
+Em seguida, o React chama `startViewTransition`. Dentro do `updateCallback`, o React irá:
 
-- Apply its mutations to the DOM and invoke `useInsertionEffect`.
-- Wait for fonts to load.
-- Call `componentDidMount`, `componentDidUpdate`, `useLayoutEffect` and refs.
-- Wait for any pending Navigation to finish.
-- Then React will measure any changes to the layout to see which boundaries will need to animate.
+- Aplicar suas mutações ao DOM e invocar `useInsertionEffect`.
+- Esperar que as fontes carreguem.
+- Chamar `componentDidMount`, `componentDidUpdate`, `useLayoutEffect` e refs.
+- Esperar que qualquer Navegação pendente termine.
+- Em seguida, o React medirá quaisquer alterações no layout para ver quais limites precisarão ser animados.
 
-After the ready Promise of the `startViewTransition` is resolved, React will then revert the `view-transition-name`. Then React will invoke the `onEnter`, `onExit`, `onUpdate` and `onShare` callbacks to allow for manual programmatic control over the animations. This will be after the built-in default ones have already been computed.
+Após a resolução da Promise `ready` de `startViewTransition`, o React reverterá o `view-transition-name`. Em seguida, o React invocará os callbacks `onEnter`, `onExit`, `onUpdate` e `onShare` para permitir o controle programático manual sobre as animações. Isso ocorrerá após o cálculo das animações padrão integradas.
 
-If a `flushSync` happens to get in the middle of this sequence, then React will skip the Transition since it relies on being able to complete synchronously.
+Se um `flushSync` ocorrer no meio desta sequência, o React pulará a Transição, pois depende de ser capaz de concluir de forma síncrona.
 
-After the finished Promise of the `startViewTransition` is resolved, React will then invoke `useEffect`. This prevents those from interfering with the performance of the animation. However, this is not a guarantee because if another `setState` happens while the animation is running it'll still have to invoke the `useEffect` earlier to preserve the sequential guarantees.
+Após a resolução da Promise `finished` de `startViewTransition`, o React invocará `useEffect`. Isso evita que eles interfiram no desempenho da animação. No entanto, isso não é uma garantia, pois se outro `setState` ocorrer enquanto a animação estiver em execução, ele ainda terá que invocar o `useEffect` mais cedo para preservar as garantias sequenciais.
 
 </DeepDive>
 
 #### Props {/*props*/}
 
-- **optional** `name`: A string or object. The name of the View Transition used for shared element transitions. If not provided, React will use a unique name for each View Transition to prevent unexpected animations.
-- [View Transition Class](#view-transition-class) props.
-- [View Transition Event](#view-transition-event) props.
+- **opcional** `name`: Uma string ou objeto. O nome da View Transition usado para transições de elementos compartilhados. Se não for fornecido, o React usará um nome exclusivo para cada View Transition para evitar animações inesperadas.
+- Props de [Classe de Transição de Visualização](#view-transition-class).
+- Props de [Evento de Transição de Visualização](#view-transition-event).
 
-#### Caveats {/*caveats*/}
+#### Ressalvas {/*caveats*/}
 
-- Only use `name` for [shared element transitions](#animating-a-shared-element). For all other animations, React automatically generates a unique name to prevent unexpected animations.
-- By default, `setState` updates immediately and does not activate `<ViewTransition>`, only updates wrapped in a [Transition](/reference/react/useTransition), [`<Suspense>`](/reference/react/Suspense), or `useDeferredValue` activate ViewTransition.
-- `<ViewTransition>` creates an image that can be moved around, scaled and cross-faded. Unlike Layout Animations you may have seen in React Native or Motion, this means that not every individual Element inside of it animates its position. This can lead to better performance and a more continuous feeling, smooth animation compared to animating every individual piece. However, it can also lose continuity in things that should be moving by themselves. So you might have to add more `<ViewTransition>` boundaries manually as a result.
-- Currently, `<ViewTransition>` only works in the DOM. We're working on adding support for React Native and other platforms.
+- Use `name` apenas para [transições de elementos compartilhados](#animating-a-shared-element). Para todas as outras animações, o React gera automaticamente um nome exclusivo para evitar animações inesperadas.
+- Por padrão, as atualizações de `setState` ocorrem imediatamente e não ativam `<ViewTransition>`, apenas atualizações encapsuladas em uma [Transition](/reference/react/useTransition), [`<Suspense>`](/reference/react/Suspense) ou `useDeferredValue` ativam ViewTransition.
+- `<ViewTransition>` cria uma imagem que pode ser movida, dimensionada e com fade cruzado. Ao contrário das Animações de Layout que você pode ter visto no React Native ou Motion, isso significa que nem todo Elemento individual dentro dele anima sua posição. Isso pode levar a um melhor desempenho e uma animação mais contínua e suave em comparação com a animação de cada peça individual. No entanto, também pode perder a continuidade em coisas que deveriam estar se movendo por conta própria. Portanto, você pode ter que adicionar mais `<ViewTransition>` manualmente como resultado.
+- Atualmente, `<ViewTransition>` funciona apenas no DOM. Estamos trabalhando para adicionar suporte ao React Native e outras plataformas.
 
-#### Animation triggers {/*animation-triggers*/}
+#### Gatilhos de animação {/*animation-triggers*/}
 
-React automatically decides the type of View Transition animation to trigger:
+O React decide automaticamente o tipo de animação de View Transition a ser acionada:
 
-- `enter`: If a `ViewTransition` is the first component inserted in this Transition, then this will activate.
-- `exit`: If a `ViewTransition` is the first component deleted in this Transition, then this will activate.
-- `update`: If a `ViewTransition` has any DOM mutations inside it that React is doing (such as a prop changing) or if the `ViewTransition` boundary itself changes size or position due to an immediate sibling. If there are nested `ViewTransition` then the mutation applies to them and not the parent.
-- `share`: If a named `ViewTransition` is inside a deleted subtree and another named `ViewTransition` with the same name is part of an inserted subtree in the same Transition, they form a Shared Element Transition, and it animates from the deleted one to the inserted one.
+- `enter`: Se um `ViewTransition` for o primeiro componente inserido nesta Transição, isso será ativado.
+- `exit`: Se um `ViewTransition` for o primeiro componente excluído nesta Transição, isso será ativado.
+- `update`: Se um `ViewTransition` tiver quaisquer mutações de DOM dentro dele que o React esteja fazendo (como uma prop mudando) ou se o próprio limite `ViewTransition` mudar de tamanho ou posição devido a um irmão imediato. Se houver `ViewTransition` aninhados, a mutação se aplica a eles e não ao pai.
+- `share`: Se um `ViewTransition` nomeado estiver dentro de uma subárvore excluída e outro `ViewTransition` nomeado com o mesmo nome fizer parte de uma subárvore inserida na mesma Transição, eles formam uma Transição de Elemento Compartilhado e animam do excluído para o inserido.
 
-By default, `<ViewTransition>` animates with a smooth cross-fade (the browser default view transition).
+Por padrão, `<ViewTransition>` anima com um fade cruzado suave (a transição de visualização padrão do navegador).
 
-You can customize the animation by providing a [View Transition Class](#view-transition-class) to the `<ViewTransition>` component for each kind of trigger (see [Styling View Transitions](#styling-view-transitions)), or by using [ViewTransition Events](#view-transition-events) to control the animation with JavaScript using the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).
+Você pode personalizar a animação fornecendo uma [Classe de Transição de Visualização](#view-transition-class) para o componente `<ViewTransition>` para cada tipo de gatilho (veja [Estilizando Transições de Visualização](#styling-view-transitions)), ou usando [Eventos de Transição de Visualização](#view-transition-events) para controlar a animação com JavaScript usando a [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).
 
 <Note>
 
-#### Always check `prefers-reduced-motion` {/*always-check-prefers-reduced-motion*/}
+#### Sempre verifique `prefers-reduced-motion` {/*always-check-prefers-reduced-motion*/}
 
-Many users may prefer not having animations on the page. React doesn't automatically disable animations for this case.
+Muitos usuários podem preferir não ter animações na página. O React não desabilita automaticamente as animações para este caso.
 
-We recommend always using the `@media (prefers-reduced-motion)` media query to disable animations or tone them down based on user preference.
+Recomendamos sempre usar a consulta de mídia `@media (prefers-reduced-motion)` para desativar animações ou atenuá-las com base na preferência do usuário.
 
-In the future, CSS libraries may have this built-in to their presets.
+No futuro, as bibliotecas CSS podem ter isso integrado em seus presets.
 
 </Note>
 
-### View Transition Class {/*view-transition-class*/}
+### Classe de Transição de Visualização {/*view-transition-class*/}
 
-`<ViewTransition>` provides props to define what animations trigger:
+`<ViewTransition>` fornece props para definir quais animações são acionadas:
 
 ```js
 <ViewTransition
@@ -125,53 +125,53 @@ In the future, CSS libraries may have this built-in to their presets.
 
 #### Props {/*view-transition-class-props*/}
 
-- **optional** `enter`: `"auto"`, `"none"`, a string, or an object.
-- **optional** `exit`: `"auto"`, `"none"`, a string, or an object.
-- **optional** `update`: `"auto"`, `"none"`, a string, or an object.
-- **optional** `share`: `"auto"`, `"none"`, a string, or an object.
-- **optional** `default`: `"auto"`, `"none"`, a string, or an object.
+- **opcional** `enter`: `"auto"`, `"none"`, uma string ou um objeto.
+- **opcional** `exit`: `"auto"`, `"none"`, uma string ou um objeto.
+- **opcional** `update`: `"auto"`, `"none"`, uma string ou um objeto.
+- **opcional** `share`: `"auto"`, `"none"`, uma string ou um objeto.
+- **opcional** `default`: `"auto"`, `"none"`, uma string ou um objeto.
 
-#### Caveats {/*view-transition-class-caveats*/}
+#### Ressalvas {/*view-transition-class-caveats*/}
 
-- If `default` is `"none"` then all other triggers are turned off unless explicitly listed.
+- Se `default` for `"none"`, todos os outros gatilhos serão desativados, a menos que sejam explicitamente listados.
 
-#### Values {/*view-transition-values*/}
+#### Valores {/*view-transition-values*/}
 
-View Transition class values can be:
-- `auto`: the default. Uses the browser default animation.
-- `none`: disable animations for this type.
-- `<classname>`: a custom CSS class name to use for [customizing View Transitions](#styling-view-transitions).
+Os valores da classe de Transição de Visualização podem ser:
+- `auto`: o padrão. Usa a animação padrão do navegador.
+- `none`: desativa as animações para este tipo.
+- `<classname>`: um nome de classe CSS personalizado a ser usado para [personalizar Transições de Visualização](#styling-view-transitions).
 
-Object values can be an object with string keys and a value of `auto`, `none` or a custom className:
-- `{[type]: value}`: applies `value` if the animation matches the [Transition Type](/reference/react/addTransitionType).
-- `{default: value}`: the default value to apply if no [Transition Type](/reference/react/addTransitionType) is matched.
+Valores de objeto podem ser um objeto com chaves de string e um valor de `auto`, `none` ou um nome de classe personalizado:
+- `{[type]: value}`: aplica `value` se a animação corresponder ao [Tipo de Transição](/reference/react/addTransitionType).
+- `{default: value}`: o valor padrão a ser aplicado se nenhum [Tipo de Transição](/reference/react/addTransitionType) for correspondido.
 
-For example, you can define a ViewTransition as:
+Por exemplo, você pode definir uma ViewTransition como:
 
 ```js
 <ViewTransition
-  /* turn off any animation not defined below */
+  /* desativa qualquer animação não definida abaixo */
   default="none"
   enter={{
-    /* apply slide-in for Transition Type `forward` */
+    /* aplica slide-in para o Tipo de Transição `forward` */
     "forward": 'slide-in',
-    /* otherwise use the browser default animation */
+    /* caso contrário, usa a animação padrão do navegador */
     "default": 'auto'
   }}
-  /* use the browser default for exit animations*/
+  /* usa o padrão do navegador para animações de saída */
   exit="auto"
-  /* apply a custom `cross-fade` class for updates */
+  /* aplica uma classe `cross-fade` personalizada para atualizações */
   update="cross-fade"
 >
 ```
 
-See [Styling View Transitions](#styling-view-transitions) for how to define CSS classes for custom animations.
+Veja [Estilizando Transições de Visualização](#styling-view-transitions) para saber como definir classes CSS para animações personalizadas.
 
 ---
 
-### View Transition Event {/*view-transition-event*/}
+### Evento de Transição de Visualização {/*view-transition-event*/}
 
-View Transition Events allow you to control the animation with JavaScript using the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API):
+Eventos de Transição de Visualização permitem que você controle a animação com JavaScript usando a [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API):
 
 ```js
 <ViewTransition
@@ -182,29 +182,29 @@ View Transition Events allow you to control the animation with JavaScript using 
 
 #### Props {/*view-transition-event-props*/}
 
-- **optional** `onEnter`: Called when an "enter" animation is triggered.
-- **optional** `onExit`: Called when an "exit" animation is triggered.
-- **optional** `onShare`: Called when a "share" animation is triggered.
-- **optional** `onUpdate`: Called when an "update" animation is triggered.
+- **opcional** `onEnter`: Chamado quando uma animação de "entrada" é acionada.
+- **opcional** `onExit`: Chamado quando uma animação de "saída" é acionada.
+- **opcional** `onShare`: Chamado quando uma animação de "compartilhamento" é acionada.
+- **opcional** `onUpdate`: Chamado quando uma animação de "atualização" é acionada.
 
 
-#### Caveats {/*view-transition-event-caveats*/}
-- Only one event fires per `<ViewTransition>` per Transition. `onShare` takes precedence over `onEnter` and `onExit`.
-- Each event should return a **cleanup function**. The cleanup function is called when the View Transition finishes, allowing you to cancel or cleanup any animations.
+#### Ressalvas {/*view-transition-event-caveats*/}
+- Apenas um evento dispara por `<ViewTransition>` por Transição. `onShare` tem precedência sobre `onEnter` e `onExit`.
+- Cada evento deve retornar uma **função de limpeza**. A função de limpeza é chamada quando a Transição de Visualização termina, permitindo que você cancele ou limpe quaisquer animações.
 
-#### Arguments {/*view-transition-event-arguments*/}
+#### Argumentos {/*view-transition-event-arguments*/}
 
-Each event receives two arguments:
+Cada evento recebe dois argumentos:
 
-- `instance`: A View Transition instance that provides access to the view transition [pseudo-elements](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API/Using#the_view_transition_process)
-  - `old`: The `::view-transition-old` pseudo-element.
-  - `new`: The `::view-transition-new` pseudo-element.
-  - `name`: The `view-transition-name` string for this boundary.
-  - `group`: The `::view-transition-group` pseudo-element.
-  - `imagePair`: The `::view-transition-image-pair` pseudo-element.
-- `types`: An `Array<string>` of [Transition Types](/reference/react/addTransitionType) included in the animation. Empty array if no types were specified.
+- `instance`: Uma instância de Transição de Visualização que fornece acesso aos [pseudo-elementos](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API/Using#the_view_transition_process) da transição de visualização
+  - `old`: O pseudo-elemento `::view-transition-old`.
+  - `new`: O pseudo-elemento `::view-transition-new`.
+  - `name`: A string `view-transition-name` para este limite.
+  - `group`: O pseudo-elemento `::view-transition-group`.
+  - `imagePair`: O pseudo-elemento `::view-transition-image-pair`.
+- `types`: Um `Array<string>` de [Tipos de Transição](/reference/react/addTransitionType) incluídos na animação. Array vazio se nenhum tipo foi especificado.
 
-For example, you can define a `onEnter` event that drives the animation using JavaScript:
+Por exemplo, você pode definir um evento `onEnter` que controla a animação usando JavaScript:
 
 ```js
 <ViewTransition
@@ -218,27 +218,27 @@ For example, you can define a `onEnter` event that drives the animation using Ja
 </ViewTransition>
 ```
 
-See [Animating with JavaScript](#animating-with-javascript) for more examples.
+Veja [Animando com JavaScript](#animating-with-javascript) para mais exemplos.
 
 ---
 
-## Styling View Transitions {/*styling-view-transitions*/}
+## Estilizando Transições de Visualização {/*styling-view-transitions*/}
 
 <Note>
 
-In many early examples of View Transitions around the web, you'll have seen using a [`view-transition-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/view-transition-name) and then style it using `::view-transition-...(my-name)` selectors. We don't recommend that for styling. Instead, we normally recommend using a View Transition Class instead.
+Em muitos exemplos iniciais de Transições de Visualização na web, você verá o uso de um [`view-transition-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/view-transition-name) e, em seguida, a estilização usando seletores `::view-transition-...(my-name)`. Não recomendamos isso para estilização. Em vez disso, normalmente recomendamos o uso de uma Classe de Transição de Visualização.
 
 </Note>
 
-To customize the animation for a `<ViewTransition>` you can provide a View Transition Class to one of the activation props. The View Transition Class is a CSS class name that React applies to the child elements when the ViewTransition activates.
+Para personalizar a animação de um `<ViewTransition>`, você pode fornecer uma Classe de Transição de Visualização a uma das props de ativação. A Classe de Transição de Visualização é um nome de classe CSS que o React aplica aos elementos filhos quando a ViewTransition é ativada.
 
-For example, to customize an "enter" animation, provide a class name to the `enter` prop:
+Por exemplo, para personalizar uma animação de "entrada", forneça um nome de classe à prop `enter`:
 
 ```js
 <ViewTransition enter="slide-in">
 ```
 
-When the `<ViewTransition>` activates an "enter" animation, React will add the class name `slide-in`. Then you can refer to this class using [view transition pseudo selectors](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API#pseudo-elements) to build reusable animations:
+Quando o `<ViewTransition>` ativar uma animação de "entrada", o React adicionará o nome de classe `slide-in`. Em seguida, você pode se referir a esta classe usando [pseudo-seletores de transição de visualização](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API#pseudo-elements) para criar animações reutilizáveis:
 
 ```css
 ::view-transition-group(.slide-in) {
@@ -249,21 +249,21 @@ When the `<ViewTransition>` activates an "enter" animation, React will add the c
 }
 ```
 
-In the future, CSS libraries may add built-in animations using View Transition Classes to make this easier to use.
+No futuro, as bibliotecas CSS podem adicionar animações integradas usando Classes de Transição de Visualização para facilitar o uso.
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Animating an element on enter/exit {/*animating-an-element-on-enter*/}
+### Animando um elemento ao entrar/sair {/*animating-an-element-on-enter*/}
 
-Enter/Exit Transitions trigger when a `<ViewTransition>` is added or removed by a component in a transition:
+Transições de Entrada/Saída são acionadas quando um `<ViewTransition>` é adicionado ou removido por um componente em uma transição:
 
 ```js {3}
 function Child() {
   return (
     <ViewTransition enter="auto" exit="auto" default="none">
-      <div>Hi</div>
+      <div>Oi</div>
     </ViewTransition>
   );
 }
@@ -277,9 +277,9 @@ function Parent() {
 }
 ```
 
-When `setShow` is called, `show` switches to `true` and the `Child` component is rendered. When `setShow` is called inside `startTransition`, and `Child` renders a `ViewTransition` before any other DOM nodes, an `enter` animation is triggered.
+Quando `setShow` é chamado, `show` muda para `true` e o componente `Child` é renderizado. Quando `setShow` é chamado dentro de `startTransition`, e `Child` renderiza um `ViewTransition` antes de qualquer outro nó DOM, uma animação de `enter` é acionada.
 
-When `show` switches back to `false`, an `exit` animation is triggered.
+Quando `show` muda de volta para `false`, uma animação de `exit` é acionada.
 
 <Sandpack>
 
@@ -447,16 +447,16 @@ button:hover {
 
 <Pitfall>
 
-#### Only top-level ViewTransitions animate on exit/enter {/*only-top-level-viewtransition-animates-on-exit-enter*/}
+#### Apenas ViewTransitions de nível superior animam na saída/entrada {/*only-top-level-viewtransition-animates-on-exit-enter*/}
 
-`<ViewTransition>` only activates exit/enter if it is placed _before_ any DOM nodes.
+`<ViewTransition>` só ativa a saída/entrada se for colocado _antes_ de quaisquer nós DOM.
 
-If there's a `<div>` above `<ViewTransition>`, no exit/enter animations trigger:
+Se houver um `<div>` acima do `<ViewTransition>`, nenhuma animação de saída/entrada será acionada:
 
 ```js [3, 5]
 function Item() {
   return (
-    <div> {/* 🚩<div> above <ViewTransition> breaks exit/enter */}
+    <div> {/* 🚩<div> acima de <ViewTransition> quebra a saída/entrada */}
       <ViewTransition enter="auto" exit="auto" default="none">
         <Video video={videos[0]} />
       </ViewTransition>
@@ -465,15 +465,15 @@ function Item() {
 }
 ```
 
-This constraint prevents subtle bugs where too much or too little animates.
+Essa restrição evita bugs sutis onde anima muito ou muito pouco.
 
 </Pitfall>
 
 ---
 
-### Animating enter/exit with Activity {/*animating-enter-exit-with-activity*/}
+### Animando entrada/saída com Activity {/*animating-enter-exit-with-activity*/}
 
-If you want to animate a component in and out while preserving its state, or pre-rendering content for an animation, you can use [`<Activity>`](/reference/react/Activity). When a `<ViewTransition>` inside an `<Activity>` becomes visible, the `enter` animation activates. When it becomes hidden, the `exit` animation activates:
+Se você deseja animar um componente entrando e saindo enquanto preserva seu estado, ou pré-renderizando conteúdo para uma animação, você pode usar [`<Activity>`](/reference/react/Activity). Quando um `<ViewTransition>` dentro de um `<Activity>` se torna visível, a animação `enter` é ativada. Quando se torna oculto, a animação `exit` é ativada:
 
 ```js
 <Activity mode={isVisible ? 'visible' : 'hidden'}>
@@ -484,7 +484,7 @@ If you want to animate a component in and out while preserving its state, or pre
 
 ```
 
-In this example, `Counter` has a counter with internal state. Try incrementing the counter, hiding it, then showing it again. The counter's value is preserved while the sidebar animates in and out:
+Neste exemplo, `Counter` tem um contador com estado interno. Tente incrementar o contador, ocultá-lo e mostrá-lo novamente. O valor do contador é preservado enquanto a barra lateral anima entrando e saindo:
 
 <Sandpack>
 
@@ -585,13 +585,13 @@ function Counter() {
 
 </Sandpack>
 
-Without `<Activity>`, the counter would reset to `0` every time the sidebar reappears.
+Sem `<Activity>`, o contador seria resetado para `0` toda vez que a barra lateral reaparecesse.
 
 ---
 
-### Animating a shared element {/*animating-a-shared-element*/}
+### Animando um elemento compartilhado {/*animating-a-shared-element*/}
 
-Normally, we don't recommend assigning a name to a `<ViewTransition>` and instead let React assign it an automatic name. The reason you might want to assign a name is to animate between completely different components when one tree unmounts and another tree mounts at the same time, to preserve continuity.
+Normalmente, não recomendamos atribuir um nome a um `<ViewTransition>` e, em vez disso, deixamos o React atribuir um nome automático. A razão pela qual você pode querer atribuir um nome é para animar entre componentes completamente diferentes quando uma árvore é desmontada e outra árvore é montada ao mesmo tempo, para preservar a continuidade.
 
 ```js
 <ViewTransition name={UNIQUE_NAME}>
@@ -599,11 +599,11 @@ Normally, we don't recommend assigning a name to a `<ViewTransition>` and instea
 </ViewTransition>
 ```
 
-When one tree unmounts and another mounts, if there's a pair where the same name exists in the unmounting tree and the mounting tree, they trigger the "share" animation on both. It animates from the unmounting side to the mounting side.
+Quando uma árvore é desmontada e outra é montada, se houver um par onde o mesmo nome existe na árvore que está sendo desmontada e na árvore que está sendo montada, eles acionam a animação "compartilhada" em ambos. Ela anima do lado que está sendo desmontado para o lado que está sendo montado.
 
-Unlike an exit/enter animation this can be deeply inside the deleted/mounted tree. If a `<ViewTransition>` would also be eligible for exit/enter, then the "share" animation takes precedence.
+Ao contrário de uma animação de saída/entrada, isso pode estar profundamente dentro da árvore deletada/montada. Se um `<ViewTransition>` também fosse elegível para saída/entrada, então a animação "compartilhada" teria precedência.
 
-If Transition first unmounts one side and then leads to a `<Suspense>` fallback being shown before eventually the new name being mounted, then no shared element transition happens.
+Se a Transição primeiro desmontar um lado e depois levar a um fallback `<Suspense>` a ser exibido antes que o novo nome seja eventualmente montado, nenhuma transição de elemento compartilhado ocorrerá.
 
 <Sandpack>
 
@@ -811,17 +811,17 @@ button:hover {
 
 <Note>
 
-If either the mounted or unmounted side of a pair is outside the viewport, then no pair is formed. This ensures that it doesn't fly in or out of the viewport when something is scrolled. Instead it's treated as a regular enter/exit by itself.
+Se um dos lados do par, montado ou desmontado, estiver fora da viewport, então nenhum par é formado. Isso garante que ele não apareça ou desapareça da viewport quando algo é rolado. Em vez disso, ele é tratado como uma entrada/saída regular por si só.
 
-This does not happen if the same Component instance changes position, which triggers an "update". Those animate regardless of whether one position is outside the viewport.
+Isso não acontece se a mesma instância do Componente mudar de posição, o que aciona uma "atualização". Essas animam independentemente de um lado estar fora da viewport.
 
-There is a known case where if a deeply nested unmounted `<ViewTransition>` is inside the viewport but the mounted side is not within the viewport, then the unmounted side animates as its own "exit" animation even if it's deeply nested instead of as part of the parent animation.
+Existe um caso conhecido onde, se um `<ViewTransition>` profundamente aninhado e desmontado estiver dentro da viewport, mas o lado montado não estiver dentro da viewport, o lado desmontado animará como sua própria animação de "saída", mesmo que esteja profundamente aninhado, em vez de como parte da animação pai.
 
 </Note>
 
 <Pitfall>
 
-It's important that there's only one thing with the same name mounted at a time in the entire app. Therefore it's important to use unique namespaces for the name to avoid conflicts. To ensure you can do this you might want to add a constant in a separate module that you import.
+É importante que haja apenas uma coisa com o mesmo nome montada por vez em todo o aplicativo. Portanto, é importante usar namespaces únicos para o nome para evitar conflitos. Para garantir que você possa fazer isso, você pode querer adicionar uma constante em um módulo separado que você importe.
 
 ```js
 export const MY_NAME = "my-globally-unique-name";
@@ -834,15 +834,15 @@ import {MY_NAME} from './shared-name';
 
 ---
 
-### Animating reorder of items in a list {/*animating-reorder-of-items-in-a-list*/}
+### Animando a reordenação de itens em uma lista {/*animating-reorder-of-items-in-a-list*/}
 
 ```js
 items.map((item) => <Component key={item.id} item={item} />);
 ```
 
-When reordering a list, without updating the content, the "update" animation triggers on each `<ViewTransition>` in the list if they're outside a DOM node. Similar to enter/exit animations.
+Ao reordenar uma lista, sem atualizar o conteúdo, a animação "update" é acionada em cada `<ViewTransition>` na lista se eles estiverem fora de um nó DOM. Semelhante às animações de entrada/saída.
 
-This means that this will trigger the animation on this `<ViewTransition>`:
+Isso significa que isso acionará a animação neste `<ViewTransition>`:
 
 ```js
 function Component() {
@@ -1043,7 +1043,7 @@ button:hover {
 
 </Sandpack>
 
-However, this wouldn't animate each individual item:
+No entanto, isso não animaria cada item individualmente:
 
 ```js
 function Component() {
@@ -1055,7 +1055,7 @@ function Component() {
 }
 ```
 
-Instead, any parent `<ViewTransition>` would cross-fade. If there is no parent `<ViewTransition>` then there's no animation in that case.
+Em vez disso, qualquer `<ViewTransition>` pai faria um cross-fade. Se não houver um `<ViewTransition>` pai, então não há animação nesse caso.
 
 <Sandpack>
 
@@ -1244,33 +1244,33 @@ button:hover {
 
 </Sandpack>
 
-This means you might want to avoid wrapper elements in lists where you want to allow the Component to control its own reorder animation:
+Isso significa que você pode querer evitar elementos de wrapper em listas onde você deseja permitir que o Componente controle sua própria animação de reordenação:
 
 ```
 items.map(item => <div><Component key={item.id} item={item} /></div>)
 ```
 
-The above rule also applies if one of the items updates to resize, which then causes the siblings to resize, it'll also animate its sibling `<ViewTransition>` but only if they're immediate siblings.
+A regra acima também se aplica se um dos itens for atualizado para redimensionar, o que faz com que os irmãos redimensionem, ele também animará seu `<ViewTransition>` irmão, mas apenas se eles forem irmãos imediatos.
 
-This means that during an update, which causes a lot of re-layout, it doesn't individually animate every `<ViewTransition>` on the page. That would lead to a lot of noisy animations which distracts from the actual change. Therefore React is more conservative about when an individual animation triggers.
+Isso significa que durante uma atualização, que causa muito relayout, ele não anima individualmente cada `<ViewTransition>` na página. Isso levaria a muitas animações barulhentas que distraem da mudança real. Portanto, o React é mais conservador sobre quando uma animação individual é acionada.
 
 <Pitfall>
 
-It's important to properly use keys to preserve identity when reordering lists. It might seem like you could use "name", shared element transitions, to animate reorders but that would not trigger if one side was outside the viewport. To animate a reorder you often want to show that it went to a position outside the viewport.
+É importante usar corretamente as chaves para preservar a identidade ao reordenar listas. Pode parecer que você poderia usar "name", transições de elementos compartilhados, para animar reordenações, mas isso não seria acionado se um lado estivesse fora da viewport. Para animar uma reordenação, você geralmente quer mostrar que ela foi para uma posição fora da viewport.
 
 </Pitfall>
 
 ---
 
-### Animating from Suspense content {/*animating-from-suspense-content*/}
+### Animando conteúdo do Suspense {/*animating-from-suspense-content*/}
 
-Like any Transition, React waits for data and new CSS (`<link rel="stylesheet" precedence="...">`) before running the animation. In addition to this, ViewTransitions also wait up to 500ms for new fonts to load before starting the animation to avoid them flickering in later. For the same reason, an image wrapped in ViewTransition will wait for the image to load.
+Como qualquer Transição, o React espera pelos dados e por novos CSS (`<link rel="stylesheet" precedence="...">`) antes de executar a animação. Além disso, as ViewTransitions também esperam até 500ms para que novas fontes sejam carregadas antes de iniciar a animação, para evitar que elas pisquem posteriormente. Pelo mesmo motivo, uma imagem envolvida por uma ViewTransition esperará o carregamento da imagem.
 
-If it's inside a new Suspense boundary instance, then the fallback is shown first. After the Suspense boundary fully loads, it triggers the `<ViewTransition>` to animate the reveal to the content.
+Se estiver dentro de uma nova instância de `Suspense boundary`, o fallback será exibido primeiro. Após o `Suspense boundary` carregar completamente, ele aciona a `<ViewTransition>` para animar a revelação do conteúdo.
 
-There are two ways to animate Suspense boundaries depending on where you place the `<ViewTransition>`:
+Existem duas maneiras de animar `Suspense boundaries` dependendo de onde você coloca a `<ViewTransition>`:
 
-**Update:**
+**Atualização:**
 
 ```
 <ViewTransition>
@@ -1280,7 +1280,7 @@ There are two ways to animate Suspense boundaries depending on where you place t
 </ViewTransition>
 ```
 
-In this scenario when the content goes from A to B, it'll be treated as an "update" and apply that class if appropriate. Both A and B will get the same view-transition-name and therefore they're acting as a cross-fade by default.
+Neste cenário, quando o conteúdo muda de A para B, ele será tratado como uma "atualização" e aplicará a classe apropriada. Tanto A quanto B terão o mesmo `view-transition-name` e, portanto, agirão como um cross-fade por padrão.
 
 <Sandpack>
 
@@ -1506,7 +1506,7 @@ button:hover {
 
 </Sandpack>
 
-**Enter/Exit:**
+**Entrada/Saída:**
 
 ```
 <Suspense fallback={<ViewTransition><A /></ViewTransition>}>
@@ -1514,17 +1514,17 @@ button:hover {
 </Suspense>
 ```
 
-In this scenario, these are two separate ViewTransition instances each with their own `view-transition-name`. This will be treated as an "exit" of the `<A>` and an "enter" of the `<B>`.
+Neste cenário, são duas instâncias separadas de `ViewTransition`, cada uma com seu próprio `view-transition-name`. Isso será tratado como uma "saída" de `<A>` e uma "entrada" de `<B>`.
 
-You can achieve different effects depending on where you choose to place the `<ViewTransition>` boundary.
+Você pode obter efeitos diferentes dependendo de onde escolher colocar o limite da `<ViewTransition>`.
 
 ---
 
-### Opting-out of an animation {/*opting-out-of-an-animation*/}
+### Otimizando para fora de uma animação {/*opting-out-of-an-animation*/}
 
-Sometimes you're wrapping a large existing component, like a whole page, and you want to animate some updates, such as changing the theme. However, you don't want it to opt-in all updates inside the whole page to cross-fade when they're updating. Especially if you're incrementally adding more animations.
+Às vezes, você está envolvendo um componente grande existente, como uma página inteira, e deseja animar algumas atualizações, como a mudança de tema. No entanto, você não quer que todas as atualizações dentro da página inteira sejam animadas com cross-fade quando elas são atualizadas. Especialmente se você estiver adicionando animações incrementalmente.
 
-You can use the class "none" to opt-out of an animation. By wrapping your children in a "none" you can disable animations for updates to them while the parent still triggers.
+Você pode usar a classe "none" para otimizar para fora de uma animação. Ao envolver seus filhos em um "none", você pode desativar animações para atualizações neles, enquanto o pai ainda aciona.
 
 ```js
 <ViewTransition>
@@ -1534,17 +1534,17 @@ You can use the class "none" to opt-out of an animation. By wrapping your childr
 </ViewTransition>
 ```
 
-This will only animate if the theme changes and not if only the children update. The children can still opt-in again with their own `<ViewTransition>` but at least it's manual again.
+Isso animará apenas se o tema mudar e não se apenas os filhos forem atualizados. Os filhos ainda podem optar por participar novamente com sua própria `<ViewTransition>`, mas pelo menos será manual novamente.
 
 ---
 
-### Customizing animations {/*customizing-animations*/}
+### Personalizando animações {/*customizing-animations*/}
 
-By default, `<ViewTransition>` includes the default cross-fade from the browser.
+Por padrão, `<ViewTransition>` inclui o cross-fade padrão do navegador.
 
-To customize animations, you can provide props to the `<ViewTransition>` component to specify which animations to use, based on how the `<ViewTransition>` activates.
+Para personalizar animações, você pode fornecer props para o componente `<ViewTransition>` para especificar quais animações usar, com base em como a `<ViewTransition>` é ativada.
 
-For example, we can slow down the default cross fade animation:
+Por exemplo, podemos desacelerar a animação de cross-fade padrão:
 
 ```js
 <ViewTransition default="slow-fade">
@@ -1552,7 +1552,7 @@ For example, we can slow down the default cross fade animation:
 </ViewTransition>
 ```
 
-And define slow-fade in CSS using view transition classes:
+E definir `slow-fade` em CSS usando classes de transição de visualização:
 
 ```css
 ::view-transition-old(.slow-fade) {
@@ -1737,7 +1737,7 @@ button:hover {
 
 </Sandpack>
 
-In addition to setting the `default`, you can also provide configurations for `enter`, `exit`, `update`, and `share` animations.
+Além de definir o `default`, você também pode fornecer configurações para animações de `enter`, `exit`, `update` e `share`.
 
 <Sandpack>
 
@@ -1924,7 +1924,7 @@ button:hover {
   justify-content: center;
   align-items: center;
   border-radius: 0.5rem;
-  outline-offset: 2px;
+  outline-offset: 4px;
   width: 8rem;
   vertical-align: middle;
   background-color: #ffffff;
@@ -1985,11 +1985,11 @@ button:hover {
 
 ---
 
-### Customizing animations with types {/*customizing-animations-with-types*/}
+### Personalizando animações com tipos {/*customizing-animations-with-types*/}
 
-You can use the [`addTransitionType`](/reference/react/addTransitionType) API to add a class name to the child elements when a specific transition type is activated for a specific activation trigger. This allows you to customize the animation for each type of transition.
+Você pode usar a API [`addTransitionType`](/reference/react/addTransitionType) para adicionar um nome de classe aos elementos filhos quando um tipo específico de transição é ativado para um gatilho de ativação específico. Isso permite que você personalize a animação para cada tipo de transição.
 
-For example, to customize the animation for all forward and backward navigations:
+Por exemplo, para personalizar a animação para todas as navegações para frente e para trás:
 
 ```js
 <ViewTransition
@@ -2000,15 +2000,15 @@ For example, to customize the animation for all forward and backward navigations
   <div>...</div>
 </ViewTransition>;
 
-// in your router:
+// no seu roteador:
 startTransition(() => {
   addTransitionType('navigation-' + navigationType);
 });
 ```
 
-When the ViewTransition activates a "navigation-back" animation, React will add the class name "slide-right". When the ViewTransition activates a "navigation-forward" animation, React will add the class name "slide-left".
+Quando a `ViewTransition` ativa uma animação "navigation-back", o React adicionará o nome da classe "slide-right". Quando a `ViewTransition` ativa uma animação "navigation-forward", o React adicionará o nome da classe "slide-left".
 
-In the future, routers and other libraries may add support for standard view-transition types and styles.
+No futuro, roteadores e outras bibliotecas poderão adicionar suporte para tipos e estilos de transição de visualização padrão.
 
 <Sandpack>
 
@@ -2314,11 +2314,11 @@ button:hover {
 
 ---
 
-### Animating with JavaScript {/*animating-with-javascript*/}
+### Animação com JavaScript {/*animating-with-javascript*/}
 
-While [View Transition Classes](#view-transition-class) let you define animations with CSS, sometimes you need imperative control over the animation. The `onEnter`, `onExit`, `onUpdate`, and `onShare` callbacks give you direct access to the view transition pseudo-elements so you can animate them using the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).
+Enquanto as [Classes de Transição de Visualização](#view-transition-class) permitem definir animações com CSS, às vezes você precisa de controle imperativo sobre a animação. Os callbacks `onEnter`, `onExit`, `onUpdate` e `onShare` dão acesso direto aos pseudo-elementos de transição de visualização para que você possa animá-los usando a [Web Animations API](https://developer.mozilla.org/pt-BR/docs/Web/API/Web_Animations_API).
 
-Each callback receives an `instance` with `.old` and `.new` properties representing the view transition pseudo-elements. You can call `.animate()` on them just like you would on a DOM element:
+Cada callback recebe uma `instance` com propriedades `.old` e `.new` representando os pseudo-elementos de transição de visualização. Você pode chamar `.animate()` neles assim como faria em um elemento DOM:
 
 ```js
 <ViewTransition
@@ -2336,9 +2336,9 @@ Each callback receives an `instance` with `.old` and `.new` properties represent
 </ViewTransition>
 ```
 
-This allows you to combine CSS-driven animations and JavaScript-driven animations.
+Isso permite combinar animações controladas por CSS e animações controladas por JavaScript.
 
-In the following example, the default cross-fade is handled by CSS, and the slide animations are driven by JavaScript in the `onEnter` and `onExit` animations:
+No exemplo a seguir, o fade cruzado padrão é tratado por CSS, e as animações de slide são controladas por JavaScript nas animações `onEnter` e `onExit`:
 
 <Sandpack>
 
@@ -2540,9 +2540,9 @@ button:hover {
 
 <Note>
 
-#### Always clean up View Transition Events {/*always-clean-up-view-transition-events*/}
+#### Sempre limpe os Eventos de Transição de Visualização {/*always-clean-up-view-transition-events*/}
 
-View Transition Events should always return a cleanup function:
+Os Eventos de Transição de Visualização devem sempre retornar uma função de limpeza:
 
 ```js {7}
 <ViewTransition
@@ -2556,15 +2556,15 @@ View Transition Events should always return a cleanup function:
 >
 ```
 
-This allows the browser to cancel the animation when the View Transition is interrupted.
+Isso permite que o navegador cancele a animação quando a Transição de Visualização for interrompida.
 
 </Note>
 
 ---
 
-### Animating transition types with JavaScript {/*animating-transition-types-with-javascript*/}
+### Animação de tipos de transição com JavaScript {/*animating-transition-types-with-javascript*/}
 
-You can use `types` passed to `ViewTransition` events to conditionally apply different animations based on how the Transition was triggered.
+Você pode usar `types` passados para eventos de `ViewTransition` para aplicar condicionalmente animações diferentes com base em como a Transição foi acionada.
 
 ```js {3}
  <ViewTransition
@@ -2579,7 +2579,7 @@ You can use `types` passed to `ViewTransition` events to conditionally apply dif
 >
 ```
 
-This example calls [`addTransitionType`](/reference/react/addTransitionType) to mark a Transition as "fast" and then adjust the animation duration:
+Este exemplo chama [`addTransitionType`](/reference/react/addTransitionType) para marcar uma Transição como "rápida" e, em seguida, ajustar a duração da animação:
 
 <Sandpack>
 
@@ -2785,49 +2785,49 @@ button:hover {
 
 ---
 
-### Building View Transition enabled routers {/*building-view-transition-enabled-routers*/}
+### Construindo roteadores com suporte a Transição de Visualização {/*building-view-transition-enabled-routers*/}
 
-React waits for any pending Navigation to finish to ensure that scroll restoration happens within the animation. If the Navigation is blocked on React, your router must unblock in `useLayoutEffect` since `useEffect` would lead to a deadlock.
+O React aguarda a conclusão de qualquer Navegação pendente para garantir que a restauração da rolagem ocorra dentro da animação. Se a Navegação estiver bloqueada no React, seu roteador deve desbloquear em `useLayoutEffect`, pois `useEffect` levaria a um deadlock.
 
-If a `startTransition` is started from the legacy popstate event, such as during a "back"-navigation then it must finish synchronously to ensure scroll and form restoration works correctly. This is in conflict with running a View Transition animation. Therefore, React will skip animations from popstate and animations won't run for the back button. You can fix this by upgrading your router to use the Navigation API.
+Se um `startTransition` for iniciado a partir do evento popstate legado, como durante uma navegação "voltar", ele deverá ser concluído de forma síncrona para garantir que a restauração de scroll e formulário funcione corretamente. Isso entra em conflito com a execução de uma animação de Transição de Visualização. Portanto, o React pulará as animações de popstate e as animações não serão executadas para o botão voltar. Você pode corrigir isso atualizando seu roteador para usar a API de Navegação.
 
 ---
 
-## Troubleshooting {/*troubleshooting*/}
+## Solução de Problemas {/*troubleshooting*/}
 
-### My `<ViewTransition>` is not activating {/*my-viewtransition-is-not-activating*/}
+### Meu `<ViewTransition>` não está ativando {/*my-viewtransition-is-not-activating*/}
 
-`<ViewTransition>` only activates if it is placed before any DOM node:
+`<ViewTransition>` só ativa se for colocado antes de qualquer nó DOM:
 
 ```js [3, 5]
 function Component() {
   return (
     <div>
-      <ViewTransition>Hi</ViewTransition>
+      <ViewTransition>Oi</ViewTransition>
     </div>
   );
 }
 ```
 
-To fix, ensure that the `<ViewTransition>` comes before any other DOM nodes:
+Para corrigir, certifique-se de que `<ViewTransition>` venha antes de quaisquer outros nós DOM:
 
 ```js [3, 5]
 function Component() {
   return (
     <ViewTransition>
-      <div>Hi</div>
+      <div>Oi</div>
     </ViewTransition>
   );
 }
 ```
 
-### I'm getting an error "There are two `<ViewTransition name=%s>` components with the same name mounted at the same time." {/*two-viewtransition-with-same-name*/}
+### Estou recebendo um erro "Existem dois componentes `<ViewTransition name=%s>` com o mesmo nome montados ao mesmo tempo." {/*two-viewtransition-with-same-name*/}
 
-This error occurs when two `<ViewTransition>` components with the same `name` are mounted at the same time:
+Este erro ocorre quando dois componentes `<ViewTransition>` com o mesmo `name` são montados ao mesmo tempo:
 
 ```js [3]
 function Item() {
-  // 🚩 All items will get the same "name".
+  // 🚩 Todos os itens receberão o mesmo "name".
   return <ViewTransition name="item">...</ViewTransition>;
 }
 
@@ -2842,31 +2842,31 @@ function ItemList({items}) {
 }
 ```
 
-This will cause the View Transition to error. In development, React detects this issue to surface it and logs two errors:
+Isso fará com que a Transição de Visualização gere um erro. Em desenvolvimento, o React detecta esse problema para exibi-lo e registra dois erros:
 
 <ConsoleBlockMulti>
 <ConsoleLogLine level="error">
 
-There are two `<ViewTransition name=%s>` components with the same name mounted at the same time. This is not supported and will cause View Transitions to error. Try to use a more unique name e.g. by using a namespace prefix and adding the id of an item to the name.
-{' '}at Item
-{' '}at ItemList
+Existem dois componentes `<ViewTransition name=%s>` com o mesmo nome montados ao mesmo tempo. Isso não é suportado e fará com que as Transições de Visualização gerem um erro. Tente usar um nome mais exclusivo, por exemplo, usando um prefixo de namespace e adicionando o id de um item ao nome.
+{' '}em Item
+{' '}em ItemList
 
 </ConsoleLogLine>
 
 <ConsoleLogLine level="error">
 
-The existing `<ViewTransition name=%s>` duplicate has this stack trace.
-{' '}at Item
-{' '}at ItemList
+A duplicata existente de `<ViewTransition name=%s>` tem este rastreamento de pilha.
+{' '}em Item
+{' '}em ItemList
 
 </ConsoleLogLine>
 </ConsoleBlockMulti>
 
-To fix, ensure that there's only one `<ViewTransition>` with the same name mounted at a time in the entire app by ensuring the `name` is unique, or adding an `id` to the name:
+Para corrigir, certifique-se de que haja apenas um `<ViewTransition>` com o mesmo nome montado ao mesmo tempo em todo o aplicativo, garantindo que o `name` seja exclusivo ou adicionando um `id` ao nome:
 
 ```js [3]
 function Item({id}) {
-  // ✅ All items will get a unique name.
+  // ✅ Todos os itens receberão um nome exclusivo.
   return <ViewTransition name={`item-${id}`}>...</ViewTransition>;
 }
 

--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -1520,11 +1520,11 @@ Você pode obter efeitos diferentes dependendo de onde escolher colocar o limite
 
 ---
 
-### Otimizando para fora de uma animação {/*opting-out-of-an-animation*/}
+### Desativando uma animação {/*opting-out-of-an-animation*/}
 
 Às vezes, você está envolvendo um componente grande existente, como uma página inteira, e deseja animar algumas atualizações, como a mudança de tema. No entanto, você não quer que todas as atualizações dentro da página inteira sejam animadas com cross-fade quando elas são atualizadas. Especialmente se você estiver adicionando animações incrementalmente.
 
-Você pode usar a classe "none" para otimizar para fora de uma animação. Ao envolver seus filhos em um "none", você pode desativar animações para atualizações neles, enquanto o pai ainda aciona.
+Você pode usar a classe "none" para desativar uma animação. Ao envolver seus filhos em um "none", você pode desativar animações para atualizações neles, enquanto o pai ainda aciona.
 
 ```js
 <ViewTransition>


### PR DESCRIPTION
Este PR contém uma tradução automatizada da página referenciada para **Português (Brasil)**.

> [!IMPORTANT]
> Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

<details>
<summary>Detalhes</summary>

### Estatísticas de Processamento



| Métrica | Valor |
|--------|-------|
| **Tamanho do Arquivo Fonte** | 69.4 kB |
| **Tamanho da Tradução** | 71.3 kB |
| **Razão de Conteúdo** | 1.03x [^content-ratio] |
| **Caminho do Arquivo** | `src/content/reference/react/ViewTransition.md` |
| **Tempo de Processamento** | ~24 minutos [^processing-time] |

### Informações Técnicas

- **Data de Geração**: 2026-06-02
- **Branch**: `refs/heads/translate/reference/react/ViewTransition.md`
- **Modelo de tradução (LLM)**: `google/gemini-2.5-flash-lite`
- **Execução do workflow**: [`Poll upstream React docs` · #26825420300](https://github.com/NivaldoFarias/translate-react/actions/runs/26825420300)


</details>

Guia para revisores: [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers).

---

[^content-ratio]: `Razão de Conteúdo` indica como o comprimento da tradução se compara à fonte (~1.0x: mesmo comprimento, >1.0x: tradução é mais longa). Diferentes idiomas naturalmente têm níveis variados de verbosidade.
[^processing-time]: `Tempo de Processamento` baseia-se no cálculo do tempo total desde o início do fluxo até a conclusão da tradução deste arquivo específico.
