### PR TITLE
Tradução de `react-19.md` para Português (Brasil)

### DIFF
--- a/src/content/blog/2024/12/05/react-19.md
+++ b/src/content/blog/2024/12/05/react-19.md
@@ -2,51 +2,51 @@
 title: "React v19"
 author: The React Team
 date: 2024/12/05
-description: React 19 is now available on npm! In this post, we'll give an overview of the new features in React 19, and how you can adopt them.
+description: O React 19 já está disponível no npm! Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
 ---
 
-December 05, 2024 by [The React Team](/community/team)
+05 de Dezembro de 2024 por[A Equipe do React](/community/team)
 
 ---
 <Note>
 
-### React 19 is now stable! {/*react-19-is-now-stable*/}
+### React 19 está estável!{/*react-19-is-now-stable*/}
 
-Additions since this post was originally shared with the React 19 RC in April:
+Adições desde que este post foi originalmente compartilhado com o RC do React 19 em abril:
 
-- **Pre-warming for suspended trees**: see [Improvements to Suspense](/blog/2024/04/25/react-19-upgrade-guide#improvements-to-suspense).
-- **React DOM static APIs**: see [New React DOM Static APIs](#new-react-dom-static-apis).
+- **Pré-aquecimento para árvores suspensas**: veja[Melhorias no Suspense](/blog/2024/04/25/react-19-upgrade-guide#improvements-to-suspense).
+- **APIs estáticas do React DOM**: veja[Novas APIs estáticas do React DOM](#new-react-dom-static-apis).
 
-_The date for this post has been updated to reflect the stable release date._
+_A data deste post foi atualizada para refletir a data de lançamento estável._
 
 </Note>
 
 <Intro>
 
-React v19 is now available on npm!
+React v19 já está disponível no npm!
 
 </Intro>
 
-In our [React 19 Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide), we shared step-by-step instructions for upgrading your app to React 19. In this post, we'll give an overview of the new features in React 19, and how you can adopt them.
+Em nosso[Guia de Upgrade do React 19](/blog/2024/04/25/react-19-upgrade-guide), compartilhamos instruções passo a passo para atualizar seu aplicativo para o React 19. Neste post, daremos uma visão geral dos novos recursos do React 19 e como você pode adotá-los.
 
-- [What's new in React 19](#whats-new-in-react-19)
-- [Improvements in React 19](#improvements-in-react-19)
-- [How to upgrade](#how-to-upgrade)
+- [O que há de novo no React 19](#whats-new-in-react-19)
+- [Melhorias no React 19](#improvements-in-react-19)
+- [Como atualizar](#how-to-upgrade)
 
-For a list of breaking changes, see the [Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide).
+Para uma lista de alterações que quebram a compatibilidade, consulte o[Guia de Upgrade](/blog/2024/04/25/react-19-upgrade-guide).
 
 ---
 
-## What's new in React 19 {/*whats-new-in-react-19*/}
+## O que há de novo no React 19{/*whats-new-in-react-19*/}
 
-### Actions {/*actions*/}
+### Ações{/*actions*/}
 
-A common use case in React apps is to perform a data mutation and then update state in response. For example, when a user submits a form to change their name, you will make an API request, and then handle the response. In the past, you would need to handle pending states, errors, optimistic updates, and sequential requests manually.
+Um caso de uso comum em aplicativos React é realizar uma mutação de dados e, em seguida, atualizar o estado em resposta. Por exemplo, quando um usuário envia um formulário para alterar seu nome, você fará uma solicitação à API e, em seguida, lidará com a resposta. No passado, você precisaria lidar manualmente com estados pendentes, erros, atualizações otimistas e solicitações sequenciais.
 
-For example, you could handle the pending and error state in `useState`:
+Por exemplo, você poderia lidar com o estado pendente e de erro em`useState`:
 
 ```js
-// Before Actions
+// Antes das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -75,12 +75,12 @@ function UpdateName({}) {
 }
 ```
 
-In React 19, we're adding support for using async functions in transitions to handle pending states, errors, forms, and optimistic updates automatically.
+No React 19, estamos adicionando suporte para usar funções assíncronas em transições para lidar automaticamente com estados pendentes, erros, formulários e atualizações otimistas.
 
-For example, you can use `useTransition` to handle the pending state for you:
+Por exemplo, você pode usar`useTransition`para lidar com o estado pendente para você:
 
 ```js
-// Using pending state from Actions
+// Usando estado pendente das Ações
 function UpdateName({}) {
   const [name, setName] = useState("");
   const [error, setError] = useState(null);
@@ -109,27 +109,27 @@ function UpdateName({}) {
 }
 ```
 
-The async transition will immediately set the `isPending` state to true, make the async request(s), and switch `isPending` to false after any transitions. This allows you to keep the current UI responsive and interactive while the data is changing.
+A transição assíncrona definirá imediatamente o estado`isPending`como true, fará as solicitações assíncronas e mudará`isPending`para false após quaisquer transições. Isso permite que você mantenha a interface do usuário atual responsiva e interativa enquanto os dados estão sendo alterados.
 
 <Note>
 
-#### By convention, functions that use async transitions are called "Actions". {/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
+#### Por convenção, as funções que usam transições assíncronas são chamadas de "Ações".{/*by-convention-functions-that-use-async-transitions-are-called-actions*/}
 
-Actions automatically manage submitting data for you:
+As Ações gerenciam automaticamente o envio de dados para você:
 
-- **Pending state**: Actions provide a pending state that starts at the beginning of a request and automatically resets when the final state update is committed.
-- **Optimistic updates**: Actions support the new [`useOptimistic`](#new-hook-optimistic-updates) hook so you can show users instant feedback while the requests are submitting.
-- **Error handling**: Actions provide error handling so you can display Error Boundaries when a request fails, and revert optimistic updates to their original value automatically.
-- **Forms**: `<form>` elements now support passing functions to the `action` and `formAction` props. Passing functions to the `action` props use Actions by default and reset the form automatically after submission.
+- **Estado pendente**: As Ações fornecem um estado pendente que começa no início de uma solicitação e é automaticamente redefinido quando a atualização final do estado é confirmada.
+- **Atualizações otimistas**: As Ações suportam o novo hook[`useOptimistic`](#new-hook-optimistic-updates)para que você possa mostrar feedback instantâneo aos usuários enquanto as solicitações estão sendo enviadas.
+- **Tratamento de erros**: As Ações fornecem tratamento de erros para que você possa exibir Limites de Erro quando uma solicitação falhar e reverter automaticamente as atualizações otimistas para seu valor original.
+- **Formulários**:`<form>`os elementos agora suportam a passagem de funções para as props`action`e`formAction`. Passar funções para as props`action`usam Ações por padrão e redefinem o formulário automaticamente após o envio.
 
 </Note>
 
-Building on top of Actions, React 19 introduces [`useOptimistic`](#new-hook-optimistic-updates) to manage optimistic updates, and a new hook [`React.useActionState`](#new-hook-useactionstate) to handle common cases for Actions. In `react-dom` we're adding [`<form>` Actions](#form-actions) to manage forms automatically and [`useFormStatus`](#new-hook-useformstatus) to support the common cases for Actions in forms.
+Construindo sobre as Ações, o React 19 introduz[`useOptimistic`](#new-hook-optimistic-updates)para gerenciar atualizações otimistas, e um novo hook[`React.useActionState`](#new-hook-useactionstate)para lidar com casos comuns para Ações. Em`react-dom`estamos adicionando[`<form>`Por convenção, funções que usam transições assíncronas são chamadas de "Actions".](#form-actions)para gerenciar formulários automaticamente e[`useFormStatus`](#new-hook-useformstatus)para dar suporte aos casos comuns de Actions.
 
-In React 19, the above example can be simplified to:
+No React 19, o exemplo acima pode ser simplificado para:
 
 ```js
-// Using <form> Actions and useActionState
+// Usando Actions de <form> e useActionState
 function ChangeName({ name, setName }) {
   const [error, submitAction, isPending] = useActionState(
     async (previousState, formData) => {
@@ -153,56 +153,56 @@ function ChangeName({ name, setName }) {
 }
 ```
 
-In the next section, we'll break down each of the new Action features in React 19.
+Na próxima seção, detalharemos cada um dos novos recursos de Action no React 19.
 
-### New hook: `useActionState` {/*new-hook-useactionstate*/}
+### Novo hook:`useActionState` {/*new-hook-useactionstate*/}
 
-To make the common cases easier for Actions, we've added a new hook called `useActionState`:
+Para facilitar os casos comuns de Actions, adicionamos um novo hook chamado`useActionState`:
 
 ```js
 const [error, submitAction, isPending] = useActionState(
   async (previousState, newName) => {
     const error = await updateName(newName);
     if (error) {
-      // You can return any result of the action.
-      // Here, we return only the error.
+      // Você pode retornar qualquer resultado da action.
+      // Aqui, retornamos apenas o erro.
       return error;
     }
 
-    // handle success
+    // Lidar com sucesso
     return null;
   },
   null,
 );
 ```
 
-`useActionState` accepts a function (the "Action"), and returns a wrapped Action to call. This works because Actions compose. When the wrapped Action is called, `useActionState` will return the last result of the Action as `data`, and the pending state of the Action as `pending`.
+`useActionState`aceita uma função (a "Action") e retorna uma Action encapsulada para ser chamada. Isso funciona porque Actions compõem. Quando a Action encapsulada é chamada,`useActionState`retornará o último resultado da Action como`data`, e o estado pendente da Action como`pending`.
 
 <Note>
 
-`React.useActionState` was previously called `ReactDOM.useFormState` in the Canary releases, but we've renamed it and deprecated `useFormState`.
+`React.useActionState`anteriormente era chamado de`ReactDOM.useFormState`nas versões Canary, mas o renomeamos e descontinuamos`useFormState`.
 
-See [#28491](https://github.com/facebook/react/pull/28491) for more info.
+Veja[#28491](https://github.com/facebook/react/pull/28491)para mais informações.
 
 </Note>
 
-For more information, see the docs for [`useActionState`](/reference/react/useActionState).
+Para mais informações, veja a documentação de[`useActionState`](/reference/react/useActionState).
 
-### React DOM: `<form>` Actions {/*form-actions*/}
+### React DOM: Actions`<form>`Actions{/*form-actions*/}
 
-Actions are also integrated with React 19's new `<form>` features for `react-dom`. We've added support for passing functions as the `action` and `formAction` props of `<form>`, `<input>`, and `<button>` elements to automatically submit forms with Actions:
+Actions também são integradas com os novos recursos do React 19 para`<form>`.`react-dom`Adicionamos suporte para passar funções como as props`action`e`formAction`de`<form>`,`<input>`, e`<button>`elementos para submeter formulários automaticamente com Actions:
 
 ```js [[1,1,"actionFunction"]]
 <form action={actionFunction}>
 ```
 
-When a `<form>` Action succeeds, React will automatically reset the form for uncontrolled components. If you need to reset the `<form>` manually, you can call the new `requestFormReset` React DOM API.
+Quando uma Action de`<form>`bem-sucedida, o React redefinirá automaticamente o formulário para componentes não controlados. Se você precisar redefinir o`<form>`manualmente, você pode chamar a nova API do React DOM`requestFormReset`.
 
-For more information, see the `react-dom` docs for [`<form>`](/reference/react-dom/components/form), [`<input>`](/reference/react-dom/components/input), and `<button>`.
+Para mais informações, veja a documentação de`react-dom`para[`<form>`](/reference/react-dom/components/form),[`<input>`](/reference/react-dom/components/input), e`<button>`.
 
-### React DOM: New hook: `useFormStatus` {/*new-hook-useformstatus*/}
+### React DOM: Novo hook:`useFormStatus` {/*new-hook-useformstatus*/}
 
-In design systems, it's common to write design components that need access to information about the `<form>` they're in, without drilling props down to the component. This can be done via Context, but to make the common case easier, we've added a new hook `useFormStatus`:
+Em sistemas de design, é comum escrever componentes de design que precisam de acesso a informações sobre o`<form>`em que estão, sem precisar passar props para o componente. Isso pode ser feito via Context, mas para facilitar o caso comum, adicionamos um novo hook`useFormStatus`:
 
 ```js [[1, 4, "pending"], [1, 5, "pending"]]
 import {useFormStatus} from 'react-dom';
@@ -213,13 +213,13 @@ function DesignButton() {
 }
 ```
 
-`useFormStatus` reads the status of the parent `<form>` as if the form was a Context provider.
+`useFormStatus`lê o status do`<form>`pai como se o formulário fosse um provedor de Contexto.
 
-For more information, see the `react-dom` docs for [`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
+Para mais informações, veja a documentação de`react-dom`para[`useFormStatus`](/reference/react-dom/hooks/useFormStatus).
 
-### New hook: `useOptimistic` {/*new-hook-optimistic-updates*/}
+### Novo hook:`useOptimistic` {/*new-hook-optimistic-updates*/}
 
-Another common UI pattern when performing a data mutation is to show the final state optimistically while the async request is underway. In React 19, we're adding a new hook called `useOptimistic` to make this easier:
+Outro padrão comum de UI ao realizar uma mutação de dados é mostrar o estado final otimisticamente enquanto a requisição assíncrona está em andamento. No React 19, estamos adicionando um novo hook chamado`useOptimistic`para facilitar isso:
 
 ```js {2,6,13,19}
 function ChangeName({currentName, onUpdateName}) {
@@ -248,28 +248,28 @@ function ChangeName({currentName, onUpdateName}) {
 }
 ```
 
-The `useOptimistic` hook will immediately render the `optimisticName` while the `updateName` request is in progress. When the update finishes or errors, React will automatically switch back to the `currentName` value.
+O`useOptimistic`renderizará imediatamente o`optimisticName`enquanto a`updateName`requisição estiver em andamento. Quando a atualização terminar ou ocorrer um erro, o React voltará automaticamente para o`currentName`valor.
 
-For more information, see the docs for [`useOptimistic`](/reference/react/useOptimistic).
+Para mais informações, veja a documentação de[`useOptimistic`](/reference/react/useOptimistic).
 
-### New API: `use` {/*new-feature-use*/}
+### Nova API:`use` {/*new-feature-use*/}
 
-In React 19 we're introducing a new API to read resources in render: `use`.
+No React 19, estamos introduzindo uma nova API para ler recursos em renderização:`use`.
 
-For example, you can read a promise with `use`, and React will Suspend until the promise resolves:
+Por exemplo, você pode ler uma promise com`use`, e o React suspenderá até que a promise seja resolvida:
 
 ```js {1,5}
 import {use} from 'react';
 
 function Comments({commentsPromise}) {
-  // `use` will suspend until the promise resolves.
+  // `use` suspenderá até que a promise seja resolvida.
   const comments = use(commentsPromise);
   return comments.map(comment => <p key={comment.id}>{comment}</p>);
 }
 
 function Page({commentsPromise}) {
-  // When `use` suspends in Comments,
-  // this Suspense boundary will be shown.
+  // Quando `use` suspende em Comentários,
+  // este limite de Suspense será exibido.
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <Comments commentsPromise={commentsPromise} />
@@ -280,25 +280,25 @@ function Page({commentsPromise}) {
 
 <Note>
 
-#### `use` does not support promises created in render. {/*use-does-not-support-promises-created-in-render*/}
+#### `use`não suporta promises criadas em renderização.{/*use-does-not-support-promises-created-in-render*/}
 
-If you try to pass a promise created in render to `use`, React will warn:
+Se você tentar passar uma promise criada em renderização para`use`, o React exibirá um aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.
+Um componente suspendeu por uma promise não cacheada. Criar promises dentro de um Componente Cliente ou hook ainda não é suportado, exceto através de uma biblioteca ou framework compatível com Suspense.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-To fix, you need to pass a promise from a Suspense powered library or framework that supports caching for promises. In the future we plan to ship features to make it easier to cache promises in render.
+Para corrigir, você precisa passar uma promise de uma biblioteca ou framework com suporte a Suspense que suporte cache para promises. No futuro, planejamos lançar recursos para facilitar o cache de promises em renderização.
 
 </Note>
 
-You can also read context with `use`, allowing you to read Context conditionally such as after early returns:
+Você também pode ler o contexto com`use`, permitindo que você leia o Contexto condicionalmente, como após retornos antecipados:
 
 ```js {1,11}
 import {use} from 'react';
@@ -309,8 +309,8 @@ function Heading({children}) {
     return null;
   }
 
-  // This would not work with useContext
-  // because of the early return.
+  // Isso não funcionaria com useContext
+  // por causa do retorno antecipado.
   const theme = use(ThemeContext);
   return (
     <h1 style={{color: theme.color}}>
@@ -320,17 +320,17 @@ function Heading({children}) {
 }
 ```
 
-The `use` API can only be called in render, similar to hooks. Unlike hooks, `use` can be called conditionally. In the future we plan to support more ways to consume resources in render with `use`.
+A`use`API só pode ser chamada em renderização, semelhante aos hooks. Diferente dos hooks,`use`pode ser chamada condicionalmente. No futuro, planejamos suportar mais maneiras de consumir recursos em renderização com`use`.
 
-For more information, see the docs for [`use`](/reference/react/use).
+Para mais informações, veja a documentação de[`use`](/reference/react/use).
 
-## New React DOM Static APIs {/*new-react-dom-static-apis*/}
+## Novas APIs do React DOM Estático{/*new-react-dom-static-apis*/}
 
-We've added two new APIs to `react-dom/static` for static site generation:
+Adicionamos duas novas APIs ao`react-dom/static`para geração de sites estáticos:
 - [`prerender`](/reference/react-dom/static/prerender)
 - [`prerenderToNodeStream`](/reference/react-dom/static/prerenderToNodeStream)
 
-These new APIs improve on `renderToString` by waiting for data to load for static HTML generation. They are designed to work with streaming environments like Node.js Streams and Web Streams. For example, in a Web Stream environment, you can prerender a React tree to static HTML with `prerender`:
+Essas novas APIs aprimoram o`renderToString`esperando que os dados sejam carregados para a geração de HTML estático. Elas são projetadas para funcionar com ambientes de streaming como Node.js Streams e Web Streams. Por exemplo, em um ambiente de Web Stream, você pode pré-renderizar uma árvore React para HTML estático com`prerender`:
 
 ```js
 import { prerender } from 'react-dom/static';
@@ -345,57 +345,57 @@ async function handler(request) {
 }
 ```
 
-Prerender APIs will wait for all data to load before returning the static HTML stream. Streams can be converted to strings, or sent with a streaming response. They do not support streaming content as it loads, which is supported by the existing [React DOM server rendering APIs](/reference/react-dom/server).
+As APIs de pré-renderização esperarão que todos os dados sejam carregados antes de retornar o stream de HTML estático. Os streams podem ser convertidos em strings ou enviados com uma resposta de streaming. Eles não suportam streaming de conteúdo conforme ele carrega, o que é suportado pelas APIs existentes de[renderização do lado do servidor do React DOM](/reference/react-dom/server).
 
-For more information, see [React DOM Static APIs](/reference/react-dom/static).
+Para mais informações, veja[APIs do React DOM Estático](/reference/react-dom/static).
 
-## React Server Components {/*react-server-components*/}
+## Componentes de Servidor React{/*react-server-components*/}
 
-### Server Components {/*server-components*/}
+### Componentes de Servidor{/*server-components*/}
 
-Server Components are a new option that allows rendering components ahead of time, before bundling, in an environment separate from your client application or SSR server. This separate environment is the "server" in React Server Components. Server Components can run once at build time on your CI server, or they can be run for each request using a web server.
+Componentes de Servidor são uma nova opção que permite renderizar componentes antecipadamente, antes do bundling, em um ambiente separado da sua aplicação cliente ou servidor SSR. Este ambiente separado é o "servidor" em Componentes de Servidor React. Componentes de Servidor podem ser executados uma vez no tempo de build no seu servidor de CI, ou podem ser executados para cada requisição usando um servidor web.
 
-React 19 includes all of the React Server Components features included from the Canary channel. This means libraries that ship with Server Components can now target React 19 as a peer dependency with a `react-server` [export condition](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports) for use in frameworks that support the [Full-stack React Architecture](/learn/creating-a-react-app#which-features-make-up-the-react-teams-full-stack-architecture-vision).
+O React 19 inclui todos os recursos de Componentes de Servidor React incluídos do canal Canary. Isso significa que bibliotecas que enviam com Componentes de Servidor agora podem ter como alvo o React 19 como uma dependência peer com uma`react-server` [condição de exportação](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md#react-server-conditional-exports)para uso em frameworks que suportam a[Arquitetura Full-stack React](/learn/creating-a-react-app#which-features-make-up-the-react-teams-full-stack-architecture-vision).
 
 
 <Note>
 
-#### How do I build support for Server Components? {/*how-do-i-build-support-for-server-components*/}
+#### Como construir suporte para Componentes de Servidor?{/*how-do-i-build-support-for-server-components*/}
 
-While React Server Components in React 19 are stable and will not break between minor versions, the underlying APIs used to implement a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x.
+Embora os Componentes de Servidor React no React 19 sejam estáveis e não quebrem entre versões menores, as APIs subjacentes usadas para implementar um bundler ou framework de Componentes de Servidor React não seguem semver e podem quebrar entre versões menores no React 19.x.
 
-To support React Server Components as a bundler or framework, we recommend pinning to a specific React version, or using the Canary release. We will continue working with bundlers and frameworks to stabilize the APIs used to implement React Server Components in the future.
+Para suportar Componentes de Servidor React como um bundler ou framework, recomendamos fixar em uma versão específica do React, ou usar a release Canary. Continuaremos trabalhando com bundlers e frameworks para estabilizar as APIs usadas para implementar Componentes de Servidor React no futuro.
 
 </Note>
 
 
-For more, see the docs for [React Server Components](/reference/rsc/server-components).
+Para mais, veja a documentação de[React Server Components](/reference/rsc/server-components).
 
-### Server Actions {/*server-actions*/}
+### Server Actions{/*server-actions*/}
 
-Server Actions allow Client Components to call async functions executed on the server.
+Server Actions permitem que Client Components chamem funções assíncronas executadas no servidor.
 
-When a Server Action is defined with the `"use server"` directive, your framework will automatically create a reference to the server function, and pass that reference to the Client Component. When that function is called on the client, React will send a request to the server to execute the function, and return the result.
+Quando uma Server Action é definida com a diretiva`"use server"`seu framework criará automaticamente uma referência para a função do servidor e passará essa referência para o Client Component. Quando essa função for chamada no cliente, o React enviará uma requisição para o servidor para executar a função e retornar o resultado.
 
 <Note>
 
-#### There is no directive for Server Components. {/*there-is-no-directive-for-server-components*/}
+#### Não existe uma diretiva para Server Components.{/*there-is-no-directive-for-server-components*/}
 
-A common misunderstanding is that Server Components are denoted by `"use server"`, but there is no directive for Server Components. The `"use server"` directive is used for Server Actions.
+Um equívoco comum é que Server Components são denotados por`"use server"`, mas não existe uma diretiva para Server Components. A diretiva`"use server"`é usada para Server Actions.
 
-For more info, see the docs for [Directives](/reference/rsc/directives).
+Para mais informações, veja a documentação de[Diretivas](/reference/rsc/directives).
 
 </Note>
 
-Server Actions can be created in Server Components and passed as props to Client Components, or they can be imported and used in Client Components.
+Server Actions podem ser criadas em Server Components e passadas como props para Client Components, ou podem ser importadas e usadas em Client Components.
 
-For more, see the docs for [React Server Actions](/reference/rsc/server-actions).
+Para mais, veja a documentação de[React Server Actions](/reference/rsc/server-actions).
 
-## Improvements in React 19 {/*improvements-in-react-19*/}
+## Melhorias no React 19{/*improvements-in-react-19*/}
 
-### `ref` as a prop {/*ref-as-a-prop*/}
+### `ref`como uma prop{/*ref-as-a-prop*/}
 
-Starting in React 19, you can now access `ref` as a prop for function components:
+A partir do React 19, você agora pode acessar`ref`como uma prop para componentes de função:
 
 ```js [[1, 1, "ref"], [1, 2, "ref", 45], [1, 6, "ref", 14]]
 function MyInput({placeholder, ref}) {
@@ -406,25 +406,23 @@ function MyInput({placeholder, ref}) {
 <MyInput ref={ref} />
 ```
 
-New function components will no longer need `forwardRef`, and we will be publishing a codemod to automatically update your components to use the new `ref` prop. In future versions we will deprecate and remove `forwardRef`.
+Novos componentes de função não precisarão mais de`forwardRef`, e publicaremos um codemod para atualizar automaticamente seus componentes para usar a nova`ref`prop. Em versões futuras, descontinuaremos e removeremos`forwardRef`.
 
 <Note>
 
-`ref`s passed to classes are not passed as props since they reference the component instance.
+`ref`passadas para classes não são passadas como props, pois referenciam a instância do componente.
 
 </Note>
 
-### Diffs for hydration errors {/*diffs-for-hydration-errors*/}
+### Diffs para erros de hidratação{/*diffs-for-hydration-errors*/}
 
-We also improved error reporting for hydration errors in `react-dom`. For example, instead of logging multiple errors in DEV without any information about the mismatch:
+Também melhoramos o reporte de erros para erros de hidratação em`react-dom`. Por exemplo, em vez de logar múltiplos erros em DEV sem nenhuma informação sobre a incompatibilidade:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Warning: Text content did not match. Server: "Server" Client: "Client"
-{'  '}at span
-{'  '}at App
+Warning: Text content did not match. Server: "Server" Client: "Client"{'  '}at span{'  '}at App
 
 </ConsoleLogLine>
 
@@ -436,9 +434,7 @@ Warning: An error occurred during hydration. The server HTML was replaced with c
 
 <ConsoleLogLine level="error">
 
-Warning: Text content did not match. Server: "Server" Client: "Client"
-{'  '}at span
-{'  '}at App
+Warning: Text content did not match. Server: "Server" Client: "Client"{'  '}at span{'  '}at App
 
 </ConsoleLogLine>
 
@@ -450,43 +446,35 @@ Warning: An error occurred during hydration. The server HTML was replaced with c
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: Text content does not match server-rendered HTML.
-{'  '}at checkForUnmatchedText
-{'  '}...
+Uncaught Error: Text content does not match server-rendered HTML.{'  '}at checkForUnmatchedText{'  '}...
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-We now log a single message with a diff of the mismatch:
+Agora logamos uma única mensagem com um diff da incompatibilidade:
 
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Uncaught Error: Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if an SSR-ed Client Component used:{'\n'}
-\- A server/client branch `if (typeof window !== 'undefined')`.
-\- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
-\- Date formatting in a user's locale which doesn't match the server.
-\- External changing data without sending a snapshot of it along with the HTML.
-\- Invalid HTML tag nesting.{'\n'}
-It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.{'\n'}
+Uncaught Error: Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if an SSR-ed Client Component used:{'\n'}- A server/client branch`if (typeof window !== 'undefined')`. 
+- Variable input such as`Date.now()`ou`Math.random()`which changes each time it's called.
+- Date formatting in a user's locale which doesn't match the server.
+- External changing data without sending a snapshot of it along with the HTML.
+- Invalid HTML tag nesting.{'\n'}It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.{'\n'}
 https://react.dev/link/hydration-mismatch {'\n'}
-{'  '}\<App\>
-{'    '}\<span\>
-{'+    '}Client
-{'-    '}Server{'\n'}
-{'  '}at throwOnHydrationMismatch
-{'  '}...
+{'  '}<App>{'    '}<span{'+    '}Cliente{'-    '}Servidor{'\n'}
+{'  '}em throwOnHydrationMismatch{'  '}...
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### `<Context>` as a provider {/*context-as-a-provider*/}
+### `<Context>`como um provider{/*context-as-a-provider*/}
 
-In React 19, you can render `<Context>` as a provider instead of `<Context.Provider>`:
+No React 19, você pode renderizar`<Context>`como um provider em vez de`<Context.Provider>`:
 
 
 ```js {5,7}
@@ -501,19 +489,19 @@ function App({children}) {
 }
 ```
 
-New Context providers can use `<Context>` and we will be publishing a codemod to convert existing providers. In future versions we will deprecate `<Context.Provider>`.
+Novos providers de Context podem usar`<Context>`e publicaremos um codemod para converter os providers existentes. Em versões futuras, descontinuaremos`<Context.Provider>`.
 
-### Cleanup functions for refs {/*cleanup-functions-for-refs*/}
+### Funções de limpeza para refs{/*cleanup-functions-for-refs*/}
 
-We now support returning a cleanup function from `ref` callbacks:
+Agora suportamos retornar uma função de limpeza de`ref`callbacks:
 
 ```js {7-9}
 <input
   ref={(ref) => {
-    // ref created
+    // ref criado
 
-    // NEW: return a cleanup function to reset
-    // the ref when element is removed from DOM.
+    // NOVO: retorne uma função de limpeza para redefinir
+    // a ref quando o elemento for removido do DOM.
     return () => {
       // ref cleanup
     };
@@ -521,35 +509,35 @@ We now support returning a cleanup function from `ref` callbacks:
 />
 ```
 
-When the component unmounts, React will call the cleanup function returned from the `ref` callback. This works for DOM refs, refs to class components, and `useImperativeHandle`.
+Quando o componente desmontar, o React chamará a função de limpeza retornada do`ref`callback. Isso funciona para refs de DOM, refs para componentes de classe e`useImperativeHandle`.
 
 <Note>
 
-Previously, React would call `ref` functions with `null` when unmounting the component. If your `ref` returns a cleanup function, React will now skip this step.
+Anteriormente, o React chamava as funções`ref`com`null`ao desmontar o componente. Se sua`ref`retornava uma função de limpeza, o React agora pulará essa etapa.
 
-In future versions, we will deprecate calling refs with `null` when unmounting components.
+Em versões futuras, descontinuaremos a chamada de refs com`null`ao desmontar componentes.
 
 </Note>
 
-Due to the introduction of ref cleanup functions, returning anything else from a `ref` callback will now be rejected by TypeScript. The fix is usually to stop using implicit returns, for example:
+Devido à introdução das funções de limpeza de refs, retornar qualquer outra coisa de um`ref`callback agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos, por exemplo:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-The original code returned the instance of the `HTMLDivElement` and TypeScript wouldn't know if this was _supposed_ to be a cleanup function or if you didn't want to return a cleanup function.
+O código original retornava a instância da`HTMLDivElement`e o TypeScript não saberia se isso era_suponha_ser uma função de limpeza ou se você não queria retornar uma função de limpeza.
 
-You can codemod this pattern with [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
+Você pode fazer o codemod deste padrão com[`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return).
 
-### `useDeferredValue` initial value {/*use-deferred-value-initial-value*/}
+### `useDeferredValue`valor inicial{/*use-deferred-value-initial-value*/}
 
-We've added an `initialValue` option to `useDeferredValue`:
+Adicionamos uma opção`initialValue`para`useDeferredValue`:
 
 ```js [[1, 1, "deferredValue"], [1, 4, "deferredValue"], [2, 4, "''"]]
 function Search({deferredValue}) {
-  // On initial render the value is ''.
-  // Then a re-render is scheduled with the deferredValue.
+  // Na renderização inicial, o valor é ''.
+  // Em seguida, uma re-renderização é agendada com o deferredValue.
   const value = useDeferredValue(deferredValue, '');
 
   return (
@@ -558,15 +546,15 @@ function Search({deferredValue}) {
 }
 ````
 
-When <CodeStep step={2}>initialValue</CodeStep> is provided, `useDeferredValue` will return it as `value` for the initial render of the component, and schedules a re-render in the background with the <CodeStep step={1}>deferredValue</CodeStep> returned.
+Quando<CodeStep step={2}>initialValue</CodeStep>é fornecido,`useDeferredValue`o retornará como`value`para a renderização inicial do componente, e agenda uma re-renderização em segundo plano com o<CodeStep step={1}>deferredValue</CodeStep>retornado.
 
-For more, see [`useDeferredValue`](/reference/react/useDeferredValue).
+Para mais informações, veja[`useDeferredValue`](/reference/react/useDeferredValue).
 
-### Support for Document Metadata {/*support-for-metadata-tags*/}
+### Suporte a Metadados de Documento{/*support-for-metadata-tags*/}
 
-In HTML, document metadata tags like `<title>`, `<link>`, and `<meta>` are reserved for placement in the `<head>` section of the document. In React, the component that decides what metadata is appropriate for the app may be very far from the place where you render the `<head>` or React does not render the `<head>` at all. In the past, these elements would need to be inserted manually in an effect, or by libraries like [`react-helmet`](https://github.com/nfl/react-helmet), and required careful handling when server rendering a React application.
+Em HTML, tags de metadados de documento como`<title>`,`<link>`, e`<meta>`são reservados para posicionamento na seção`<head>`do documento. No React, o componente que decide quais metadados são apropriados para o aplicativo pode estar muito distante do local onde você renderiza o`<head>`ou o React não renderiza o`<head>`de forma alguma. No passado, esses elementos precisariam ser inseridos manualmente em um efeito, ou por bibliotecas como[`react-helmet`](https://github.com/nfl/react-helmet), e exigiam um manuseio cuidadoso ao renderizar um aplicativo React no servidor.
 
-In React 19, we're adding support for rendering document metadata tags in components natively:
+No React 19, estamos adicionando suporte nativo para renderizar tags de metadados de documentos em componentes:
 
 ```js {5-8}
 function BlogPost({post}) {
@@ -585,23 +573,23 @@ function BlogPost({post}) {
 }
 ```
 
-When React renders this component, it will see the `<title>` `<link>` and `<meta>` tags, and automatically hoist them to the `<head>` section of document. By supporting these metadata tags natively, we're able to ensure they work with client-only apps, streaming SSR, and Server Components.
+Quando o React renderizar este componente, ele verá as tags`<title>` `<link>`e`<meta>`, e as promoverá automaticamente para a seção`<head>`do documento. Ao suportar essas tags de metadados nativamente, garantimos que elas funcionem com aplicativos apenas do lado do cliente, SSR em streaming e Server Components.
 
 <Note>
 
-#### You may still want a Metadata library {/*you-may-still-want-a-metadata-library*/}
+#### Você ainda pode querer uma biblioteca de metadados{/*you-may-still-want-a-metadata-library*/}
 
-For simple use cases, rendering Document Metadata as tags may be suitable, but libraries can offer more powerful features like overriding generic metadata with specific metadata based on the current route. These features make it easier for frameworks and libraries like [`react-helmet`](https://github.com/nfl/react-helmet) to support metadata tags, rather than replace them.
+Para casos de uso simples, renderizar metadados de documentos como tags pode ser adequado, mas bibliotecas podem oferecer recursos mais poderosos, como substituir metadados genéricos por metadados específicos com base na rota atual. Esses recursos facilitam para frameworks e bibliotecas como[`react-helmet`](https://github.com/nfl/react-helmet)dar suporte a tags de metadados, em vez de substituí-las.
 
 </Note>
 
-For more info, see the docs for [`<title>`](/reference/react-dom/components/title), [`<link>`](/reference/react-dom/components/link), and [`<meta>`](/reference/react-dom/components/meta).
+Para mais informações, veja a documentação de[`<title>`](/reference/react-dom/components/title),[`<link>`](/reference/react-dom/components/link), e[`<meta>`](/reference/react-dom/components/meta).
 
-### Support for stylesheets {/*support-for-stylesheets*/}
+### Suporte a folhas de estilo{/*support-for-stylesheets*/}
 
-Stylesheets, both externally linked (`<link rel="stylesheet" href="...">`) and inline (`<style>...</style>`), require careful positioning in the DOM due to style precedence rules. Building a stylesheet capability that allows for composability within components is hard, so users often end up either loading all of their styles far from the components that may depend on them, or they use a style library which encapsulates this complexity.
+Folhas de estilo, tanto vinculadas externamente (`<link rel="stylesheet" href="...">`) quanto inline (`<style>...</style>`), exigem posicionamento cuidadoso no DOM devido às regras de precedência de estilo. Construir uma capacidade de folha de estilo que permita a composição dentro de componentes é difícil, então os usuários geralmente acabam carregando todos os seus estilos longe dos componentes que podem depender deles, ou usam uma biblioteca de estilos que encapsula essa complexidade.
 
-In React 19, we're addressing this complexity and providing even deeper integration into Concurrent Rendering on the Client and Streaming Rendering on the Server with built in support for stylesheets. If you tell React the `precedence` of your stylesheet it will manage the insertion order of the stylesheet in the DOM and ensure that the stylesheet (if external) is loaded before revealing content that depends on those style rules.
+No React 19, estamos abordando essa complexidade e fornecendo uma integração ainda mais profunda com o Concurrent Rendering no Cliente e o Streaming Rendering no Servidor com suporte integrado para folhas de estilo. Se você informar ao React o`precedence`de sua folha de estilo, ele gerenciará a ordem de inserção da folha de estilo no DOM e garantirá que a folha de estilo (se externa) seja carregada antes de revelar o conteúdo que depende dessas regras de estilo.
 
 ```js {4,5,17}
 function ComponentOne() {
@@ -626,31 +614,31 @@ function ComponentTwo() {
 }
 ```
 
-During Server Side Rendering React will include the stylesheet in the `<head>`, which ensures that the browser will not paint until it has loaded. If the stylesheet is discovered late after we've already started streaming, React will ensure that the stylesheet is inserted into the `<head>` on the client before revealing the content of a Suspense boundary that depends on that stylesheet.
+Durante o Server Side Rendering, o React incluirá a folha de estilo no`<head>`, o que garante que o navegador não renderizará até que ela seja carregada. Se a folha de estilo for descoberta tardiamente após já termos começado a transmitir, o React garantirá que a folha de estilo seja inserida no`<head>`no cliente antes de revelar o conteúdo de um boundary de Suspense que depende dessa folha de estilo.
 
-During Client Side Rendering React will wait for newly rendered stylesheets to load before committing the render. If you render this component from multiple places within your application React will only include the stylesheet once in the document:
+Durante o Client Side Rendering, o React esperará que as folhas de estilo recém-renderizadas sejam carregadas antes de confirmar a renderização. Se você renderizar este componente de vários lugares em seu aplicativo, o React incluirá a folha de estilo apenas uma vez no documento:
 
 ```js {5}
 function App() {
   return <>
     <ComponentOne />
     ...
-    <ComponentOne /> // won't lead to a duplicate stylesheet link in the DOM
+    <ComponentOne /> // não resultará em um link duplicado de folha de estilo no DOM
   </>
 }
 ```
 
-For users accustomed to loading stylesheets manually this is an opportunity to locate those stylesheets alongside the components that depend on them allowing for better local reasoning and an easier time ensuring you only load the stylesheets that you actually depend on.
+Para usuários acostumados a carregar folhas de estilo manualmente, esta é uma oportunidade de localizar essas folhas de estilo ao lado dos componentes que dependem delas, permitindo um melhor raciocínio local e uma maneira mais fácil de garantir que você carregue apenas as folhas de estilo das quais realmente depende.
 
-Style libraries and style integrations with bundlers can also adopt this new capability so even if you don't directly render your own stylesheets, you can still benefit as your tools are upgraded to use this feature.
+Bibliotecas de estilo e integrações de estilo com bundlers também podem adotar essa nova capacidade, de modo que, mesmo que você não renderize diretamente suas próprias folhas de estilo, ainda poderá se beneficiar à medida que suas ferramentas forem atualizadas para usar esse recurso.
 
-For more details, read the docs for [`<link>`](/reference/react-dom/components/link) and [`<style>`](/reference/react-dom/components/style).
+Para mais detalhes, leia a documentação de[`<link>`](/reference/react-dom/components/link)e[`<style>`](/reference/react-dom/components/style).
 
-### Support for async scripts {/*support-for-async-scripts*/}
+### Suporte a scripts assíncronos{/*support-for-async-scripts*/}
 
-In HTML normal scripts (`<script src="...">`) and deferred scripts (`<script defer="" src="...">`) load in document order which makes rendering these kinds of scripts deep within your component tree challenging. Async scripts (`<script async="" src="...">`) however will load in arbitrary order.
+Em HTML, scripts normais (`<script src="...">`) e scripts com defer (`<script defer="" src="...">`) carregam na ordem do documento, o que torna desafiador renderizar esses tipos de scripts profundamente em sua árvore de componentes. Scripts assíncronos (`<script async="" src="...">`), no entanto, carregarão em ordem arbitrária.
 
-In React 19 we've included better support for async scripts by allowing you to render them anywhere in your component tree, inside the components that actually depend on the script, without having to manage relocating and deduplicating script instances.
+No React 19, incluímos melhor suporte para scripts assíncronos, permitindo que você os renderize em qualquer lugar em sua árvore de componentes, dentro dos componentes que realmente dependem do script, sem ter que gerenciar a realocação e deduplicação de instâncias de script.
 
 ```js {4,15}
 function MyComponent() {
@@ -667,32 +655,32 @@ function App() {
     <body>
       <MyComponent>
       ...
-      <MyComponent> // won't lead to duplicate script in the DOM
+      <MyComponent> // não resultará em um script duplicado no DOM
     </body>
   </html>
 }
 ```
 
-In all rendering environments, async scripts will be deduplicated so that React will only load and execute the script once even if it is rendered by multiple different components.
+Em todos os ambientes de renderização, os scripts assíncronos serão deduplicados para que o React carregue e execute o script apenas uma vez, mesmo que seja renderizado por vários componentes diferentes.
 
-In Server Side Rendering, async scripts will be included in the `<head>` and prioritized behind more critical resources that block paint such as stylesheets, fonts, and image preloads.
+No Server Side Rendering, os scripts assíncronos serão incluídos no`<head>`e priorizados atrás de recursos mais críticos que bloqueiam a renderização, como folhas de estilo, fontes e pré-carregamentos de imagem.
 
-For more details, read the docs for [`<script>`](/reference/react-dom/components/script).
+Para mais detalhes, leia a documentação de[`<script>`](/reference/react-dom/components/script).
 
-### Support for preloading resources {/*support-for-preloading-resources*/}
+### Suporte para pré-carregamento de recursos{/*support-for-preloading-resources*/}
 
-During initial document load and on client side updates, telling the Browser about resources that it will likely need to load as early as possible can have a dramatic effect on page performance.
+Durante o carregamento inicial do documento e em atualizações do lado do cliente, informar ao navegador sobre recursos que ele provavelmente precisará carregar o mais cedo possível pode ter um efeito dramático no desempenho da página.
 
-React 19 includes a number of new APIs for loading and preloading Browser resources to make it as easy as possible to build great experiences that aren't held back by inefficient resource loading.
+O React 19 inclui várias novas APIs para carregar e pré-carregar recursos do navegador para tornar o mais fácil possível construir ótimas experiências que não sejam prejudicadas por carregamento ineficiente de recursos.
 
 ```js
 import { prefetchDNS, preconnect, preload, preinit } from 'react-dom'
 function MyComponent() {
-  preinit('https://.../path/to/some/script.js', {as: 'script' }) // loads and executes this script eagerly
-  preload('https://.../path/to/font.woff', { as: 'font' }) // preloads this font
-  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // preloads this stylesheet
-  prefetchDNS('https://...') // when you may not actually request anything from this host
-  preconnect('https://...') // when you will request something but aren't sure what
+  preinit('https://.../path/to/some/script.js', {as: 'script' }) // carrega e executa este script de forma antecipada
+  preload('https://.../path/to/font.woff', { as: 'font' }) // pré-carrega esta fonte
+  preload('https://.../path/to/stylesheet.css', { as: 'style' }) // pré-carrega esta folha de estilo
+  prefetchDNS('https://...') // quando você pode não solicitar nada deste host
+  preconnect('https://...') // quando você solicitará algo, mas não tem certeza do quê
 }
 ```
 ```html
@@ -712,99 +700,80 @@ function MyComponent() {
 </html>
 ```
 
-These APIs can be used to optimize initial page loads by moving discovery of additional resources like fonts out of stylesheet loading. They can also make client updates faster by prefetching a list of resources used by an anticipated navigation and then eagerly preloading those resources on click or even on hover.
+Essas APIs podem ser usadas para otimizar carregamentos iniciais de página, movendo a descoberta de recursos adicionais, como fontes, para fora do carregamento de folhas de estilo. Elas também podem tornar as atualizações do cliente mais rápidas, pré-buscando uma lista de recursos usados por uma navegação antecipada e, em seguida, pré-carregando esses recursos antecipadamente ao clicar ou até mesmo ao passar o mouse.
 
-For more details see [Resource Preloading APIs](/reference/react-dom#resource-preloading-apis).
+Para mais detalhes, veja[APIs de pré-carregamento de recursos](/reference/react-dom#resource-preloading-apis).
 
-### Compatibility with third-party scripts and extensions {/*compatibility-with-third-party-scripts-and-extensions*/}
+### Compatibilidade com scripts e extensões de terceiros{/*compatibility-with-third-party-scripts-and-extensions*/}
 
-We've improved hydration to account for third-party scripts and browser extensions.
+Melhoramos a hidratação para levar em conta scripts e extensões de navegador de terceiros.
 
-When hydrating, if an element that renders on the client doesn't match the element found in the HTML from the server, React will force a client re-render to fix up the content. Previously, if an element was inserted by third-party scripts or browser extensions, it would trigger a mismatch error and client render.
+Ao hidratar, se um elemento que é renderizado no cliente não corresponder ao elemento encontrado no HTML do servidor, o React forçará uma nova renderização do cliente para corrigir o conteúdo. Anteriormente, se um elemento fosse inserido por scripts de terceiros ou extensões de navegador, isso acionaria um erro de incompatibilidade e uma renderização do cliente.
 
-In React 19, unexpected tags in the `<head>` and `<body>` will be skipped over, avoiding the mismatch errors. If React needs to re-render the entire document due to an unrelated hydration mismatch, it will leave in place stylesheets inserted by third-party scripts and browser extensions.
+No React 19, tags inesperadas em`<head>`e`<body>`serão ignoradas, evitando os erros de incompatibilidade. Se o React precisar renderizar o documento inteiro novamente devido a uma incompatibilidade de hidratação não relacionada, ele manterá as folhas de estilo inseridas por scripts de terceiros e extensões de navegador.
 
-### Better error reporting {/*error-handling*/}
+### Melhor relatório de erros{/*error-handling*/}
 
-We improved error handling in React 19 to remove duplication and provide options for handling caught and uncaught errors. For example, when there's an error in render caught by an Error Boundary, previously React would throw the error twice (once for the original error, then again after failing to automatically recover), and then call `console.error` with info about where the error occurred.
+Melhoramos o tratamento de erros no React 19 para remover duplicação e fornecer opções para lidar com erros capturados e não capturados. Por exemplo, quando há um erro na renderização capturado por um Error Boundary, anteriormente o React lançava o erro duas vezes (uma para o erro original, depois novamente após falhar em se recuperar automaticamente) e, em seguida, chamava`console.error`com informações sobre onde o erro ocorreu.
 
-This resulted in three errors for every caught error:
-
-<ConsoleBlockMulti>
-
-<ConsoleLogLine level="error">
-
-Uncaught Error: hit
-{'  '}at Throws
-{'  '}at renderWithHooks
-{'  '}...
-
-</ConsoleLogLine>
-
-<ConsoleLogLine level="error">
-
-Uncaught Error: hit<span className="ms-2 text-gray-30">{'    <--'} Duplicate</span>
-{'  '}at Throws
-{'  '}at renderWithHooks
-{'  '}...
-
-</ConsoleLogLine>
-
-<ConsoleLogLine level="error">
-
-The above error occurred in the Throws component:
-{'  '}at Throws
-{'  '}at ErrorBoundary
-{'  '}at App{'\n'}
-React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary.
-
-</ConsoleLogLine>
-
-</ConsoleBlockMulti>
-
-In React 19, we log a single error with all the error information included:
+Isso resultava em três erros para cada erro capturado:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Error: hit
-{'  '}at Throws
-{'  '}at renderWithHooks
-{'  '}...{'\n'}
-The above error occurred in the Throws component:
-{'  '}at Throws
-{'  '}at ErrorBoundary
-{'  '}at App{'\n'}
-React will try to recreate this component tree from scratch using the error boundary you provided, ErrorBoundary.
-{'  '}at ErrorBoundary
-{'  '}at App
+Erro não capturado: hit{'  '}em Throws{'  '}em renderWithHooks{'  '}...
+
+</ConsoleLogLine>
+
+<ConsoleLogLine level="error">
+
+Erro não capturado: hit<span className="ms-2 text-gray-30">{'    <--'}Duplicado</span>
+{'  '}em Throws{'  '}em renderWithHooks{'  '}...
+
+</ConsoleLogLine>
+
+<ConsoleLogLine level="error">
+
+O erro acima ocorreu no componente Throws:{'  '}em Throws{'  '}em ErrorBoundary{'  '}em App{'\n'}O React tentará recriar esta árvore de componentes do zero usando o Error Boundary que você forneceu, ErrorBoundary.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-Additionally, we've added two new root options to complement `onRecoverableError`:
+No React 19, registramos um único erro com todas as informações de erro incluídas:
 
-- `onCaughtError`: called when React catches an error in an Error Boundary.
-- `onUncaughtError`: called when an error is thrown and not caught by an Error Boundary.
-- `onRecoverableError`: called when an error is thrown and automatically recovered.
+<ConsoleBlockMulti>
 
-For more info and examples, see the docs for [`createRoot`](/reference/react-dom/client/createRoot) and [`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
+<ConsoleLogLine level="error">
 
-### Support for Custom Elements {/*support-for-custom-elements*/}
+Erro: hit{'  '}em Throws{'  '}em renderWithHooks{'  '}...{'\n'}O erro acima ocorreu no componente Throws:{'  '}em Throws{'  '}em ErrorBoundary{'  '}em App{'\n'}O React tentará recriar esta árvore de componentes do zero usando o Error Boundary que você forneceu, ErrorBoundary.{'  '}em ErrorBoundary{'  '}em App
 
-React 19 adds full support for custom elements and passes all tests on [Custom Elements Everywhere](https://custom-elements-everywhere.com/).
+</ConsoleLogLine>
 
-In past versions, using Custom Elements in React has been difficult because React treated unrecognized props as attributes rather than properties. In React 19, we've added support for properties that works on the client and during SSR with the following strategy:
+</ConsoleBlockMulti>
 
-- **Server Side Rendering**: props passed to a custom element will render as attributes if their type is a primitive value like `string`, `number`, or the value is `true`. Props with non-primitive types like `object`, `symbol`, `function`, or value `false` will be omitted.
-- **Client Side Rendering**: props that match a property on the Custom Element instance will be assigned as properties, otherwise they will be assigned as attributes.
+Adicionalmente, adicionamos duas novas opções de root para complementar`onRecoverableError`:
 
-Thanks to [Joey Arhar](https://github.com/josepharhar) for driving the design and implementation of Custom Element support in React.
+- `onCaughtError`: chamado quando o React captura um erro em um Error Boundary.
+- `onUncaughtError`: chamado quando um erro é lançado e não capturado por um Error Boundary.
+- `onRecoverableError`: chamado quando um erro é lançado e recuperado automaticamente.
+
+Para mais informações e exemplos, veja a documentação de[`createRoot`](/reference/react-dom/client/createRoot)e[`hydrateRoot`](/reference/react-dom/client/hydrateRoot).
+
+### Suporte a Custom Elements{/*support-for-custom-elements*/}
+
+O React 19 adiciona suporte completo a custom elements e passa em todos os testes em[Custom Elements Everywhere](https://custom-elements-everywhere.com/).
+
+Em versões anteriores, usar Custom Elements no React era difícil porque o React tratava props não reconhecidas como atributos em vez de propriedades. No React 19, adicionamos suporte para propriedades que funciona no cliente e durante o SSR com a seguinte estratégia:
+
+- **Renderização do Lado do Servidor (Server Side Rendering)**: props passadas para um custom element serão renderizadas como atributos se o tipo for um valor primitivo como`string`,`number`, ou o valor for`true`. Props com tipos não primitivos como`object`,`symbol`,`function`, ou o valor`false`serão omitidas.
+- **Renderização do Lado do Cliente (Client Side Rendering)**: props que correspondem a uma propriedade na instância do Custom Element serão atribuídas como propriedades, caso contrário, serão atribuídas como atributos.
+
+Graças a[Joey Arhar](https://github.com/josepharhar)por impulsionar o design e a implementação do suporte a Custom Elements no React.
 
 
-#### How to upgrade {/*how-to-upgrade*/}
-See the [React 19 Upgrade Guide](/blog/2024/04/25/react-19-upgrade-guide) for step-by-step instructions and a full list of breaking and notable changes.
+#### Como atualizar{/*how-to-upgrade*/}
+Veja o[Guia de Atualização do React 19](/blog/2024/04/25/react-19-upgrade-guide)para instruções passo a passo e uma lista completa de alterações que quebram a compatibilidade e outras notáveis.
 
-_Note: this post was originally published 04/25/2024 and has been updated to 12/05/2024 with the stable release._
+_Nota: esta postagem foi originalmente publicada em 25/04/2024 e foi atualizada em 05/12/2024 com o lançamento estável._


### PR DESCRIPTION
Esta tradução foi gerada usando LLMs e **requer revisão humana** para garantir precisão, contexto cultural e terminologia técnica.

> [!TIP]
> Consulte [For React Docs Maintainers](https://github.com/NivaldoFarias/translate-react/wiki/For-React-Docs-Maintainers) para orientações de revisão e formato de feedback estruturado.

A validação automática detectou problemas mecânicos que precisam de correção manual antes do merge:

<details>
<summary>Ver detalhes da validação</summary>

### Identificadores de função em blocos de código

In fenced code blocks, do not translate or rename programming identifiers (function, class, variable, hook, and prop names as written in code).

##### `fenceFunctionIdentifiers`

###### 1. linha 515

Keep `to` exactly as in the source.

### Texto JSX estático em blocos de código

Inside fenced code blocks, do not translate JSX text between tags or demo UI string literals used in examples. Copy static JSX text exactly from the source in English.

##### `fenceJsxStaticText`

###### 1. linhas 670–671

```diff
-  // won't lead to duplicate script in the DOM
-     
+  // não resultará em um script duplicado no DOM
+     
```

</details>
